### PR TITLE
ln/pxdkernel-3: pxd kernel fastpath extensions

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -666,6 +666,7 @@ static void pxd_free_disk(struct pxd_device *pxd_dev)
 	if (!disk)
 		return;
 
+	disableFastPath(pxd_dev);
 	pxd_dev->disk = NULL;
 	if (disk->flags & GENHD_FL_UP) {
 		del_gendisk(disk);
@@ -785,6 +786,7 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 		goto out;
 	}
 
+	disableFastPath(pxd_dev);
 	pxd_dev->removing = true;
 
 	/* Make sure the req_fn isn't called anymore even if the device hangs around */

--- a/pxd.c
+++ b/pxd.c
@@ -539,7 +539,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_out *add)
 	q = blk_alloc_queue(GFP_KERNEL);
 	if (!q)
 		goto out_disk;
-	blk_queue_make_request(q, pxd_make_request);
+	blk_queue_make_request(q, pxd_make_request_fastpath);
 #else
 	q = blk_init_queue(pxd_rq_fn, &pxd_dev->qlock);
 	if (!q)

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -57,6 +57,11 @@ int compute_bio_rq_size(struct bio *breq) {
 	return total_size;
 }
 
+static inline
+sector_t getsectors(struct bio *breq) {
+	return compute_bio_rq_size(breq) >> 9;
+}
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)
 #define BIO_OP(bio)   bio_op(bio)
 #define SUBMIT_BIO(bio) submit_bio(bio)

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -34,6 +34,8 @@ struct pxd_device {
 	bool removing;
 	struct pxd_fastpath_extension fp;
 	struct pxd_context *ctx;
+
+	bool connected;
 };
 
 #define pxd_printk(args...)

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -52,4 +52,12 @@ struct pxd_device {
 #define MAX_DISCARD_SIZE (4*SEGMENT_SIZE)
 #define MAX_WRITESEGS_FOR_FLUSH ((4*SEGMENT_SIZE)/PXD_LBS)
 
+// slow path make request io entry point
+struct request_queue;
+struct bio;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
+blk_qc_t pxd_make_request_slowpath(struct request_queue *q, struct bio *bio);
+#else
+void pxd_make_request_slowpath(struct request_queue *q, struct bio *bio);
+#endif
 #endif /* _PXD_CORE_H_ */

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -779,11 +779,9 @@ void pxd_fastpath_cleanup(struct pxd_device *pxd_dev) {
 
 /* fast path make request function, io entry point */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
-blk_qc_t pxd_make_request(struct request_queue *q, struct bio *bio)
-#define BLK_QC_RETVAL BLK_QC_T_NONE
+blk_qc_t pxd_make_request_fastpath(struct request_queue *q, struct bio *bio)
 #else
-void pxd_make_request(struct request_queue *q, struct bio *bio)
-#define BLK_QC_RETVAL
+void pxd_make_request_fastpath(struct request_queue *q, struct bio *bio)
 #endif
 {
 	struct pxd_device *pxd_dev = q->queuedata;

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -490,6 +490,7 @@ static int pxd_io_thread(void *data) {
  * shall get called last when new device is added/updated or when fuse connection is lost
  * and re-estabilished.
  */
+static
 void enableFastPath(struct pxd_device *pxd_dev, bool force) {
 	struct file *f;
 	struct inode *inode;

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -357,8 +357,8 @@ static void pxd_complete_io(struct bio* bio) {
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
 {
-	blk_status_t status = bio->bi_status;
-	bio_endio(iot->orig, status);
+	iot->orig->bi_status = bio->bi_status;
+	bio_endio(iot->orig);
 }
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
 {

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -6,6 +6,10 @@
 
 #define STATIC // temporary hack to compile until final patch completes
 
+// forward decl
+static void enableFastPath(struct pxd_device *pxd_dev, bool force);
+static void disableFastPath(struct pxd_device *pxd_dev);
+
 struct file* getFile(struct pxd_device *pxd_dev, int index) {
 	if (index < pxd_dev->fp.nfd) {
 		return pxd_dev->fp.file[index];
@@ -490,8 +494,7 @@ static int pxd_io_thread(void *data) {
  * shall get called last when new device is added/updated or when fuse connection is lost
  * and re-estabilished.
  */
-static
-void enableFastPath(struct pxd_device *pxd_dev, bool force) {
+static void enableFastPath(struct pxd_device *pxd_dev, bool force) {
 	struct file *f;
 	struct inode *inode;
 	int i;
@@ -555,7 +558,7 @@ out_file_failed:
 		pxd_dev->dev_id);
 }
 
-void disableFastPath(struct pxd_device *pxd_dev) {
+static void disableFastPath(struct pxd_device *pxd_dev) {
 	int i;
 	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
 
@@ -644,4 +647,5 @@ fail:
 }
 
 void pxd_fastpath_cleanup(struct pxd_device *pxd_dev) {
+	disableFastPath(pxd_dev);
 }

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -354,12 +354,21 @@ static void pxd_complete_io(struct bio* bio) {
 #else
 	generic_end_io_acct(bio_data_dir(bio), &pxd_dev->disk->part0, iot->start);
 #endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
-        if (bio->bi_error) { /* non-zero indicates failure */
-                bio_io_error(iot->orig);
-        } else {
-                bio_endio(iot->orig);
-        }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
+{
+	blk_status_t status = bio->bi_status;
+	bio_endio(iot->orig, status);
+}
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
+{
+	int status = bio->bi_error;
+	if (status) {
+		bio_io_error(iot->orig);
+	} else {
+		bio_endio(iot->orig);
+	}
+}
 #else
         bio_endio(iot->orig, bio->bi_error);
 #endif

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -4,8 +4,6 @@
 #include "pxd_core.h"
 #include "pxd_compat.h"
 
-#define STATIC // temporary hack to compile until final patch completes
-
 // A one-time built, static lookup table to distribute requests to cpu
 // within same numa node
 static struct node_cpu_map *node_cpu_map;
@@ -568,7 +566,7 @@ static inline void pxd_handle_bio(struct thread_context *tc, struct bio *bio, bo
 #endif
 }
 
-STATIC void pxd_add_bio(struct thread_context *tc, struct bio *bio) {
+static void pxd_add_bio(struct thread_context *tc, struct bio *bio) {
 	atomic_inc(&tc->pxd_dev->fp.ncount);
 
 	spin_lock_irq(&tc->lock);

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -80,7 +80,7 @@ void pxd_fastpath_cleanup(struct pxd_device *pxd_dev);
 
 // shall get called last when new device is added/updated or when fuse connection is lost
 // and re-estabilished.
-void enableFastPath(struct pxd_device *pxd_dev, bool force);
+// static void enableFastPath(struct pxd_device *pxd_dev, bool force);
 void disableFastPath(struct pxd_device *pxd_dev);
 
 

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -69,10 +69,11 @@ struct pxd_fastpath_extension {
 
 // helpers
 struct file* getFile(struct pxd_device *pxd_dev, int index);
+int getnextcpu(int node, int pos);
 
 // global initialization during module init for fastpath
-// void fastpath_init();
-// void fastpath_cleanup();
+int fastpath_init();
+void fastpath_cleanup();
 
 // per device initialization for fastpath
 int pxd_fastpath_init(struct pxd_device *pxd_dev, loff_t offset);

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -15,6 +15,8 @@
 
 #define MAX_THREADS (nr_cpu_ids)
 
+struct pxd_device;
+struct pxd_context;
 
 // A one-time built, static lookup table to distribute requests to cpu within
 // same numa node
@@ -23,7 +25,13 @@ struct node_cpu_map {
 	int ncpu;
 };
 
-struct pxd_device;
+// Added metadata for each bio
+struct pxd_io_tracker {
+	unsigned long start; // start time
+	struct bio *orig;    // original request bio
+	struct bio clone;    // cloned bio
+};
+
 struct thread_context {
 	struct pxd_device  *pxd_dev;
 	struct task_struct *pxd_thread;
@@ -59,6 +67,9 @@ struct pxd_fastpath_extension {
 	atomic_t index[MAX_NUMNODES];
 };
 
+// helpers
+struct file* getFile(struct pxd_device *pxd_dev, int index);
+
 // global initialization during module init for fastpath
 // void fastpath_init();
 // void fastpath_cleanup();
@@ -71,5 +82,8 @@ void pxd_fastpath_cleanup(struct pxd_device *pxd_dev);
 // and re-estabilished.
 void enableFastPath(struct pxd_device *pxd_dev, bool force);
 void disableFastPath(struct pxd_device *pxd_dev, bool force);
+
+
+void pxdctx_set_connected(struct pxd_context *ctx, bool enable);
 
 #endif /* _PXD_FASTPATH_H_ */

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -72,13 +72,22 @@ struct file* getFile(struct pxd_device *pxd_dev, int index);
 int getnextcpu(int node, int pos);
 
 // global initialization during module init for fastpath
-int fastpath_init();
-void fastpath_cleanup();
+int fastpath_init(void);
+void fastpath_cleanup(void);
 
 // per device initialization for fastpath
 int pxd_fastpath_init(struct pxd_device *pxd_dev, loff_t offset);
 void pxd_fastpath_cleanup(struct pxd_device *pxd_dev);
 
 void pxdctx_set_connected(struct pxd_context *ctx, bool enable);
+
+// IO entry point
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
+blk_qc_t pxd_make_request(struct request_queue *q, struct bio *bio);
+#define BLK_QC_RETVAL BLK_QC_T_NONE
+#else
+void pxd_make_request(struct request_queue *q, struct bio *bio);
+#define BLK_QC_RETVAL
+#endif
 
 #endif /* _PXD_FASTPATH_H_ */

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -83,10 +83,10 @@ void pxdctx_set_connected(struct pxd_context *ctx, bool enable);
 
 // IO entry point
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
-blk_qc_t pxd_make_request(struct request_queue *q, struct bio *bio);
+blk_qc_t pxd_make_request_fastpath(struct request_queue *q, struct bio *bio);
 #define BLK_QC_RETVAL BLK_QC_T_NONE
 #else
-void pxd_make_request(struct request_queue *q, struct bio *bio);
+void pxd_make_request_fastpath(struct request_queue *q, struct bio *bio);
 #define BLK_QC_RETVAL
 #endif
 

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -81,7 +81,7 @@ void pxd_fastpath_cleanup(struct pxd_device *pxd_dev);
 // shall get called last when new device is added/updated or when fuse connection is lost
 // and re-estabilished.
 void enableFastPath(struct pxd_device *pxd_dev, bool force);
-void disableFastPath(struct pxd_device *pxd_dev, bool force);
+void disableFastPath(struct pxd_device *pxd_dev);
 
 
 void pxdctx_set_connected(struct pxd_context *ctx, bool enable);

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -78,12 +78,6 @@ struct file* getFile(struct pxd_device *pxd_dev, int index);
 int pxd_fastpath_init(struct pxd_device *pxd_dev, loff_t offset);
 void pxd_fastpath_cleanup(struct pxd_device *pxd_dev);
 
-// shall get called last when new device is added/updated or when fuse connection is lost
-// and re-estabilished.
-// static void enableFastPath(struct pxd_device *pxd_dev, bool force);
-void disableFastPath(struct pxd_device *pxd_dev);
-
-
 void pxdctx_set_connected(struct pxd_context *ctx, bool enable);
 
 #endif /* _PXD_FASTPATH_H_ */


### PR DESCRIPTION
extend for fastpath routines and enable the IO path.

Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>