### PR TITLE
Pxd minor cleanup

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -733,7 +733,6 @@ static ssize_t fuse_dev_do_write(struct fuse_conn *fc, struct iov_iter *iter)
 	int err;
 	struct fuse_req *req;
 	struct fuse_out_header oh;
-	size_t copied = 0;
 	size_t len;
 	size_t nbytes = iter->count;
 
@@ -745,7 +744,6 @@ static ssize_t fuse_dev_do_write(struct fuse_conn *fc, struct iov_iter *iter)
 		printk(KERN_ERR "%s: can't copy header\n", __func__);
 		return -EFAULT;
 	}
-	copied += len;
 
 	if (oh.len != nbytes)
 		return -EINVAL;
@@ -796,18 +794,13 @@ static ssize_t fuse_dev_do_write(struct fuse_conn *fc, struct iov_iter *iter)
 					       __func__, i, breq->nr_phys_segments);
 					return -EFAULT;
 				}
-				copied += len;
+				i++;
 			}
 		}
 	}
-	err = 0;
-
 	spin_lock(&fc->lock);
-	if (err)
-		req->out.h.error = -EIO;
 	request_end(fc, req);
-
-	return err ? err : nbytes ;
+	return nbytes;
 
  err_unlock:
 	spin_unlock(&fc->lock);

--- a/pxd.c
+++ b/pxd.c
@@ -267,6 +267,9 @@ static struct fuse_req *pxd_fuse_req(struct pxd_device *pxd_dev, int nr_pages)
 static void pxd_req_misc(struct fuse_req *req, uint32_t size, uint64_t off,
 			uint32_t minor, uint32_t flags)
 {
+	req->in.numargs = 1;
+	req->in.args[0].size = sizeof(struct pxd_rdwr_in);
+	req->in.args[0].value = &req->misc.pxd_rdwr_in;
 	req->bio_pages = true;
 	req->in.h.pid = current->pid;
 	req->misc.pxd_rdwr_in.minor = minor;
@@ -329,9 +332,6 @@ static void pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 {
 	trace_pxd_request(reqctr, req->in.h.unique, size, off, minor, flags);
 
-	req->in.numargs = 1;
-	req->in.args[0].size = sizeof(struct pxd_rdwr_in);
-	req->in.args[0].value = &req->misc.pxd_rdwr_in;
 	switch (op) {
 	case REQ_OP_WRITE_SAME:
 		pxd_write_same_request(req, size, off, minor, flags, qfn);
@@ -358,9 +358,6 @@ static void pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 {
 	trace_pxd_request(reqctr, req->in.h.unique, size, off, minor, flags);
 
-	req->in.numargs = 1;
-	req->in.args[0].size = sizeof(struct pxd_rdwr_in);
-	req->in.args[0].value = &req->misc.pxd_rdwr_in;
 	switch (flags & (REQ_WRITE | REQ_DISCARD | REQ_WRITE_SAME)) {
 	case REQ_WRITE:
 		/* FALLTHROUGH */


### PR DESCRIPTION
The request structure is already zeroed after allocating, so need to zero some of the fields of the structure again.  Also some duplicate code in some functions are moved to a common function.  Also removing some unnecessary code.