### PR TITLE
ln/pxdkernel-1: use direct bio instead of request queue for blkdev.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -66,7 +66,7 @@ docker-build: docker-build-dev
 	portworx/px-fuse:dev make
 
 px_version.c:
-	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@
+	echo "const char *gitversion = \"$(shell git name-rev --name-only HEAD):$(shell git rev-parse HEAD)\";" > $@
 
 distclean: clean
 	@/bin/rm -f  config.* Makefile

--- a/dev.c
+++ b/dev.c
@@ -319,7 +319,11 @@ __acquires(fc->lock)
 
 ssize_t fuse_copy_req_read(struct fuse_req *req, struct iov_iter *iter)
 {
+#ifdef USE_REQUESTQ_MODEL
 	struct request *breq = req->rq;
+#else
+	struct bio *breq = req->bio;
+#endif
 	size_t copied, len;
 
 	copied = sizeof(req->in.h);
@@ -342,8 +346,13 @@ ssize_t fuse_copy_req_read(struct fuse_req *req, struct iov_iter *iter)
 			if (copy_page_to_iter(req->pages[i],
 					      req->page_descs[i].offset,
 					      len, iter) != len) {
+#ifdef USE_REQUESTQ_MODEL
 				printk(KERN_ERR "%s: copy page arg %d of %d error\n",
 				       __func__, i, breq->nr_phys_segments);
+#else
+				printk(KERN_ERR "%s: copy page arg %d of %d error\n",
+				       __func__, i, bio_phys_segments(req->queue, breq));
+#endif
 				return -EFAULT;
 			}
 			copied += len;
@@ -361,7 +370,14 @@ extern uint32_t pxd_detect_zero_writes;
 static void fuse_convert_zero_writes(struct fuse_req *req)
 {
 	uint8_t wsize = sizeof(uint64_t);
+#ifdef USE_REQUESTQ_MODEL
 	struct req_iterator breq_iter;
+#elif defined(HAVE_BVEC_ITER)
+	struct bvec_iter bvec_iter;
+#else
+	int bvec_iter;
+#endif
+
 #ifdef HAVE_BVEC_ITER
 	struct bio_vec bvec;
 #else
@@ -371,7 +387,11 @@ static void fuse_convert_zero_writes(struct fuse_req *req)
 	size_t i, len;
 	uint64_t *q;
 
+#ifdef USE_REQUESTQ_MODEL
 	rq_for_each_segment(bvec, req->rq, breq_iter) {
+#else
+	bio_for_each_segment(bvec, req->bio, bvec_iter) {
+#endif
 		kaddr = kmap_atomic(BVEC(bvec).bv_page);
 		p = kaddr + BVEC(bvec).bv_offset;
 		q = (uint64_t *)p;
@@ -609,7 +629,15 @@ static int fuse_notify_read_data(struct fuse_conn *conn, unsigned int size,
 #else
 	struct bio_vec *bvec = NULL;
 #endif
+
+#ifdef USE_REQUESTQ_MODEL
 	struct req_iterator breq_iter;
+#elif defined(HAVE_BVEC_ITER)
+	struct bvec_iter bvec_iter;
+#else
+	int bvec_iter;
+#endif
+
 	struct iov_iter data_iter;
 	size_t copied, skipped = 0;
 	int ret;
@@ -644,7 +672,11 @@ static int fuse_notify_read_data(struct fuse_conn *conn, unsigned int size,
 		iov_iter_advance(&data_iter,
 				 req->misc.pxd_rdwr_in.offset & PXD_LBS_MASK);
 
+#ifdef USE_REQUESTQ_MODEL
 	rq_for_each_segment(bvec, req->rq, breq_iter) {
+#else
+	bio_for_each_segment(bvec, req->bio, bvec_iter) {
+#endif
 		copied = 0;
 		len = BVEC(bvec).bv_len;
 		if (skipped < read_data.offset) {
@@ -782,22 +814,44 @@ static ssize_t fuse_dev_do_write(struct fuse_conn *fc, struct iov_iter *iter)
 	req->out.h = oh;
 
 	if (req->bio_pages && req->out.numargs && iter->count > 0) {
-		struct request *breq = req->rq;
 #ifdef HAVE_BVEC_ITER
 		struct bio_vec bvec;
 #else
 		struct bio_vec *bvec = NULL;
 #endif
+
+#ifdef USE_REQUESTQ_MODEL
+		struct request *breq = req->rq;
 		struct req_iterator breq_iter;
-		if (breq->nr_phys_segments && req->in.h.opcode == PXD_READ) {
+		int nsegs = breq->nr_phys_segments;
+#elif defined(HAVE_BVEC_ITER)
+		struct bio *breq = req->bio;
+		struct bvec_iter bvec_iter;
+		int nsegs = bio_phys_segments(req->queue, breq);
+#else
+		struct bio *breq = req->bio;
+		int bvec_iter;
+		int nsegs = bio_phys_segments(req->queue, breq);
+#endif
+
+		if (nsegs && req->in.h.opcode == PXD_READ) {
 			int i = 0;
+#ifdef USE_REQUESTQ_MODEL
 			rq_for_each_segment(bvec, breq, breq_iter) {
+#else
+			bio_for_each_segment(bvec, breq, bvec_iter) {
+#endif
 				len = BVEC(bvec).bv_len;
 				if (copy_page_from_iter(BVEC(bvec).bv_page,
 							BVEC(bvec).bv_offset,
 							len, iter) != len) {
+#ifdef USE_REQUESTQ_MODEL
 					printk(KERN_ERR "%s: copy page %d of %d error\n",
 					       __func__, i, breq->nr_phys_segments);
+#else
+					printk(KERN_ERR "%s: copy page %d of %d error\n",
+					       __func__, i, bio_phys_segments(req->queue, req->bio));
+#endif
 					return -EFAULT;
 				}
 				i++;

--- a/dev.c
+++ b/dev.c
@@ -323,10 +323,8 @@ ssize_t fuse_copy_req_read(struct fuse_req *req, struct iov_iter *iter)
 {
 #ifdef USE_REQUESTQ_MODEL
 	struct request *breq = req->rq;
-	int nsegs = breq->nr_phys_segments;
 #else
 	struct bio *breq = req->bio;
-	int nsegs = bio_phys_segments(req->queue, breq);
 #endif
 	size_t copied, len;
 
@@ -350,6 +348,11 @@ ssize_t fuse_copy_req_read(struct fuse_req *req, struct iov_iter *iter)
 			if (copy_page_to_iter(req->pages[i],
 					      req->page_descs[i].offset,
 					      len, iter) != len) {
+#ifdef USE_REQUESTQ_MODEL
+				int nsegs = breq->nr_phys_segments;
+#else
+				int nsegs = bio_phys_segments(req->queue, breq);
+#endif
 				printk(KERN_ERR "%s: copy page arg %d of %d error\n",
 				       __func__, i, nsegs);
 				return -EFAULT;

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -328,11 +328,13 @@ struct fuse_req {
 		/** AIO control block */
 		struct fuse_io_priv *io;
 
+#ifdef USE_REQUESTQ_MODEL
 		/** Associated request structrure. */
 		struct request *rq;
-
+#else
 		/** Associated bio structrure. */
  		struct bio *bio;
+#endif
 	};
 
 	/** Request completion callback */

--- a/pxd.c
+++ b/pxd.c
@@ -462,7 +462,11 @@ static void pxd_make_request(struct request_queue *q, struct bio *bio)
 
 	flags = bio->bi_flags;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
 	blk_queue_split(q, &bio);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
+	blk_queue_split(q, &bio, q->bio_split);
+#endif
 
 	total_size = compute_bio_rq_size(bio);
 

--- a/pxd.c
+++ b/pxd.c
@@ -466,7 +466,7 @@ static void pxd_make_request(struct request_queue *q, struct bio *bio)
 
 	total_size = compute_bio_rq_size(bio);
 
-	printk("%s: dev m %d g %lld %s at %ld len %d bytes %d pages "
+	pxd_printk("%s: dev m %d g %lld %s at %ld len %d bytes %d pages "
 			"flags 0x%x op_flags 0x%x\n", __func__,
 			pxd_dev->minor, pxd_dev->dev_id,
 			bio_data_dir(bio) == WRITE ? "wr" : "rd",

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -1,6 +1,9 @@
 #ifndef GDFS_PXD_COMPAT_H
 #define GDFS_PXD_COMPAT_H
 
+#define dbg_printk(args...)
+//#define dbg_printk(args...) printk(KERN_INFO args)
+
 #include <linux/version.h>
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
 #include <linux/timekeeping.h>
@@ -34,7 +37,12 @@
 #define BVEC(bvec) (*(bvec))
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
+#define BIO_ENDIO(bio, err) do {                \
+    bio->bi_status = err;                       \
+    bio_endio(bio);                             \
+} while (0)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
 #define BIO_ENDIO(bio, err) do { 		\
 	if (err != 0) { 			\
 		bio_io_error((bio)); 		\

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -38,23 +38,10 @@
 static inline
 int compute_bio_rq_size(struct bio *breq) {
 #ifdef HAVE_BVEC_ITER
-	struct bio_vec bvec;
+	return breq->bi_iter.bi_size;
 #else
-	struct bio_vec *bvec = NULL;
+	return breq->bi_size;
 #endif
-
-#if defined(HAVE_BVEC_ITER)
-	struct bvec_iter bvec_iter;
-#else
-	int bvec_iter;
-#endif
-
-	int total_size = 0;
-	bio_for_each_segment(bvec, breq, bvec_iter) {
-		total_size += BVEC(bvec).bv_len;
-	}
-
-	return total_size;
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)


### PR DESCRIPTION
This is a series of changes to bring in pxdkernel changes into master.

- use direct bio instead of request queue for blkdev. 

a) The real optimization happens with the actual target device (sorting, queueing etc..). For px virtual device, it is best to pick and punt at the earliest.
b) Using bio will also allow to switch (zero copy) if the target device is a block device as well.

Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>