### PR TITLE
**** extend pxd to use inkernel path for IO ******

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -555,6 +555,7 @@ static int fuse_notify_add(struct fuse_conn *conn, unsigned int size,
 	newadd.dev_id = add.dev_id;
 	newadd.size = add.size;
 	newadd.queue_depth = add.queue_depth;
+	newadd.discard_size = add.discard_size;
 
 	newadd.extended = 1; // req is extended
 	newadd.pool_id = 0; // hardcoded pool id

--- a/pxd.c
+++ b/pxd.c
@@ -1332,6 +1332,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_out *add)
 	blk_queue_logical_block_size(q, PXD_LBS);
 
 	set_capacity(disk, add->size / SECTOR_SIZE);
+	queue_flag_set_unlocked(QUEUE_FLAG_NONROT, q);
 
 	/* Enable discard support. */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,17,0)

--- a/pxd.c
+++ b/pxd.c
@@ -1326,7 +1326,10 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_out *add)
 #endif
 	q->limits.discard_granularity = PXD_LBS;
 	q->limits.discard_alignment = PXD_LBS;
-	q->limits.max_discard_sectors = SEGMENT_SIZE / SECTOR_SIZE;
+	if (add->discard_size < SECTOR_SIZE)
+		q->limits.max_discard_sectors = SEGMENT_SIZE / SECTOR_SIZE;
+	else
+		q->limits.max_discard_sectors = add->discard_size / SECTOR_SIZE;
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0)
 	q->limits.discard_zeroes_data = 1;
 #endif

--- a/pxd.h
+++ b/pxd.h
@@ -87,6 +87,7 @@ struct pxd_add_out {
 	uint64_t dev_id;	/**< device global id */
 	size_t size;		/**< block device size in bytes */
 	int32_t queue_depth;	/**< use queue depth 0 to bypass queueing. */
+	int32_t discard_size; /**< block device discard size in bytes */
 	int32_t pad;
 };
 
@@ -94,6 +95,7 @@ struct pxd_add_vol_out {
 	uint64_t dev_id;
 	size_t size;
 	int32_t queue_depth;
+	int32_t discard_size; /**< block device discard size in bytes */
 	int32_t extended; /* pad used as extended flag */
 
 	uint32_t pool_id;

--- a/pxd.h
+++ b/pxd.h
@@ -88,7 +88,6 @@ struct pxd_add_out {
 	size_t size;		/**< block device size in bytes */
 	int32_t queue_depth;	/**< use queue depth 0 to bypass queueing. */
 	int32_t discard_size; /**< block device discard size in bytes */
-	int32_t pad;
 };
 
 struct pxd_add_vol_out {
@@ -96,8 +95,8 @@ struct pxd_add_vol_out {
 	size_t size;
 	int32_t queue_depth;
 	int32_t discard_size; /**< block device discard size in bytes */
-	int32_t extended; /* pad used as extended flag */
 
+	int32_t extended;
 	uint32_t pool_id;
 	char     device_path[64];
 	bool     block_device; /* is it a block device or a file path */

--- a/pxd.h
+++ b/pxd.h
@@ -18,7 +18,7 @@
 #define PXD_DEV  	"pxd/pxd"		/**< block device prefix */
 #define PXD_DEV_PATH	"/dev/" PXD_DEV		/**< block device path prefix */
 
-#define PXD_VERSION 8				/**< driver version */
+#define PXD_VERSION 7		/**< driver version */
 
 #define PXD_NUM_CONTEXTS			11	/**< Total available control devices */
 #define PXD_NUM_CONTEXT_EXPORTED	1	/**< Available for external use */
@@ -86,8 +86,20 @@ struct pxd_init_out {
 struct pxd_add_out {
 	uint64_t dev_id;	/**< device global id */
 	size_t size;		/**< block device size in bytes */
-	int32_t queue_depth;	/**< use queue depth 0 to bypass queueing */
-	int32_t discard_size;	/**< block device discard size in bytes */
+	int32_t queue_depth;	/**< use queue depth 0 to bypass queueing. */
+	int32_t pad;
+};
+
+struct pxd_add_vol_out {
+	uint64_t dev_id;
+	size_t size;
+	int32_t queue_depth;
+	int32_t extended; /* pad used as extended flag */
+
+	uint32_t pool_id;
+	char     device_path[64];
+	bool     block_device; /* is it a block device or a file path */
+	char     pad2[7];
 };
 
 /**

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -7,7 +7,7 @@ TARGET="/test2/file"
 #TARGET="/dev/io/iotest"
 #TARGET="/dev/myloop0"
 
-sudo dd if=/dev/zero of=$TARGET bs=1M count=32000
+sudo dd if=/dev/zero of=$TARGET bs=1M count=32768
 #for i in seq{1..10}; do
 #echo "Random Read - loop $i"
 echo "Random Read"


### PR DESCRIPTION
Make pxd to take inkernel IO path instead of fuse.
Please note, the changes has been compiled upto latest kernels upto 4.4, but only tested with 3.10.x kernels ("CentOS Linux 7 (Core)")

Dependent changes:
https://github.com/portworx/porx/pull/2698