### PR TITLE
Revert "use non blocking allocations for fuse requests - GFP_ATOMIC"

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -110,7 +110,7 @@ static struct fuse_req *__fuse_request_alloc(unsigned npages, gfp_t flags)
 
 struct fuse_req *fuse_request_alloc(unsigned npages)
 {
-	return __fuse_request_alloc(npages, GFP_ATOMIC);
+	return __fuse_request_alloc(npages, GFP_NOIO);
 }
 
 struct fuse_req *fuse_request_alloc_nofs(unsigned npages)


### PR DESCRIPTION
This reverts commit 2b7dad519668f9b7f7b877fcd60a32f7b8ab92d1.