### PR TITLE
ln/pxdkernel-5: provide a path to configure backing device/file dynamically

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,4 +1,4 @@
-px-objs = pxd.o dev.o iov_iter.o px_version.o
+px-objs = pxd.o dev.o iov_iter.o px_version.o pxd_fastpath.o
 obj-m = px.o
 
 KBUILD_CPPFLAGS := -D__KERNEL__

--- a/Makefile.in
+++ b/Makefile.in
@@ -66,7 +66,7 @@ docker-build: docker-build-dev
 	portworx/px-fuse:dev make
 
 px_version.c:
-	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@
+	echo "const char *gitversion = \"$(shell git name-rev --name-only HEAD):$(shell git rev-parse HEAD)\";" > $@
 
 distclean: clean
 	@/bin/rm -f  config.* Makefile

--- a/dev.c
+++ b/dev.c
@@ -319,7 +319,11 @@ __acquires(fc->lock)
 
 ssize_t fuse_copy_req_read(struct fuse_req *req, struct iov_iter *iter)
 {
+#ifdef USE_REQUESTQ_MODEL
 	struct request *breq = req->rq;
+#else
+	struct bio *breq = req->bio;
+#endif
 	size_t copied, len;
 
 	copied = sizeof(req->in.h);
@@ -342,8 +346,13 @@ ssize_t fuse_copy_req_read(struct fuse_req *req, struct iov_iter *iter)
 			if (copy_page_to_iter(req->pages[i],
 					      req->page_descs[i].offset,
 					      len, iter) != len) {
+#ifdef USE_REQUESTQ_MODEL
 				printk(KERN_ERR "%s: copy page arg %d of %d error\n",
 				       __func__, i, breq->nr_phys_segments);
+#else
+				printk(KERN_ERR "%s: copy page arg %d of %d error\n",
+				       __func__, i, bio_phys_segments(req->queue, breq));
+#endif
 				return -EFAULT;
 			}
 			copied += len;
@@ -361,7 +370,14 @@ extern uint32_t pxd_detect_zero_writes;
 static void fuse_convert_zero_writes(struct fuse_req *req)
 {
 	uint8_t wsize = sizeof(uint64_t);
+#ifdef USE_REQUESTQ_MODEL
 	struct req_iterator breq_iter;
+#elif defined(HAVE_BVEC_ITER)
+	struct bvec_iter bvec_iter;
+#else
+	int bvec_iter;
+#endif
+
 #ifdef HAVE_BVEC_ITER
 	struct bio_vec bvec;
 #else
@@ -371,7 +387,11 @@ static void fuse_convert_zero_writes(struct fuse_req *req)
 	size_t i, len;
 	uint64_t *q;
 
+#ifdef USE_REQUESTQ_MODEL
 	rq_for_each_segment(bvec, req->rq, breq_iter) {
+#else
+	bio_for_each_segment(bvec, req->bio, bvec_iter) {
+#endif
 		kaddr = kmap_atomic(BVEC(bvec).bv_page);
 		p = kaddr + BVEC(bvec).bv_offset;
 		q = (uint64_t *)p;
@@ -609,7 +629,15 @@ static int fuse_notify_read_data(struct fuse_conn *conn, unsigned int size,
 #else
 	struct bio_vec *bvec = NULL;
 #endif
+
+#ifdef USE_REQUESTQ_MODEL
 	struct req_iterator breq_iter;
+#elif defined(HAVE_BVEC_ITER)
+	struct bvec_iter bvec_iter;
+#else
+	int bvec_iter;
+#endif
+
 	struct iov_iter data_iter;
 	size_t copied, skipped = 0;
 	int ret;
@@ -644,7 +672,11 @@ static int fuse_notify_read_data(struct fuse_conn *conn, unsigned int size,
 		iov_iter_advance(&data_iter,
 				 req->misc.pxd_rdwr_in.offset & PXD_LBS_MASK);
 
+#ifdef USE_REQUESTQ_MODEL
 	rq_for_each_segment(bvec, req->rq, breq_iter) {
+#else
+	bio_for_each_segment(bvec, req->bio, bvec_iter) {
+#endif
 		copied = 0;
 		len = BVEC(bvec).bv_len;
 		if (skipped < read_data.offset) {
@@ -782,22 +814,44 @@ static ssize_t fuse_dev_do_write(struct fuse_conn *fc, struct iov_iter *iter)
 	req->out.h = oh;
 
 	if (req->bio_pages && req->out.numargs && iter->count > 0) {
-		struct request *breq = req->rq;
 #ifdef HAVE_BVEC_ITER
 		struct bio_vec bvec;
 #else
 		struct bio_vec *bvec = NULL;
 #endif
+
+#ifdef USE_REQUESTQ_MODEL
+		struct request *breq = req->rq;
 		struct req_iterator breq_iter;
-		if (breq->nr_phys_segments && req->in.h.opcode == PXD_READ) {
+		int nsegs = breq->nr_phys_segments;
+#elif defined(HAVE_BVEC_ITER)
+		struct bio *breq = req->bio;
+		struct bvec_iter bvec_iter;
+		int nsegs = bio_phys_segments(req->queue, breq);
+#else
+		struct bio *breq = req->bio;
+		int bvec_iter;
+		int nsegs = bio_phys_segments(req->queue, breq);
+#endif
+
+		if (nsegs && req->in.h.opcode == PXD_READ) {
 			int i = 0;
+#ifdef USE_REQUESTQ_MODEL
 			rq_for_each_segment(bvec, breq, breq_iter) {
+#else
+			bio_for_each_segment(bvec, breq, bvec_iter) {
+#endif
 				len = BVEC(bvec).bv_len;
 				if (copy_page_from_iter(BVEC(bvec).bv_page,
 							BVEC(bvec).bv_offset,
 							len, iter) != len) {
+#ifdef USE_REQUESTQ_MODEL
 					printk(KERN_ERR "%s: copy page %d of %d error\n",
 					       __func__, i, breq->nr_phys_segments);
+#else
+					printk(KERN_ERR "%s: copy page %d of %d error\n",
+					       __func__, i, bio_phys_segments(req->queue, req->bio));
+#endif
 					return -EFAULT;
 				}
 				i++;

--- a/dev.c
+++ b/dev.c
@@ -353,6 +353,46 @@ ssize_t fuse_copy_req_read(struct fuse_req *req, struct iov_iter *iter)
 	return copied;
 }
 
+extern uint32_t pxd_detect_zero_writes;
+
+/* Check if the request is writing zeroes and if so, convert it as a discard
+ * request.
+ */
+static void fuse_convert_zero_writes(struct fuse_req *req)
+{
+	uint8_t wsize = sizeof(uint64_t);
+	struct req_iterator breq_iter;
+#ifdef HAVE_BVEC_ITER
+	struct bio_vec bvec;
+#else
+	struct bio_vec *bvec = NULL;
+#endif
+	char *kaddr, *p;
+	size_t i, len;
+	uint64_t *q;
+
+	rq_for_each_segment(bvec, req->rq, breq_iter) {
+		kaddr = kmap_atomic(BVEC(bvec).bv_page);
+		p = kaddr + BVEC(bvec).bv_offset;
+		q = (uint64_t *)p;
+		len = BVEC(bvec).bv_len;
+		for (i = 0; i < (len / wsize); i++) {
+			if (q[i]) {
+				kunmap_atomic(kaddr);
+				return;
+			}
+		}
+		for (i = len - (len % wsize); i < len; i++) {
+			if (p[i]) {
+				kunmap_atomic(kaddr);
+				return;
+			}
+		}
+		kunmap_atomic(kaddr);
+	}
+	req->in.h.opcode = PXD_DISCARD;
+}
+
 /*
  * Read a single request into the userspace filesystem's buffer.  This
  * function waits until a request is available, then removes it from
@@ -399,6 +439,7 @@ retry:
 			remain -= req->in.h.len;
 			entry = entry->next;
 		} else {
+			remain = 0;
 			break;
 		}
 	}
@@ -415,6 +456,13 @@ retry:
 	err = 0;
 	while (1) {
 		req = list_entry(entry, struct fuse_req, list);
+
+		/* Check if a write request is writing zeroes */
+		if (pxd_detect_zero_writes && (req->in.h.opcode == PXD_WRITE) &&
+			req->misc.pxd_rdwr_in.size &&
+			!(req->misc.pxd_rdwr_in.flags & PXD_FLAGS_SYNC)) {
+			fuse_convert_zero_writes(req);
+		}
 		next = entry->next;
 		copied_this_time = fuse_copy_req_read(req, iter);
 		if (likely(copied_this_time > 0)) {

--- a/dev.c
+++ b/dev.c
@@ -323,10 +323,8 @@ ssize_t fuse_copy_req_read(struct fuse_req *req, struct iov_iter *iter)
 {
 #ifdef USE_REQUESTQ_MODEL
 	struct request *breq = req->rq;
-	int nsegs = breq->nr_phys_segments;
 #else
 	struct bio *breq = req->bio;
-	int nsegs = bio_phys_segments(req->queue, breq);
 #endif
 	size_t copied, len;
 
@@ -350,6 +348,11 @@ ssize_t fuse_copy_req_read(struct fuse_req *req, struct iov_iter *iter)
 			if (copy_page_to_iter(req->pages[i],
 					      req->page_descs[i].offset,
 					      len, iter) != len) {
+#ifdef USE_REQUESTQ_MODEL
+				int nsegs = breq->nr_phys_segments;
+#else
+				int nsegs = bio_phys_segments(req->queue, breq);
+#endif
 				printk(KERN_ERR "%s: copy page arg %d of %d error\n",
 				       __func__, i, nsegs);
 				return -EFAULT;

--- a/dev.c
+++ b/dev.c
@@ -764,6 +764,19 @@ static int fuse_notify_update_size(struct fuse_conn *conn, unsigned int size,
 	return pxd_update_size(conn, &update_size);
 }
 
+static int fuse_notify_update_path(struct fuse_conn *conn, unsigned int size,
+		struct iov_iter *iter)
+{
+	struct pxd_update_path_out update_path;
+	size_t len = sizeof(update_path);
+
+	if (copy_from_iter(&update_path, len, iter) != len) {
+		printk(KERN_ERR "%s: can't copy arg\n", __func__);
+		return -EFAULT;
+	}
+	return pxd_update_path(conn, &update_path);
+}
+
 static int fuse_notify(struct fuse_conn *fc, enum fuse_notify_code code,
 		       unsigned int size, struct iov_iter *iter)
 {
@@ -776,6 +789,8 @@ static int fuse_notify(struct fuse_conn *fc, enum fuse_notify_code code,
 		return fuse_notify_remove(fc, size, iter);
 	case PXD_UPDATE_SIZE:
 		return fuse_notify_update_size(fc, size, iter);
+	case PXD_UPDATE_PATH:
+		return fuse_notify_update_path(fc, size, iter);
 	default:
 		return -EINVAL;
 	}

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -834,5 +834,6 @@ int fuse_do_setattr(struct inode *inode, struct iattr *attr,
 ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_out *add);
 ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove);
 ssize_t pxd_update_size(struct fuse_conn *fc, struct pxd_update_size_out *update_size);
+ssize_t pxd_update_path(struct fuse_conn *fc, struct pxd_update_path_out *update_path);
 
 #endif /* _FS_FUSE_I_H */

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -257,9 +257,6 @@ struct fuse_req {
 	/** hash table entry */
 	struct hlist_node hash_entry;
 
-	/** refcount */
-	atomic_t count;
-
 	/*
 	 * The following bitfields are either set once before the
 	 * request is queued or setting/clearing them is protected by
@@ -702,11 +699,6 @@ struct fuse_req *fuse_get_req(struct fuse_conn *fc, unsigned npages);
 struct fuse_req *fuse_get_req_for_background(struct fuse_conn *fc,
 					     unsigned npages);
 
-/*
- * Increment reference count on request
- */
-void __fuse_get_request(struct fuse_req *req);
-
 /**
  * Get a request, may fail with -ENOMEM,
  * useful for callers who doesn't use req->pages[]
@@ -715,12 +707,6 @@ static inline struct fuse_req *fuse_get_req_nopages(struct fuse_conn *fc)
 {
 	return fuse_get_req(fc, 0);
 }
-
-/**
- * Decrement reference count of a request.  If count goes to zero free
- * the request.
- */
-void fuse_put_request(struct fuse_req *req);
 
 /**
  * Send a request to head of pending queue.

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -266,9 +266,6 @@ struct fuse_req {
 	 * fuse_conn->lock
 	 */
 
-	/** True if the request has reply */
-	unsigned isreply:1;
-
 	/** Request is sent in the background */
 	unsigned background:1;
 
@@ -723,7 +720,7 @@ static inline struct fuse_req *fuse_get_req_nopages(struct fuse_conn *fc)
  * Decrement reference count of a request.  If count goes to zero free
  * the request.
  */
-void fuse_put_request(struct fuse_conn *fc, struct fuse_req *req);
+void fuse_put_request(struct fuse_req *req);
 
 /**
  * Send a request to head of pending queue.
@@ -733,7 +730,7 @@ void fuse_request_send_oob(struct fuse_conn *fc, struct fuse_req *req);
 /**
  * Send a request in the background
  */
-void fuse_request_send_background(struct fuse_conn *fc, struct fuse_req *req);
+void fuse_request_send_nowait(struct fuse_conn *fc, struct fuse_req *req);
 
 /* Abort all requests */
 void fuse_abort_conn(struct fuse_conn *fc);

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -328,11 +328,13 @@ struct fuse_req {
 		/** AIO control block */
 		struct fuse_io_priv *io;
 
+#ifdef USE_REQUESTQ_MODEL
 		/** Associated request structrure. */
 		struct request *rq;
-
+#else
 		/** Associated bio structrure. */
  		struct bio *bio;
+#endif
 	};
 
 	/** Request completion callback */

--- a/pxd.c
+++ b/pxd.c
@@ -666,6 +666,7 @@ static void pxd_free_disk(struct pxd_device *pxd_dev)
 	if (!disk)
 		return;
 
+	disableFastPath(pxd_dev);
 	pxd_dev->disk = NULL;
 	if (disk->flags & GENHD_FL_UP) {
 		del_gendisk(disk);
@@ -785,6 +786,7 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 		goto out;
 	}
 
+	disableFastPath(pxd_dev);
 	pxd_dev->removing = true;
 
 	/* Make sure the req_fn isn't called anymore even if the device hangs around */

--- a/pxd.c
+++ b/pxd.c
@@ -539,7 +539,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_out *add)
 	q = blk_alloc_queue(GFP_KERNEL);
 	if (!q)
 		goto out_disk;
-	blk_queue_make_request(q, pxd_make_request);
+	blk_queue_make_request(q, pxd_make_request_fastpath);
 #else
 	q = blk_init_queue(pxd_rq_fn, &pxd_dev->qlock);
 	if (!q)

--- a/pxd.c
+++ b/pxd.c
@@ -559,7 +559,11 @@ static void pxd_make_request(struct request_queue *q, struct bio *bio)
 
 	flags = bio->bi_flags;
 
-	// blk_queue_split(q, &bio);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
+	blk_queue_split(q, &bio);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
+	blk_queue_split(q, &bio, q->bio_split);
+#endif
 
 	total_size = compute_bio_rq_size(bio);
 

--- a/pxd.c
+++ b/pxd.c
@@ -954,7 +954,6 @@ static void pxd_process_init_reply(struct fuse_conn *fc,
 	if (req->out.h.error != 0)
 		fc->connected = 0;
 	fc->pend_open = 0;
-	fuse_put_request(req);
 }
 
 static int pxd_send_init(struct fuse_conn *fc)
@@ -1013,7 +1012,7 @@ err_free_pages:
 		if (req->pages[i])
 			put_page(req->pages[i]);
 	}
-	fuse_put_request(req);
+	fuse_request_free(req);
 err:
 	return rc;
 }

--- a/pxd.c
+++ b/pxd.c
@@ -60,9 +60,11 @@ struct pxd_context *pxd_contexts;
 uint32_t pxd_num_contexts = PXD_NUM_CONTEXTS;
 uint32_t pxd_num_contexts_exported = PXD_NUM_CONTEXT_EXPORTED;
 uint32_t pxd_timeout_secs = PXD_TIMER_SECS_MAX;
+uint32_t pxd_detect_zero_writes = 0;
 
 module_param(pxd_num_contexts_exported, uint, 0644);
 module_param(pxd_num_contexts, uint, 0644);
+module_param(pxd_detect_zero_writes, uint, 0644);
 
 struct pxd_device {
 	uint64_t dev_id;

--- a/pxd.c
+++ b/pxd.c
@@ -466,7 +466,7 @@ static void pxd_make_request(struct request_queue *q, struct bio *bio)
 
 	total_size = compute_bio_rq_size(bio);
 
-	printk("%s: dev m %d g %lld %s at %ld len %d bytes %d pages "
+	pxd_printk("%s: dev m %d g %lld %s at %ld len %d bytes %d pages "
 			"flags 0x%x op_flags 0x%x\n", __func__,
 			pxd_dev->minor, pxd_dev->dev_id,
 			bio_data_dir(bio) == WRITE ? "wr" : "rd",

--- a/pxd.h
+++ b/pxd.h
@@ -1,6 +1,7 @@
 #ifndef PXD_H_
 #define PXD_H_
 
+#include <linux/kernel.h>
 #include <linux/version.h>
 #ifdef __PXKERNEL__
 #include <linux/types.h>

--- a/pxd.h
+++ b/pxd.h
@@ -19,7 +19,7 @@
 #define PXD_DEV  	"pxd/pxd"		/**< block device prefix */
 #define PXD_DEV_PATH	"/dev/" PXD_DEV		/**< block device path prefix */
 
-#define PXD_VERSION 8				/**< driver version */
+#define PXD_VERSION 9				/**< driver version */
 
 #define PXD_NUM_CONTEXTS			11	/**< Total available control devices */
 #define PXD_NUM_CONTEXT_EXPORTED	1	/**< Available for external use */
@@ -46,6 +46,7 @@ enum pxd_opcode {
 	PXD_READ_DATA,		/**< read data from kernel */
 	PXD_UPDATE_SIZE,	/**< update device size */
 	PXD_WRITE_SAME,		/**< write_same operation */
+	PXD_UPDATE_PATH,    /**< update backing file/device path for a virtual vol */
 	PXD_LAST,
 };
 
@@ -92,6 +93,7 @@ struct pxd_add_out {
 	size_t size;		/**< block device size in bytes */
 	int32_t queue_depth;	/**< use queue depth 0 to bypass queueing */
 	int32_t discard_size;	/**< block device discard size in bytes */
+	loff_t offset; /**< starting offset within the backing file/device */
 };
 
 /**
@@ -118,6 +120,16 @@ struct pxd_read_data_out {
 struct pxd_update_size_out {
 	uint64_t dev_id;
 	size_t size;
+};
+
+/**
+ * PXD_UPDATE_PATH request from user space
+ */
+struct pxd_update_path_out {
+	uint64_t dev_id;
+	size_t size; // count of paths below
+
+	char devpath[MAX_PXD_BACKING_DEVS][MAX_PXD_DEVPATH_LEN];
 };
 
 /**

--- a/pxd.h
+++ b/pxd.h
@@ -31,6 +31,9 @@
 #define PXD_MAX_IO		(1024*1024)	/**< maximum io size in bytes */
 #define PXD_MAX_QDEPTH  256			/**< maximum device queue depth */
 
+#define MAX_PXD_BACKING_DEVS (3)
+#define MAX_PXD_DEVPATH_LEN  (128)
+
 /** fuse opcodes */
 enum pxd_opcode {
 	PXD_INIT = 8192,	/**< send on device open from kernel */

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -57,6 +57,11 @@ int compute_bio_rq_size(struct bio *breq) {
 	return total_size;
 }
 
+static inline
+sector_t getsectors(struct bio *breq) {
+	return compute_bio_rq_size(breq) >> 9;
+}
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)
 #define BIO_OP(bio)   bio_op(bio)
 #define SUBMIT_BIO(bio) submit_bio(bio)

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -1,6 +1,9 @@
 #ifndef GDFS_PXD_COMPAT_H
 #define GDFS_PXD_COMPAT_H
 
+#define dbg_printk(args...)
+//#define dbg_printk(args...) printk(KERN_INFO args)
+
 #include <linux/version.h>
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
 #include <linux/timekeeping.h>
@@ -34,7 +37,12 @@
 #define BVEC(bvec) (*(bvec))
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
+#define BIO_ENDIO(bio, err) do {                \
+    bio->bi_status = err;                       \
+    bio_endio(bio);                             \
+} while (0)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
 #define BIO_ENDIO(bio, err) do { 		\
 	if (err != 0) { 			\
 		bio_io_error((bio)); 		\

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -1,0 +1,53 @@
+#ifndef _PXD_CORE_H_
+#define _PXD_CORE_H_
+
+#include <linux/miscdevice.h>
+
+#include "pxd_fastpath.h"
+#include "fuse_i.h"
+struct pxd_context {
+	spinlock_t lock;
+	struct list_head list;
+	size_t num_devices;
+	struct fuse_conn fc;
+	struct file_operations fops;
+	char name[256];
+	int id;
+	struct miscdevice miscdev;
+	struct list_head pending_requests;
+	struct timer_list timer;
+	bool init_sent;
+	uint64_t unique;
+};
+
+struct pxd_device {
+	uint64_t dev_id;
+	int major;
+	int minor;
+	struct gendisk *disk;
+	struct device dev;
+	size_t size;
+	spinlock_t lock;
+	spinlock_t qlock;
+	struct list_head node;
+	int open_count;
+	bool removing;
+	struct pxd_fastpath_extension fp;
+	struct pxd_context *ctx;
+};
+
+#define pxd_printk(args...)
+//#define pxd_printk(args...) printk(KERN_ERR args)
+
+#ifndef SECTOR_SIZE
+#define SECTOR_SIZE 512
+#endif
+#ifndef SECTOR_SHIFT
+#define SECTOR_SHIFT (9)
+#endif
+
+#define SEGMENT_SIZE (1024 * 1024)
+#define MAX_DISCARD_SIZE (4*SEGMENT_SIZE)
+#define MAX_WRITESEGS_FOR_FLUSH ((4*SEGMENT_SIZE)/PXD_LBS)
+
+#endif /* _PXD_CORE_H_ */

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -34,6 +34,8 @@ struct pxd_device {
 	bool removing;
 	struct pxd_fastpath_extension fp;
 	struct pxd_context *ctx;
+
+	bool connected;
 };
 
 #define pxd_printk(args...)

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -52,4 +52,12 @@ struct pxd_device {
 #define MAX_DISCARD_SIZE (4*SEGMENT_SIZE)
 #define MAX_WRITESEGS_FOR_FLUSH ((4*SEGMENT_SIZE)/PXD_LBS)
 
+// slow path make request io entry point
+struct request_queue;
+struct bio;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
+blk_qc_t pxd_make_request_slowpath(struct request_queue *q, struct bio *bio);
+#else
+void pxd_make_request_slowpath(struct request_queue *q, struct bio *bio);
+#endif
 #endif /* _PXD_CORE_H_ */

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -779,11 +779,9 @@ void pxd_fastpath_cleanup(struct pxd_device *pxd_dev) {
 
 /* fast path make request function, io entry point */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
-blk_qc_t pxd_make_request(struct request_queue *q, struct bio *bio)
-#define BLK_QC_RETVAL BLK_QC_T_NONE
+blk_qc_t pxd_make_request_fastpath(struct request_queue *q, struct bio *bio)
 #else
-void pxd_make_request(struct request_queue *q, struct bio *bio)
-#define BLK_QC_RETVAL
+void pxd_make_request_fastpath(struct request_queue *q, struct bio *bio)
 #endif
 {
 	struct pxd_device *pxd_dev = q->queuedata;

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -490,6 +490,7 @@ static int pxd_io_thread(void *data) {
  * shall get called last when new device is added/updated or when fuse connection is lost
  * and re-estabilished.
  */
+static
 void enableFastPath(struct pxd_device *pxd_dev, bool force) {
 	struct file *f;
 	struct inode *inode;

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -72,7 +72,6 @@ void fastpath_cleanup(void) {
 }
 
 // forward decl
-static void enableFastPath(struct pxd_device *pxd_dev, bool force);
 static void disableFastPath(struct pxd_device *pxd_dev);
 
 struct file* getFile(struct pxd_device *pxd_dev, int index) {
@@ -619,7 +618,7 @@ static int pxd_io_thread(void *data) {
  * shall get called last when new device is added/updated or when fuse connection is lost
  * and re-estabilished.
  */
-static void enableFastPath(struct pxd_device *pxd_dev, bool force) {
+void enableFastPath(struct pxd_device *pxd_dev, bool force) {
 	struct file *f;
 	struct inode *inode;
 	int i;

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -6,6 +6,10 @@
 
 #define STATIC // temporary hack to compile until final patch completes
 
+// forward decl
+static void enableFastPath(struct pxd_device *pxd_dev, bool force);
+static void disableFastPath(struct pxd_device *pxd_dev);
+
 struct file* getFile(struct pxd_device *pxd_dev, int index) {
 	if (index < pxd_dev->fp.nfd) {
 		return pxd_dev->fp.file[index];
@@ -490,8 +494,7 @@ static int pxd_io_thread(void *data) {
  * shall get called last when new device is added/updated or when fuse connection is lost
  * and re-estabilished.
  */
-static
-void enableFastPath(struct pxd_device *pxd_dev, bool force) {
+static void enableFastPath(struct pxd_device *pxd_dev, bool force) {
 	struct file *f;
 	struct inode *inode;
 	int i;
@@ -555,7 +558,7 @@ out_file_failed:
 		pxd_dev->dev_id);
 }
 
-void disableFastPath(struct pxd_device *pxd_dev) {
+static void disableFastPath(struct pxd_device *pxd_dev) {
 	int i;
 	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
 
@@ -644,4 +647,5 @@ fail:
 }
 
 void pxd_fastpath_cleanup(struct pxd_device *pxd_dev) {
+	disableFastPath(pxd_dev);
 }

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1,0 +1,151 @@
+#include <linux/types.h>
+
+#include "pxd.h"
+#include "pxd_core.h"
+
+static int pxd_io_thread(void *data) {
+	return 0;
+}
+
+/*
+ * shall get called last when new device is added/updated or when fuse connection is lost
+ * and re-estabilished.
+ */
+void enableFastPath(struct pxd_device *pxd_dev, bool force) {
+	struct file *f;
+	struct inode *inode;
+	int i;
+	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
+	int nfd = fp->nfd;
+
+	for (i=0; i<nfd; i++) {
+		if (fp->file[i] > 0) { /* valid fd exists already */
+			if (force) {
+				filp_close(fp->file[i], NULL);
+				f = filp_open(fp->device_path[i], O_DIRECT | O_LARGEFILE | O_RDWR, 0600);
+				if (IS_ERR_OR_NULL(f)) {
+					printk(KERN_ERR"Failed attaching path: device %llu, path %s err %ld\n",
+						pxd_dev->dev_id, fp->device_path[i], PTR_ERR(f));
+					goto out_file_failed;
+				}
+			} else {
+				f = fp->file[i];
+			}
+		} else {
+			f = filp_open(fp->device_path[i], O_DIRECT | O_LARGEFILE | O_RDWR, 0600);
+			if (IS_ERR_OR_NULL(f)) {
+				printk(KERN_ERR"Failed attaching path: device %llu, path %s err %ld\n",
+					pxd_dev->dev_id, fp->device_path[i], PTR_ERR(f));
+				goto out_file_failed;
+			}
+		}
+
+		fp->file[i] = f;
+
+		inode = f->f_inode;
+		printk(KERN_INFO"device %lld:%d, inode %lu\n", pxd_dev->dev_id, i, inode->i_ino);
+		if (S_ISREG(inode->i_mode)) {
+			fp->block_device = false; /* override config to use file io */
+			printk(KERN_INFO"device[%lld:%d] is a regular file - inode %lu\n",
+					pxd_dev->dev_id, i, inode->i_ino);
+		} else if (S_ISBLK(inode->i_mode)) {
+			printk(KERN_INFO"device[%lld:%d] is a block device - inode %lu\n",
+				pxd_dev->dev_id, i, inode->i_ino);
+		} else {
+			fp->block_device = false; /* override config to use file io */
+			printk(KERN_INFO"device[%lld:%d] inode %lu unknown device %#x\n",
+				pxd_dev->dev_id, i, inode->i_ino, inode->i_mode);
+		}
+	}
+
+	printk(KERN_INFO"pxd_dev %llu setting up with %d backing volumes, [%p,%p,%p]\n",
+		pxd_dev->dev_id, fp->nfd,
+		fp->file[0], fp->file[1], fp->file[2]);
+
+	return;
+
+out_file_failed:
+	fp->nfd = 0;
+	for (i=0; i<nfd; i++) {
+		if (fp->file[i] > 0) filp_close(fp->file[i], NULL);
+	}
+	memset(fp->file, 0, sizeof(fp->file));
+	memset(fp->device_path, 0, sizeof(fp->device_path));
+	printk(KERN_INFO"Device %llu no backing volume setup, will take slow path\n",
+		pxd_dev->dev_id);
+}
+
+void disableFastPath(struct pxd_device *pxd_dev, bool force) {
+}
+
+int pxd_fastpath_init(struct pxd_device *pxd_dev, loff_t offset) {
+	int err = -EINVAL;
+	int i;
+	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
+
+	fp->offset = offset;
+	fp->block_device = true; // always default to considering as block device
+	fp->nfd = 0; // will take slow path, if additional info not provided.
+
+	pxd_printk("Number of cpu ids %d\n", MAX_THREADS);
+	fp->bg_flush_enabled = false; // introduces high latency
+	fp->n_flush_wrsegs = MAX_WRITESEGS_FOR_FLUSH;
+
+	// congestion init
+	init_waitqueue_head(&fp->congestion_wait);
+	init_waitqueue_head(&fp->sync_event);
+	spin_lock_init(&fp->sync_lock);
+
+	atomic_set(&fp->nsync_active, 0);
+	atomic_set(&fp->nsync, 0);
+	atomic_set(&fp->ncount,0);
+	atomic_set(&fp->nswitch,0);
+	atomic_set(&fp->nslowPath,0);
+	atomic_set(&fp->ncomplete,0);
+	atomic_set(&fp->nwrite_counter,0);
+
+	fp->offset = 0;
+
+	fp->tc = kzalloc(MAX_THREADS * sizeof(struct thread_context), GFP_NOIO);
+	if (!fp->tc) {
+		printk(KERN_ERR"Initializing backing volumes for pxd failed %d\n", err);
+		return -ENOMEM;
+	}
+
+	for (i=0; i<nr_node_ids; i++) {
+		atomic_set(&fp->index[i], 0);
+	}
+
+	for (i=0; i<MAX_THREADS; i++) {
+		struct thread_context *tc = &fp->tc[i];
+		tc->pxd_dev = pxd_dev;
+		spin_lock_init(&tc->lock);
+		init_waitqueue_head(&tc->pxd_event);
+		tc->pxd_thread = kthread_create_on_node(pxd_io_thread, tc, cpu_to_node(i),
+				"pxd%d:%llu", i, pxd_dev->dev_id);
+		if (IS_ERR(tc->pxd_thread)) {
+			pxd_printk("Init kthread for device %llu failed %lu\n",
+				pxd_dev->dev_id, PTR_ERR(tc->pxd_thread));
+			err = -EINVAL;
+			goto fail;
+		}
+
+		kthread_bind(tc->pxd_thread, i);
+		wake_up_process(tc->pxd_thread);
+	}
+
+	enableFastPath(pxd_dev, true);
+
+	return 0;
+fail:
+	for (i=0; i<MAX_THREADS; i++) {
+		struct thread_context *tc = &fp->tc[i];
+		if (tc->pxd_thread) kthread_stop(tc->pxd_thread);
+	}
+
+	if (fp->tc) kfree(fp->tc);
+	return err;
+}
+
+void pxd_fastpath_cleanup(struct pxd_device *pxd_dev) {
+}

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -4,8 +4,6 @@
 #include "pxd_core.h"
 #include "pxd_compat.h"
 
-#define STATIC // temporary hack to compile until final patch completes
-
 // A one-time built, static lookup table to distribute requests to cpu
 // within same numa node
 static struct node_cpu_map *node_cpu_map;
@@ -568,7 +566,7 @@ static inline void pxd_handle_bio(struct thread_context *tc, struct bio *bio, bo
 #endif
 }
 
-STATIC void pxd_add_bio(struct thread_context *tc, struct bio *bio) {
+static void pxd_add_bio(struct thread_context *tc, struct bio *bio) {
 	atomic_inc(&tc->pxd_dev->fp.ncount);
 
 	spin_lock_irq(&tc->lock);

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -1,0 +1,70 @@
+#ifndef _PXD_FASTPATH_H_
+#define _PXD_FASTPATH_H_
+
+#include <linux/atomic.h>
+#include <linux/blkdev.h>
+#include <linux/uio.h>
+#include <linux/kthread.h>
+#include <linux/dma-mapping.h>
+#include <linux/statfs.h>
+#include <linux/file.h>
+#include <linux/splice.h>
+#include <linux/fs.h>
+#include <linux/falloc.h>
+#include <linux/bio.h>
+
+#define MAX_THREADS (nr_cpu_ids)
+
+
+// A one-time built, static lookup table to distribute requests to cpu within
+// same numa node
+struct node_cpu_map {
+	int cpu[NR_CPUS];
+	int ncpu;
+};
+
+struct pxd_device;
+struct thread_context {
+	struct pxd_device  *pxd_dev;
+	struct task_struct *pxd_thread;
+	wait_queue_head_t   pxd_event;
+	spinlock_t  		lock;
+	struct bio_list  bio_list;
+};
+
+struct pxd_fastpath_extension {
+	// Extended information
+	bool   block_device;
+	loff_t offset; // offset into the backing device/file
+	int bg_flush_enabled; // dynamically enable bg flush from driver
+	int n_flush_wrsegs; // num of PXD_LBS write segments to force flush
+
+	// Below information has to be set through new PXD_UPDATE_PATH ioctl
+	int nfd;
+	struct file *file[MAX_PXD_BACKING_DEVS];
+	char device_path[MAX_PXD_BACKING_DEVS][MAX_PXD_DEVPATH_LEN];
+
+	struct thread_context *tc;
+	wait_queue_head_t   congestion_wait;
+	wait_queue_head_t   sync_event;
+	spinlock_t   	sync_lock;
+	atomic_t nsync_active; // [global] currently active?
+	atomic_t nsync; // [global] number of forced syncs completed
+	atomic_t ncount; // [global] total active requests
+	atomic_t nswitch; // [global] total number of requests through bio switch path
+	atomic_t nslowPath; // [global] total requests through slow path
+	atomic_t ncomplete; // [global] total completed requests
+	atomic_t ncongested; // [global] total number of times queue congested
+	atomic_t nwrite_counter; // [global] completed writes, gets cleared on a threshold
+	atomic_t index[MAX_NUMNODES];
+};
+
+// global initialization during module init for fastpath
+// void fastpath_init();
+// void fastpath_cleanup();
+
+// per device initialization for fastpath
+int pxd_fastpath_init(struct pxd_device *pxd_dev, loff_t offset);
+void pxd_fastpath_cleanup(struct pxd_device *pxd_dev, loff_t offset);
+
+#endif /* _PXD_FASTPATH_H_ */

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -80,7 +80,7 @@ void pxd_fastpath_cleanup(struct pxd_device *pxd_dev);
 
 // shall get called last when new device is added/updated or when fuse connection is lost
 // and re-estabilished.
-void enableFastPath(struct pxd_device *pxd_dev, bool force);
+// static void enableFastPath(struct pxd_device *pxd_dev, bool force);
 void disableFastPath(struct pxd_device *pxd_dev);
 
 

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -69,10 +69,11 @@ struct pxd_fastpath_extension {
 
 // helpers
 struct file* getFile(struct pxd_device *pxd_dev, int index);
+int getnextcpu(int node, int pos);
 
 // global initialization during module init for fastpath
-// void fastpath_init();
-// void fastpath_cleanup();
+int fastpath_init();
+void fastpath_cleanup();
 
 // per device initialization for fastpath
 int pxd_fastpath_init(struct pxd_device *pxd_dev, loff_t offset);

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -15,6 +15,8 @@
 
 #define MAX_THREADS (nr_cpu_ids)
 
+struct pxd_device;
+struct pxd_context;
 
 // A one-time built, static lookup table to distribute requests to cpu within
 // same numa node
@@ -23,7 +25,13 @@ struct node_cpu_map {
 	int ncpu;
 };
 
-struct pxd_device;
+// Added metadata for each bio
+struct pxd_io_tracker {
+	unsigned long start; // start time
+	struct bio *orig;    // original request bio
+	struct bio clone;    // cloned bio
+};
+
 struct thread_context {
 	struct pxd_device  *pxd_dev;
 	struct task_struct *pxd_thread;
@@ -59,6 +67,9 @@ struct pxd_fastpath_extension {
 	atomic_t index[MAX_NUMNODES];
 };
 
+// helpers
+struct file* getFile(struct pxd_device *pxd_dev, int index);
+
 // global initialization during module init for fastpath
 // void fastpath_init();
 // void fastpath_cleanup();
@@ -71,5 +82,8 @@ void pxd_fastpath_cleanup(struct pxd_device *pxd_dev);
 // and re-estabilished.
 void enableFastPath(struct pxd_device *pxd_dev, bool force);
 void disableFastPath(struct pxd_device *pxd_dev, bool force);
+
+
+void pxdctx_set_connected(struct pxd_context *ctx, bool enable);
 
 #endif /* _PXD_FASTPATH_H_ */

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -65,6 +65,11 @@ struct pxd_fastpath_extension {
 
 // per device initialization for fastpath
 int pxd_fastpath_init(struct pxd_device *pxd_dev, loff_t offset);
-void pxd_fastpath_cleanup(struct pxd_device *pxd_dev, loff_t offset);
+void pxd_fastpath_cleanup(struct pxd_device *pxd_dev);
+
+// shall get called last when new device is added/updated or when fuse connection is lost
+// and re-estabilished.
+void enableFastPath(struct pxd_device *pxd_dev, bool force);
+void disableFastPath(struct pxd_device *pxd_dev, bool force);
 
 #endif /* _PXD_FASTPATH_H_ */

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -72,13 +72,22 @@ struct file* getFile(struct pxd_device *pxd_dev, int index);
 int getnextcpu(int node, int pos);
 
 // global initialization during module init for fastpath
-int fastpath_init();
-void fastpath_cleanup();
+int fastpath_init(void);
+void fastpath_cleanup(void);
 
 // per device initialization for fastpath
 int pxd_fastpath_init(struct pxd_device *pxd_dev, loff_t offset);
 void pxd_fastpath_cleanup(struct pxd_device *pxd_dev);
 
 void pxdctx_set_connected(struct pxd_context *ctx, bool enable);
+
+// IO entry point
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
+blk_qc_t pxd_make_request(struct request_queue *q, struct bio *bio);
+#define BLK_QC_RETVAL BLK_QC_T_NONE
+#else
+void pxd_make_request(struct request_queue *q, struct bio *bio);
+#define BLK_QC_RETVAL
+#endif
 
 #endif /* _PXD_FASTPATH_H_ */

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -83,10 +83,10 @@ void pxdctx_set_connected(struct pxd_context *ctx, bool enable);
 
 // IO entry point
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
-blk_qc_t pxd_make_request(struct request_queue *q, struct bio *bio);
+blk_qc_t pxd_make_request_fastpath(struct request_queue *q, struct bio *bio);
 #define BLK_QC_RETVAL BLK_QC_T_NONE
 #else
-void pxd_make_request(struct request_queue *q, struct bio *bio);
+void pxd_make_request_fastpath(struct request_queue *q, struct bio *bio);
 #define BLK_QC_RETVAL
 #endif
 

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -81,7 +81,7 @@ void pxd_fastpath_cleanup(struct pxd_device *pxd_dev);
 // shall get called last when new device is added/updated or when fuse connection is lost
 // and re-estabilished.
 void enableFastPath(struct pxd_device *pxd_dev, bool force);
-void disableFastPath(struct pxd_device *pxd_dev, bool force);
+void disableFastPath(struct pxd_device *pxd_dev);
 
 
 void pxdctx_set_connected(struct pxd_context *ctx, bool enable);

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -91,4 +91,6 @@ void pxd_make_request_fastpath(struct request_queue *q, struct bio *bio);
 #define BLK_QC_RETVAL
 #endif
 
+void enableFastPath(struct pxd_device *pxd_dev, bool force);
+
 #endif /* _PXD_FASTPATH_H_ */

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -78,12 +78,6 @@ struct file* getFile(struct pxd_device *pxd_dev, int index);
 int pxd_fastpath_init(struct pxd_device *pxd_dev, loff_t offset);
 void pxd_fastpath_cleanup(struct pxd_device *pxd_dev);
 
-// shall get called last when new device is added/updated or when fuse connection is lost
-// and re-estabilished.
-// static void enableFastPath(struct pxd_device *pxd_dev, bool force);
-void disableFastPath(struct pxd_device *pxd_dev);
-
-
 void pxdctx_set_connected(struct pxd_context *ctx, bool enable);
 
 #endif /* _PXD_FASTPATH_H_ */


### PR DESCRIPTION
This changeset part of the kernel px driver, that enables fast path operation to kick in, once a backing file/device is configured through the extended interface.