### PR TITLE
Fix a kernel memory corruption and remove unnecessary refcount for requests

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -72,7 +72,6 @@ static void fuse_request_init(struct fuse_req *req, struct page **pages,
 	memset(page_descs, 0, sizeof(*page_descs) * npages);
 	INIT_LIST_HEAD(&req->list);
 	INIT_HLIST_NODE(&req->hash_entry);
-	atomic_set(&req->count, 1);
 	req->pages = pages;
 	req->page_descs = page_descs;
 	req->max_pages = npages;
@@ -127,11 +126,6 @@ void fuse_request_free(struct fuse_req *req)
 	kmem_cache_free(fuse_req_cachep, req);
 }
 
-void __fuse_get_request(struct fuse_req *req)
-{
-	atomic_inc(&req->count);
-}
-
 static void fuse_req_init_context(struct fuse_req *req)
 {
 	req->in.h.uid = from_kuid_munged(&init_user_ns, current_fsuid());
@@ -172,12 +166,6 @@ struct fuse_req *fuse_get_req_for_background(struct fuse_conn *fc,
 					     unsigned npages)
 {
 	return __fuse_get_req(fc, npages, true);
-}
-
-void fuse_put_request(struct fuse_conn *fc, struct fuse_req *req)
-{
-	if (atomic_dec_and_test(&req->count))
-		fuse_request_free(req);
 }
 
 static unsigned len_args(unsigned numargs, struct fuse_arg *args)
@@ -267,7 +255,7 @@ __releases(fc->lock)
 	spin_unlock(&fc->lock);
 	if (end)
 		end(fc, req);
-	fuse_put_request(fc, req);
+	fuse_request_free(req);
 }
 
 static void fuse_request_send_nowait_locked(struct fuse_conn *fc,

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -257,9 +257,6 @@ struct fuse_req {
 	/** hash table entry */
 	struct hlist_node hash_entry;
 
-	/** refcount */
-	atomic_t count;
-
 	/*
 	 * The following bitfields are either set once before the
 	 * request is queued or setting/clearing them is protected by
@@ -705,11 +702,6 @@ struct fuse_req *fuse_get_req(struct fuse_conn *fc, unsigned npages);
 struct fuse_req *fuse_get_req_for_background(struct fuse_conn *fc,
 					     unsigned npages);
 
-/*
- * Increment reference count on request
- */
-void __fuse_get_request(struct fuse_req *req);
-
 /**
  * Get a request, may fail with -ENOMEM,
  * useful for callers who doesn't use req->pages[]
@@ -718,12 +710,6 @@ static inline struct fuse_req *fuse_get_req_nopages(struct fuse_conn *fc)
 {
 	return fuse_get_req(fc, 0);
 }
-
-/**
- * Decrement reference count of a request.  If count goes to zero free
- * the request.
- */
-void fuse_put_request(struct fuse_conn *fc, struct fuse_req *req);
 
 /**
  * Send a request to head of pending queue.

--- a/pxd.c
+++ b/pxd.c
@@ -954,7 +954,6 @@ static void pxd_process_init_reply(struct fuse_conn *fc,
 	if (req->out.h.error != 0)
 		fc->connected = 0;
 	fc->pend_open = 0;
-	fuse_put_request(fc, req);
 }
 
 static int pxd_send_init(struct fuse_conn *fc)
@@ -1014,7 +1013,7 @@ err_free_pages:
 		if (req->pages[i])
 			put_page(req->pages[i]);
 	}
-	fuse_put_request(fc, req);
+	fuse_request_free(req);
 err:
 	return rc;
 }


### PR DESCRIPTION
refcount on the init request is decremented twice, which could cause memory corruption.  Fix that by not freeing the request more than once.

Also the refcount on the requests is unnecessary which could be removed along with code processing that.