### PR TITLE
fix for small sync io perf issue

### DIFF
--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -49,11 +49,6 @@ sector_t getsectors(struct bio *breq) {
 	return compute_bio_rq_size(breq) >> 9;
 }
 
-static inline
-sector_t getsectors(struct bio *breq) {
-	return compute_bio_rq_size(breq) >> 9;
-}
-
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)
 #define BIO_OP(bio)   bio_op(bio)
 #define SUBMIT_BIO(bio) submit_bio(bio)

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -35,10 +35,11 @@ struct pxd_device {
 	struct pxd_fastpath_extension fp;
 	struct pxd_context *ctx;
 	bool connected;
+	bool sync;
 };
 
 #define pxd_printk(args...)
-//#define pxd_printk(args...) printk(KERN_ERR args)
+//#define pxd_printk(args, ...) printk(KERN_ERR args, ##__VA_ARGS__)
 
 #ifndef SECTOR_SIZE
 #define SECTOR_SIZE 512

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -59,6 +59,12 @@ struct pxd_fastpath_extension {
 	spinlock_t   	sync_lock;
 	atomic_t nsync_active; // [global] currently active?
 	atomic_t nsync; // [global] number of forced syncs completed
+	atomic_t nio_discard;
+	atomic_t nio_preflush;
+	atomic_t nio_flush;
+	atomic_t nio_flush_nop;
+	atomic_t nio_fua;
+	atomic_t nio_write;
 	atomic_t ncount; // [global] total active requests
 	atomic_t nswitch; // [global] total number of requests through bio switch path
 	atomic_t nslowPath; // [global] total requests through slow path


### PR DESCRIPTION
This PR addresses perf issue for small sequential IO in sync mode.

The test profile is defined as 128MB sequential write with fdatasync set.
This test profile, opens the target file in O_RDWR|O_SYNC|O_DIRECT|O_NOATIME
This open mode implies that fdatasync is actually a nop.
Also, the queue depth is just 1. This implies that progress gets made one 
request at a time.

The behavior though is as below.
  write: io=8227.5MB, bw=140413KB/s, iops=35103, runt= 60001msec


With px virtual device, there is 2 hop in the IO path, one from user app (fio) to the
virtual px device (/dev/pxd) and then within the px driver to the actual target file 
(/var/.px/0/uuid/pxdev). So atleast 50% of direct ext4 file io iops/throughput is minimal
expectation.

Inside, in the px driver, we open the target file in O_RDWR|O_DIRECT|O_LARGEFILE.
So could file mode have any impact?

Secondly, writes schedule further processing on threads in the same cpu.
Could this be a bottleneck? Yes. If the kernel threads are unbound, then they 
are free to be scheduled on any idle cpu, which pushes throughput higher.
This one change is significant to cause throughput to reach 60% of direct ext4.

direct ext4 - 34K iops
  write: io=8073.4MB, bw=137783KB/s, iops=34445, runt= 60001msec

fast path - 
  write: io=1488.4MB, bw=25401KB/s, iops=6350, runt= 60001msec
  write: io=1602.2MB, bw=27343KB/s, iops=6835, runt= 60001msec

slow path - 
  write: io=393528KB, bw=6558.8KB/s, iops=1639, runt= 60001msec

fast path, with thread unbound
  write: io=4975.4MB, bw=84912KB/s, iops=21227, runt= 60001msec

fastpath: sync + noatime + thread unbound - 21k
  write: io=4965.3MB, bw=84739KB/s, iops=21184, runt= 60001msec
  write: io=5042.8MB, bw=86061KB/s, iops=21515, runt= 60001msec


Below are the changes specific to this test case:
1/ update file open mode of target file.

2/ if target file is opened in O_SYNC with px driver, then any sync call 
on that file shall become nop. this can become another arg part of the pxd_add_device ioctl.

3/ there is one kthread bound on cpu, to service writes on the same cpu on which it is received.
This introduces scheduling delay on the cpu. If the kthreads are left unbounded, then 
it increases chances of thread being scheduled on other idle cpu, and improves throughput.
The correct fix on this should be to create a pool of idle threads per cpu and rotate among
them, instead of just one dedicated thread. 

4/ while we were on it, i added few more counters to dump io statistics in more detail.