### PR TITLE
PWX-8766: Use __PX_BLKMQ__ define in pxd_update_stats.

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -194,12 +194,19 @@ static const struct block_device_operations pxd_bd_ops = {
 
 static void pxd_update_stats(struct fuse_req *req, int rw, unsigned int count)
 {
-	struct pxd_device *pxd_dev = req->queue->queuedata;
+        struct pxd_device *pxd_dev = req->queue->queuedata;
 
-	int cpu = part_stat_lock();
-	part_stat_inc(cpu, &pxd_dev->disk->part0, ios[rw]);
-	part_stat_add(cpu, &pxd_dev->disk->part0, sectors[rw], count);
-	part_stat_unlock();
+#ifdef __PX_BLKMQ__
+        part_stat_lock();
+        part_stat_inc(&pxd_dev->disk->part0, ios[rw]);
+        part_stat_add(&pxd_dev->disk->part0, sectors[rw], count);
+#else
+        int cpu = part_stat_lock();
+        part_stat_inc(cpu, &pxd_dev->disk->part0, ios[rw]);
+        part_stat_add(cpu, &pxd_dev->disk->part0, sectors[rw], count);
+#endif
+
+        part_stat_unlock();
 }
 
 /*


### PR DESCRIPTION
pxd_update_stats uses, 'part_stat_inc' & 'part_stat_add'.  Those functions changes in EL8.    Need to use this define to get around them for now. 