### PR TITLE
CONFIG_HARDENED_USERCOPY isn't reliable, use kernel version instead for whitelist annotations

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -1056,7 +1056,7 @@ int fuse_dev_init(void)
 {
 	int err = -ENOMEM;
 
-#ifdef CONFIG_HARDENED_USERCOPY
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,16,0)
 	fuse_req_cachep = kmem_cache_create_usercopy("pxd_fuse_request",
 					    sizeof(struct fuse_req),
 					    0, 0, 0, sizeof(struct fuse_req), NULL);


### PR DESCRIPTION
Version isn't completely reliable either but that's the best we can do for now.