### PR TITLE
Use kernel path version for determining defines.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -50,12 +50,10 @@ export OUTPATH
 
 # EL8 Specific kernel checks
 ifeq ($(shell echo "$(CHK_KVER)" | grep -Eq '.*\.el8.*\.x86_64'; echo $$?),0)
-FOUND = "RHEL8"
 PXDEFINES += -D__PX_BLKMQ__
 else
 # 5.x kernel checks
 ifeq ($(shell test "$(MAJOR)" = "5"; echo $$?),0)
-FOUND = "5.x"
 PXDEFINES += -D__PX_BLKMQ__
 endif
 endif

--- a/Makefile.in
+++ b/Makefile.in
@@ -24,13 +24,6 @@ ifeq ($(CHK_KVER),)
 CHK_KVER=$(KVERSION)
 endif
 
-# EL8 Specific kernel checks
-ifeq ($(shell test "$(CHK_KVER)" = "4.18.0-80.el8.x86_64"  -o  "$(CHK_KVER)" = "4.18.0-80.1.2.el8.x86_64" -o "$(CHK_KVER)" = "4.18.0.el8.x86_64"; echo $$?),0)
-PXDEFINES += -D__PX_BLKMQ__
-endif
-
-ccflags-y := $(ADDCCFLAGS) -Wframe-larger-than=2048 -Werror -I$(src) $(KBUILD_CPPFLAGS) $(PXDEFINES)
-
 ifeq ($(shell test -d $(KERNELPATH); echo $$?),1)
 $(error Kernel path: $(KERNELPATH)  directory does not exist.)
 endif
@@ -54,6 +47,20 @@ export REVISION=$(shell echo $(KVERSION) | awk -F. '{print $$3}' |  awk -F- '{pr
 export VERSION=$(MAJOR).$(MINOR).$(PATCH)
 export KERNELPATH
 export OUTPATH
+
+# EL8 Specific kernel checks
+ifeq ($(shell echo "$(CHK_KVER)" | grep -Eq '.*\.el8.*\.x86_64'; echo $$?),0)
+FOUND = "RHEL8"
+PXDEFINES += -D__PX_BLKMQ__
+else
+# 5.x kernel checks
+ifeq ($(shell test "$(MAJOR)" = "5"; echo $$?),0)
+FOUND = "5.x"
+PXDEFINES += -D__PX_BLKMQ__
+endif
+endif
+
+ccflags-y := $(ADDCCFLAGS) -Wframe-larger-than=2048 -Werror -I$(src) $(KBUILD_CPPFLAGS) $(PXDEFINES)
 
 .PHONY: rpm
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -6,13 +6,6 @@ PXDEFINES := -D__PXKERNEL__
 
 KVERSION=$(shell uname -r)
 
-# EL8 Specific kernel checks
-ifeq ($(shell test "$(KVERSION)" = "4.18.0-80.el8.x86_64"  -o  "$(KVERSION)" = "4.18.0-80.1.2.el8.x86_64" -o "$(KVERSION)" = "4.18.0.el8.x86_64"; echo $$?),0)
-PXDEFINES += -D__PX_BLKMQ__
-endif
-
-ccflags-y := $(ADDCCFLAGS) -Wframe-larger-than=2048 -Werror -I$(src) $(KBUILD_CPPFLAGS) $(PXDEFINES)
-
 ifndef KERNELPATH
 ifeq ($(shell test -d "/usr/src/linux-headers-$(KVERSION)"; echo $$?),0)
      KERNELPATH=/usr/src/linux-headers-$(KVERSION)
@@ -21,11 +14,28 @@ else
 endif
 endif
 
+# Check for version in KERNELPATH version release file
+ifeq ($(shell test -f "$(KERNELPATH)/include/generated/utsrelease.h"; echo $$?),0)
+CHK_KVER=$(shell sed -n 's/.* *UTS_RELEASE *"\(.*\)".*/\1/p' $(KERNELPATH)/include/generated/utsrelease.h)
+endif
+
+# If no KERNELPATH version found or extract fails use $(KVERSION)
+ifeq ($(CHK_KVER),)
+CHK_KVER=$(KVERSION)
+endif
+
+# EL8 Specific kernel checks
+ifeq ($(shell test "$(CHK_KVER)" = "4.18.0-80.el8.x86_64"  -o  "$(CHK_KVER)" = "4.18.0-80.1.2.el8.x86_64" -o "$(CHK_KVER)" = "4.18.0.el8.x86_64"; echo $$?),0)
+PXDEFINES += -D__PX_BLKMQ__
+endif
+
+ccflags-y := $(ADDCCFLAGS) -Wframe-larger-than=2048 -Werror -I$(src) $(KBUILD_CPPFLAGS) $(PXDEFINES)
+
 ifeq ($(shell test -d $(KERNELPATH); echo $$?),1)
 $(error Kernel path: $(KERNELPATH)  directory does not exist.)
 endif
 
-ifeq ($(shell test  -f "/usr/bin/bc"; echo $$?),0)
+ifeq ($(shell test -f "/usr/bin/bc"; echo $$?),0)
 MINKVER=3.10
 KERNELVER=$(shell echo $(KVERSION) | /bin/sed 's/-.*//' | /bin/sed 's/\(.*\..*\)\..*/\1/')
 ifeq ($(shell echo "$(KERNELVER)>=$(MINKVER)" | /usr/bin/bc),0)


### PR DESCRIPTION
Signed-off-by: Jose Rivera <jose@portworx.com>

This is needed because we build according to the version specified by the KERNELPATH env var rather than the actual kernel that is running $(uname -r).  So we should use the kernel path version if it exists to determine defines used to build.  If it does not exist or cannot be found then use $(uname -r).

Also enable BLKMQ changes for 5.x kernel builds.