### PR TITLE
Try to pick up as many requests in every iteration

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -390,7 +390,7 @@ static ssize_t fuse_dev_do_read(struct fuse_conn *fc, struct file *file,
 	int err;
 	struct fuse_req *req;
 	struct list_head *entry, *first, *last, tmp, *next;
-	ssize_t copied, copied_this_time;
+	ssize_t copied = 0, copied_this_time;
 	ssize_t remain = iter->count;
 	bool no_reply = false;
 
@@ -410,6 +410,7 @@ static ssize_t fuse_dev_do_read(struct fuse_conn *fc, struct file *file,
 			goto err_unlock;
 	}
 
+retry:
 	entry = fc->pending.next;
 	first = fc->pending.next;
 	last = &fc->pending;
@@ -435,7 +436,6 @@ static ssize_t fuse_dev_do_read(struct fuse_conn *fc, struct file *file,
 	spin_unlock(&fc->lock);
 
 	entry = first;
-	copied = 0;
 	err = 0;
 	while (1) {
 		req = list_entry(entry, struct fuse_req, list);
@@ -468,6 +468,16 @@ static ssize_t fuse_dev_do_read(struct fuse_conn *fc, struct file *file,
 		}
 	}
 
+	/* Check if more requests could be picked up */
+	if (remain && request_pending(fc)) {
+		INIT_LIST_HEAD(&tmp);
+		no_reply = false;
+		spin_lock(&fc->lock);
+		if (request_pending(fc)) {
+			goto retry;
+		}
+		spin_unlock(&fc->lock);
+	}
 	return copied;
 
  err_unlock:

--- a/dev.c
+++ b/dev.c
@@ -426,7 +426,7 @@ retry:
 		}
 	}
 
-	err = -EINVAL;
+	err = copied ? copied : -EINVAL;
 	if (last == &fc->pending)
 		goto err_unlock;
 


### PR DESCRIPTION
Try to pick as many requests each time requests are copied from kernel to user space.  This seems to improve our throughput.