### PR TITLE
Convert writes of zeros to discard request

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -375,6 +375,44 @@ ssize_t fuse_copy_req_read(struct fuse_req *req, struct iov_iter *iter)
 	return copied;
 }
 
+/* Check if the request is writing zeroes and if so, convert it as a discard
+ * request.
+ */
+static void fuse_convert_zero_writes(struct fuse_req *req)
+{
+	uint8_t wsize = sizeof(uint64_t);
+	struct req_iterator breq_iter;
+#ifdef HAVE_BVEC_ITER
+	struct bio_vec bvec;
+#else
+	struct bio_vec *bvec = NULL;
+#endif
+	char *kaddr, *p;
+	size_t i, len;
+	uint64_t *q;
+
+	rq_for_each_segment(bvec, req->rq, breq_iter) {
+		kaddr = kmap_atomic(BVEC(bvec).bv_page);
+		p = kaddr + BVEC(bvec).bv_offset;
+		q = (uint64_t *)p;
+		len = BVEC(bvec).bv_len;
+		for (i = 0; i < (len / wsize); i++) {
+			if (q[i]) {
+				kunmap_atomic(kaddr);
+				return;
+			}
+		}
+		for (i = len - (len % wsize); i < len; i++) {
+			if (p[i]) {
+				kunmap_atomic(kaddr);
+				return;
+			}
+		}
+		kunmap_atomic(kaddr);
+	}
+	req->in.h.opcode = PXD_DISCARD;
+}
+
 /*
  * Read a single request into the userspace filesystem's buffer.  This
  * function waits until a request is available, then removes it from
@@ -439,6 +477,10 @@ static ssize_t fuse_dev_do_read(struct fuse_conn *fc, struct file *file,
 	err = 0;
 	while (1) {
 		req = list_entry(entry, struct fuse_req, list);
+		if ((req->in.h.opcode == PXD_WRITE) && req->misc.pxd_rdwr_in.size &&
+			!(req->misc.pxd_rdwr_in.flags & PXD_FLAGS_SYNC)) {
+			fuse_convert_zero_writes(req);
+		}
 		copied_this_time = fuse_copy_req_read(req, iter);
 		if (copied_this_time > 0) {
 			copied += copied_this_time;

--- a/dev.c
+++ b/dev.c
@@ -72,7 +72,6 @@ static void fuse_request_init(struct fuse_req *req, struct page **pages,
 	memset(page_descs, 0, sizeof(*page_descs) * npages);
 	INIT_LIST_HEAD(&req->list);
 	INIT_HLIST_NODE(&req->hash_entry);
-	atomic_set(&req->count, 1);
 	req->pages = pages;
 	req->page_descs = page_descs;
 	req->max_pages = npages;
@@ -127,11 +126,6 @@ void fuse_request_free(struct fuse_req *req)
 	kmem_cache_free(fuse_req_cachep, req);
 }
 
-void __fuse_get_request(struct fuse_req *req)
-{
-	atomic_inc(&req->count);
-}
-
 static void fuse_req_init_context(struct fuse_req *req)
 {
 	req->in.h.uid = from_kuid_munged(&init_user_ns, current_fsuid());
@@ -145,13 +139,14 @@ static struct fuse_req *__fuse_get_req(struct fuse_conn *fc, unsigned npages,
 	struct fuse_req *req;
 	int err;
 
-	err = -ENOTCONN;
-	if (!fc->connected && !fc->allow_disconnected)
+	if (!fc->connected && !fc->allow_disconnected) {
+		 err = -ENOTCONN;
 		goto out;
+	}
 
 	req = fuse_request_alloc(npages);
-	err = -ENOMEM;
 	if (!req) {
+		err = -ENOMEM;
 		goto out;
 	}
 
@@ -174,12 +169,6 @@ struct fuse_req *fuse_get_req_for_background(struct fuse_conn *fc,
 	return __fuse_get_req(fc, npages, true);
 }
 
-void fuse_put_request(struct fuse_conn *fc, struct fuse_req *req)
-{
-	if (atomic_dec_and_test(&req->count))
-		fuse_request_free(req);
-}
-
 static unsigned len_args(unsigned numargs, struct fuse_arg *args)
 {
 	unsigned nbytes = 0;
@@ -195,7 +184,7 @@ static u64 fuse_get_unique(struct fuse_conn *fc)
 {
 	fc->reqctr++;
 	/* zero is special */
-	if (fc->reqctr == 0)
+	if (unlikely(fc->reqctr == 0))
 		fc->reqctr = 1;
 
 	return fc->reqctr;
@@ -207,7 +196,6 @@ static void queue_request(struct fuse_conn *fc, struct fuse_req *req)
 	if (hlist_unhashed(&req->hash_entry))
 		hlist_add_head(&req->hash_entry,
 			       &fc->hash[req->in.h.unique % FUSE_HASH_SIZE]);
-	req->state = FUSE_REQ_PENDING;
 }
 
 static void fuse_conn_wakeup(struct fuse_conn *fc)
@@ -218,17 +206,15 @@ static void fuse_conn_wakeup(struct fuse_conn *fc)
 
 void fuse_request_send_oob(struct fuse_conn *fc, struct fuse_req *req)
 {
-	spin_lock(&fc->lock);
-	req->background = 0;
-	req->isreply = 1;
-	req->in.h.unique = fuse_get_unique(fc);
 	req->in.h.len = sizeof(struct fuse_in_header) +
 		len_args(req->in.numargs, (struct fuse_arg *) req->in.args);
+	req->state = FUSE_REQ_PENDING;
+	spin_lock(&fc->lock);
+	req->in.h.unique = fuse_get_unique(fc);
 	list_add(&req->list, &fc->pending);
 	if (hlist_unhashed(&req->hash_entry))
 		hlist_add_head(&req->hash_entry,
 			       &fc->hash[req->in.h.unique % FUSE_HASH_SIZE]);
-	req->state = FUSE_REQ_PENDING;
 	spin_unlock(&fc->lock);
 
 	fuse_conn_wakeup(fc);
@@ -242,20 +228,19 @@ void fuse_request_send_oob(struct fuse_conn *fc, struct fuse_req *req)
  * the 'end' callback is called if given, else the reference to the
  * request is released
  *
- * Called with fc->lock, unlocks it
+ * If called with fc->lock, unlocks it
  */
-static void request_end(struct fuse_conn *fc, struct fuse_req *req)
+static void request_end(struct fuse_conn *fc, struct fuse_req *req,
+                        bool lock)
 __releases(fc->lock)
 {
-	void (*end) (struct fuse_conn *, struct fuse_req *) = req->end;
-	req->end = NULL;
+	if (likely(lock)) {
+		spin_lock(&fc->lock);
+	}
 	if (!hlist_unhashed(&req->hash_entry))
 		hlist_del_init(&req->hash_entry);
 	list_del(&req->list);
-	req->state = FUSE_REQ_FINISHED;
 	if (req->background) {
-		req->background = 0;
-
 		if (fc->num_background == fc->congestion_threshold &&
 		    fc->connected && fc->bdi_initialized) {
 			clear_bdi_congested(&fc->bdi, BLK_RW_SYNC);
@@ -265,9 +250,10 @@ __releases(fc->lock)
 		fc->active_background--;
 	}
 	spin_unlock(&fc->lock);
-	if (end)
-		end(fc, req);
-	fuse_put_request(fc, req);
+	req->state = FUSE_REQ_FINISHED;
+	if (req->end)
+		req->end(fc, req);
+	fuse_request_free(req);
 }
 
 static void fuse_request_send_nowait_locked(struct fuse_conn *fc,
@@ -285,14 +271,14 @@ static void fuse_request_send_nowait_locked(struct fuse_conn *fc,
 	queue_request(fc, req);
 }
 
-static void fuse_request_send_nowait(struct fuse_conn *fc, struct fuse_req *req)
+void fuse_request_send_nowait(struct fuse_conn *fc, struct fuse_req *req)
 {
 	req->in.h.len = sizeof(struct fuse_in_header) +
 		len_args(req->in.numargs, (struct fuse_arg *)req->in.args);
-
+	req->state = FUSE_REQ_PENDING;
 	spin_lock(&fc->lock);
 	if (fc->connected || fc->allow_disconnected) {
-		if (!fc->connected) {
+		if (unlikely(!fc->connected)) {
 			printk(KERN_INFO "%s: Request on disconnected FC", __func__);
 		}
 		fuse_request_send_nowait_locked(fc, req);
@@ -301,14 +287,8 @@ static void fuse_request_send_nowait(struct fuse_conn *fc, struct fuse_req *req)
 		fuse_conn_wakeup(fc);
 	} else {
 		req->out.h.error = -ENOTCONN;
-		request_end(fc, req);
+		request_end(fc, req, false);
 	}
-}
-
-void fuse_request_send_background(struct fuse_conn *fc, struct fuse_req *req)
-{
-	req->isreply = 1;
-	fuse_request_send_nowait(fc, req);
 }
 
 static int request_pending(struct fuse_conn *fc)
@@ -340,15 +320,13 @@ __acquires(fc->lock)
 ssize_t fuse_copy_req_read(struct fuse_req *req, struct iov_iter *iter)
 {
 	struct request *breq = req->rq;
-	size_t copied = 0;
-	size_t len;
+	size_t copied, len;
 
-	len = sizeof(req->in.h);
-	if (copy_to_iter(&req->in.h, len, iter) != len) {
+	copied = sizeof(req->in.h);
+	if (copy_to_iter(&req->in.h, copied, iter) != copied) {
 		printk(KERN_ERR "%s: copy header error\n", __func__);
 		return -EFAULT;
 	}
-	copied += len;
 
 	len = req->in.args[0].size;
 	if (copy_to_iter((void *)req->in.args[0].value, len, iter) != len) {
@@ -430,9 +408,8 @@ static ssize_t fuse_dev_do_read(struct fuse_conn *fc, struct file *file,
 	int err;
 	struct fuse_req *req;
 	struct list_head *entry, *first, *last, tmp, *next;
-	ssize_t copied, copied_this_time;
+	ssize_t copied = 0, copied_this_time;
 	ssize_t remain = iter->count;
-	bool no_reply = false;
 
 	INIT_LIST_HEAD(&tmp);
 
@@ -450,6 +427,7 @@ static ssize_t fuse_dev_do_read(struct fuse_conn *fc, struct file *file,
 			goto err_unlock;
 	}
 
+retry:
 	entry = fc->pending.next;
 	first = fc->pending.next;
 	last = &fc->pending;
@@ -466,17 +444,15 @@ static ssize_t fuse_dev_do_read(struct fuse_conn *fc, struct file *file,
 		}
 	}
 
-	err = -EINVAL;
+	err = copied ? copied : -EINVAL;
 	if (last == &fc->pending)
 		goto err_unlock;
 
 	list_cut_position(&tmp, &fc->pending, last);
 	list_splice_tail(&tmp, &fc->processing);
-
 	spin_unlock(&fc->lock);
 
 	entry = first;
-	copied = 0;
 	err = 0;
 	while (1) {
 		req = list_entry(entry, struct fuse_req, list);
@@ -487,53 +463,36 @@ static ssize_t fuse_dev_do_read(struct fuse_conn *fc, struct file *file,
 			!(req->misc.pxd_rdwr_in.flags & PXD_FLAGS_SYNC)) {
 			fuse_convert_zero_writes(req);
 		}
+		next = entry->next;
 		copied_this_time = fuse_copy_req_read(req, iter);
-		if (copied_this_time > 0) {
+		if (likely(copied_this_time > 0)) {
 			copied += copied_this_time;
 		} else {
 			err = copied_this_time;
-			goto err_reqs;
+			req->out.h.error = -EIO;
+			request_end(fc, req, true);
 		}
-
-		no_reply = no_reply || !req->isreply;
-		if (entry == last)
-			break;
-		entry = entry->next;
-	}
-
-	if (unlikely(no_reply)) {
-		entry = first;
-		while (1) {
-			req = list_entry(entry, struct fuse_req, list);
-			next = entry->next;
-			if (!req->isreply) {
-				spin_lock(&fc->lock);
-				request_end(fc, req);
-			}
-			if (entry == last)
-				break;
-			entry = next;
-		}
-	}
-
-	return copied;
-
- err_unlock:
-	spin_unlock(&fc->lock);
-	return err;
-
- err_reqs:
-	entry = first;
-	while (1) {
-		req = list_entry(entry, struct fuse_req, list);
-		next = entry->next;
-		req->out.h.error = -EIO;
-		spin_lock(&fc->lock);
-		request_end(fc, req);
 		if (entry == last)
 			break;
 		entry = next;
 	}
+	if (!copied) {
+		copied = err;
+	}
+
+	/* Check if more requests could be picked up */
+	if (remain && request_pending(fc)) {
+		INIT_LIST_HEAD(&tmp);
+		spin_lock(&fc->lock);
+		if (request_pending(fc)) {
+			goto retry;
+		}
+		spin_unlock(&fc->lock);
+	}
+	return copied;
+
+ err_unlock:
+	spin_unlock(&fc->lock);
 	return err;
 }
 
@@ -781,7 +740,6 @@ static ssize_t fuse_dev_do_write(struct fuse_conn *fc, struct iov_iter *iter)
 	int err;
 	struct fuse_req *req;
 	struct fuse_out_header oh;
-	size_t copied = 0;
 	size_t len;
 	size_t nbytes = iter->count;
 
@@ -793,7 +751,6 @@ static ssize_t fuse_dev_do_write(struct fuse_conn *fc, struct iov_iter *iter)
 		printk(KERN_ERR "%s: can't copy header\n", __func__);
 		return -EFAULT;
 	}
-	copied += len;
 
 	if (oh.len != nbytes)
 		return -EINVAL;
@@ -810,8 +767,8 @@ static ssize_t fuse_dev_do_write(struct fuse_conn *fc, struct iov_iter *iter)
 	if (oh.error <= -1000 || oh.error > 0)
 		return -EINVAL;
 
-	spin_lock(&fc->lock);
 	err = -ENOENT;
+	spin_lock(&fc->lock);
 	if (!fc->connected)
 		goto err_unlock;
 
@@ -819,10 +776,9 @@ static ssize_t fuse_dev_do_write(struct fuse_conn *fc, struct iov_iter *iter)
 	if (!req)
 		goto err_unlock;
 
-	req->state = FUSE_REQ_WRITING;
 	list_del_init(&req->list);
 	spin_unlock(&fc->lock);
-
+	req->state = FUSE_REQ_WRITING;
 	req->out.h = oh;
 
 	if (req->bio_pages && req->out.numargs && iter->count > 0) {
@@ -844,18 +800,12 @@ static ssize_t fuse_dev_do_write(struct fuse_conn *fc, struct iov_iter *iter)
 					       __func__, i, breq->nr_phys_segments);
 					return -EFAULT;
 				}
-				copied += len;
+				i++;
 			}
 		}
 	}
-	err = 0;
-
-	spin_lock(&fc->lock);
-	if (err)
-		req->out.h.error = -EIO;
-	request_end(fc, req);
-
-	return err ? err : nbytes ;
+	request_end(fc, req, true);
+	return nbytes;
 
  err_unlock:
 	spin_unlock(&fc->lock);
@@ -925,7 +875,7 @@ __acquires(fc->lock)
 		struct fuse_req *req;
 		req = list_entry(head->next, struct fuse_req, list);
 		req->out.h.error = -ECONNABORTED;
-		request_end(fc, req);
+		request_end(fc, req, false);
 		spin_lock(&fc->lock);
 	}
 }

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -257,17 +257,11 @@ struct fuse_req {
 	/** hash table entry */
 	struct hlist_node hash_entry;
 
-	/** refcount */
-	atomic_t count;
-
 	/*
 	 * The following bitfields are either set once before the
 	 * request is queued or setting/clearing them is protected by
 	 * fuse_conn->lock
 	 */
-
-	/** True if the request has reply */
-	unsigned isreply:1;
 
 	/** Request is sent in the background */
 	unsigned background:1;
@@ -705,11 +699,6 @@ struct fuse_req *fuse_get_req(struct fuse_conn *fc, unsigned npages);
 struct fuse_req *fuse_get_req_for_background(struct fuse_conn *fc,
 					     unsigned npages);
 
-/*
- * Increment reference count on request
- */
-void __fuse_get_request(struct fuse_req *req);
-
 /**
  * Get a request, may fail with -ENOMEM,
  * useful for callers who doesn't use req->pages[]
@@ -720,12 +709,6 @@ static inline struct fuse_req *fuse_get_req_nopages(struct fuse_conn *fc)
 }
 
 /**
- * Decrement reference count of a request.  If count goes to zero free
- * the request.
- */
-void fuse_put_request(struct fuse_conn *fc, struct fuse_req *req);
-
-/**
  * Send a request to head of pending queue.
  */
 void fuse_request_send_oob(struct fuse_conn *fc, struct fuse_req *req);
@@ -733,7 +716,7 @@ void fuse_request_send_oob(struct fuse_conn *fc, struct fuse_req *req);
 /**
  * Send a request in the background
  */
-void fuse_request_send_background(struct fuse_conn *fc, struct fuse_req *req);
+void fuse_request_send_nowait(struct fuse_conn *fc, struct fuse_req *req);
 
 /* Abort all requests */
 void fuse_abort_conn(struct fuse_conn *fc);

--- a/pxd.c
+++ b/pxd.c
@@ -303,7 +303,37 @@ static void pxd_read_request(struct fuse_req *req, uint32_t size, uint64_t off,
 static void pxd_write_request(struct fuse_req *req, uint32_t size, uint64_t off,
 			uint32_t minor, uint32_t flags, bool qfn)
 {
+	struct req_iterator breq_iter;
+#ifdef HAVE_BVEC_ITER
+	struct bio_vec bvec;
+#else
+	struct bio_vec *bvec = NULL;
+#endif
+	char *kaddr, *p;
+	size_t i, len;
+
 	req->in.h.opcode = PXD_WRITE;
+
+	/* Check if this is a write of zero blocks and if so, convert that to a
+	 * discard request.
+	 */
+	if (size && qfn && !(flags & (REQ_FLUSH | REQ_FUA))) {
+		rq_for_each_segment(bvec, req->rq, breq_iter) {
+			kaddr = kmap_atomic(BVEC(bvec).bv_page);
+			p = kaddr + BVEC(bvec).bv_offset;
+			len = BVEC(bvec).bv_len;
+			for (i = 0; i < len; i++) {
+				if (p[i]) {
+					kunmap_atomic(kaddr);
+					goto out;
+				}
+			}
+			kunmap_atomic(kaddr);
+		}
+		req->in.h.opcode = PXD_DISCARD;
+	}
+
+out:
 	req->in.numargs = 1;
 	req->in.argpages = 0;
 	req->in.args[0].size = sizeof(struct pxd_rdwr_in);
@@ -488,6 +518,10 @@ static void pxd_rq_fn(struct request_queue *q)
 			continue;
 		}
 
+		req->num_pages = 0;
+		req->misc.pxd_rdwr_in.chksum = 0;
+		req->rq = rq;
+		req->queue = q;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) || defined(REQ_PREFLUSH)
 		pxd_request(req, blk_rq_bytes(rq), blk_rq_pos(rq) * SECTOR_SIZE,
 			    pxd_dev->minor, req_op(rq), rq->cmd_flags, true,
@@ -498,10 +532,6 @@ static void pxd_rq_fn(struct request_queue *q)
 			    REQCTR(&pxd_dev->ctx->fc));
 #endif
 
-		req->num_pages = 0;
-		req->misc.pxd_rdwr_in.chksum = 0;
-		req->rq = rq;
-		req->queue = q;
 		fuse_request_send_background(&pxd_dev->ctx->fc, req);
 		spin_lock_irq(&pxd_dev->qlock);
 	}

--- a/pxd.c
+++ b/pxd.c
@@ -60,9 +60,11 @@ struct pxd_context *pxd_contexts;
 uint32_t pxd_num_contexts = PXD_NUM_CONTEXTS;
 uint32_t pxd_num_contexts_exported = PXD_NUM_CONTEXT_EXPORTED;
 uint32_t pxd_timeout_secs = PXD_TIMER_SECS_MAX;
+uint32_t pxd_detect_zero_writes = 0;
 
 module_param(pxd_num_contexts_exported, uint, 0644);
 module_param(pxd_num_contexts, uint, 0644);
+module_param(pxd_detect_zero_writes, uint, 0644);
 
 struct pxd_device {
 	uint64_t dev_id;

--- a/pxd.c
+++ b/pxd.c
@@ -300,6 +300,20 @@ static void pxd_read_request(struct fuse_req *req, uint32_t size, uint64_t off,
 	pxd_req_misc(req, size, off, minor, flags);
 }
 
+static void pxd_write_request(struct fuse_req *req, uint32_t size, uint64_t off,
+			uint32_t minor, uint32_t flags, bool qfn)
+{
+	req->in.h.opcode = PXD_WRITE;
+	req->in.numargs = 1;
+	req->in.argpages = 0;
+	req->in.args[0].size = sizeof(struct pxd_rdwr_in);
+	req->in.args[0].value = &req->misc.pxd_rdwr_in;
+	req->out.numargs = 0;
+	req->end = qfn ? pxd_process_write_reply_q : pxd_process_write_reply;
+
+	pxd_req_misc(req, size, off, minor, flags);
+}
+
 static void pxd_discard_request(struct fuse_req *req, uint32_t size, uint64_t off,
 			uint32_t minor, uint32_t flags, bool qfn)
 {
@@ -308,58 +322,6 @@ static void pxd_discard_request(struct fuse_req *req, uint32_t size, uint64_t of
 	req->in.args[0].size = sizeof(struct pxd_rdwr_in);
 	req->in.args[0].value = &req->misc.pxd_rdwr_in;
 	req->in.argpages = 0;
-	req->out.numargs = 0;
-	req->end = qfn ? pxd_process_write_reply_q : pxd_process_write_reply;
-
-	pxd_req_misc(req, size, off, minor, flags);
-}
-
-static void pxd_write_request(struct fuse_req *req, uint32_t size, uint64_t off,
-			uint32_t minor, uint32_t flags, bool qfn)
-{
-	struct req_iterator breq_iter;
-#ifdef HAVE_BVEC_ITER
-	struct bio_vec bvec;
-#else
-	struct bio_vec *bvec = NULL;
-#endif
-	char *kaddr, *p;
-	size_t i, len;
-	uint64_t *q;
-
-	/* Check if this is a write of zero blocks and if so, convert that to a
-	 * discard request.
-	 */
-	if (size && qfn && !(flags & (REQ_FLUSH | REQ_FUA))) {
-		rq_for_each_segment(bvec, req->rq, breq_iter) {
-			kaddr = kmap_atomic(BVEC(bvec).bv_page);
-			p = kaddr + BVEC(bvec).bv_offset;
-			q = (uint64_t *)p;
-			len = BVEC(bvec).bv_len;
-			for (i = 0; i < (len / 8); i++) {
-				if (q[i]) {
-					kunmap_atomic(kaddr);
-					goto out;
-				}
-			}
-			for (i = len - (len % 8); i < len; i++) {
-				if (p[i]) {
-					kunmap_atomic(kaddr);
-					goto out;
-				}
-			}
-			kunmap_atomic(kaddr);
-		}
-		pxd_discard_request(req, size, off, minor, flags, qfn);
-		return;
-	}
-
-out:
-	req->in.h.opcode = PXD_WRITE;
-	req->in.numargs = 1;
-	req->in.argpages = 0;
-	req->in.args[0].size = sizeof(struct pxd_rdwr_in);
-	req->in.args[0].value = &req->misc.pxd_rdwr_in;
 	req->out.numargs = 0;
 	req->end = qfn ? pxd_process_write_reply_q : pxd_process_write_reply;
 


### PR DESCRIPTION
PXD driver can convert writes of zero blocks as discard requests and avoid unnecessary transfer of zeroes from kernel to user space.