### PR TITLE
fastpath kernel driver changes (1/8)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -14,6 +14,16 @@ else
 endif
 endif
 
+# Check for version in KERNELPATH version release file
+ifeq ($(shell test -f "$(KERNELPATH)/include/generated/utsrelease.h"; echo $$?),0)
+CHK_KVER=$(shell sed -n 's/.* *UTS_RELEASE *"\(.*\)".*/\1/p' $(KERNELPATH)/include/generated/utsrelease.h)
+endif
+
+# If no KERNELPATH version found or extract fails use $(KVERSION)
+ifeq ($(CHK_KVER),)
+CHK_KVER=$(KVERSION)
+endif
+
 ifeq ($(shell test -d $(KERNELPATH); echo $$?),1)
 $(error Kernel path: $(KERNELPATH)  directory does not exist.)
 endif
@@ -53,7 +63,6 @@ endif
 endif
 endif
 
-
 ## blkmq checks
 ifeq ($(call verlater,${kmajor},${blkmq_major}),0)
 PXDEFINES += -D__PX_BLKMQ__
@@ -68,8 +77,8 @@ endif
 endif
 
 # EL8 Specific kernel checks
-ifeq ($(shell test "$(KVERSION)" = "4.18.0-80.el8.x86_64"  -o  "$(KVERSION)" = "4.18.0-80.1.2.el8.x86_64" -o "$(KVERSION)" = "4.18.0.el8.x86_64"; echo $$?),0)
-PXDEFINES += -D__PX_BLKMQ__
+ifeq ($(shell echo "$(CHK_KVER)" | grep -Eq '.*\.el8.*\.x86_64'; echo $$?),0)
+PXDEFINES += -D__PX_BLKMQ__ -D__EL8__
 endif
 
 ## fastpath specific checks
@@ -98,15 +107,15 @@ ifdef KERNELOTHER
 KERNELOTHEROPT=O=$(KERNELOTHER)
 endif
 
-ccflags-y := $(ADDCCFLAGS) -Wframe-larger-than=2048 -Werror -I$(src) $(KBUILD_CPPFLAGS) $(PXDEFINES)
+MAJOR=$(shell echo $(CHK_KVER) | awk -F. '{print $$1}')
+MINOR=$(shell echo $(CHK_KVER) | awk -F. '{print $$2}')
+PATCH=$(shell echo $(CHK_KVER) | awk -F. '{print $$3}' | awk -F- '{print $$1}')
+export REVISION=$(shell echo $(CHK_KVER) | awk -F. '{print $$3}' |  awk -F- '{print $$2}')
 
-MAJOR=$(shell echo $(KVERSION) | awk -F. '{print $$1}')
-MINOR=$(shell echo $(KVERSION) | awk -F. '{print $$2}')
-PATCH=$(shell echo $(KVERSION) | awk -F. '{print $$3}' | awk -F- '{print $$1}')
-export REVISION=$(shell echo $(KVERSION) | awk -F. '{print $$3}' |  awk -F- '{print $$2}')
 export VERSION=$(MAJOR).$(MINOR).$(PATCH)
 export KERNELPATH
 export OUTPATH
+ccflags-y := $(ADDCCFLAGS) -Wframe-larger-than=2048 -Werror -I$(src) $(KBUILD_CPPFLAGS) $(PXDEFINES)
 
 .PHONY: rpm
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -20,24 +20,79 @@ endif
 
 MINKVER=3.10
 FPATH_MINKVER=4.0
+BLKMQ_MINKVER=4.18
 KERNELVER=$(shell echo $(KVERSION) | /bin/sed 's/\([0-9].[0-9]\+\).*/\1/g')
-ifeq ($(shell expr $(KERNELVER) \>= $(MINKVER)),0)
+
+majorfn=$(shell echo "$1" | /bin/sed 's/\(.*\)\.\(.*\)/\1/g')
+minorfn=$(shell echo "$1" | /bin/sed 's/\(.*\)\.\(.*\)/\2/g')
+
+verlater=$(shell test "$1" -gt "$2"; echo $$?)
+versameorlater=$(shell test "$1" -ge "$2"; echo $$?)
+versame=$(shell test "$1" -eq "$2"; echo $$?)
+
+minver_major=$(call majorfn, ${MINKVER})
+minver_minor=$(call minorfn, ${MINKVER})
+
+blkmq_major=$(call majorfn, ${BLKMQ_MINKVER})
+blkmq_minor=$(call minorfn, ${BLKMQ_MINKVER})
+
+fp_major=$(call majorfn, ${FPATH_MINKVER})
+fp_minor=$(call minorfn, ${FPATH_MINKVER})
+
+kmajor=$(call majorfn, ${KERNELVER})
+kminor=$(call minorfn, ${KERNELVER})
+
+## min kernel version checks
+ifeq ($(call verlater,${minver_major},${kmajor}),0)
+$(error Kernel version error: Build kernel version must be >= $(MINKVER).)
+else
+ifeq ($(call versame,${minver_major},${kmajor}),0)
+ifeq ($(call verlater,${minver_minor},${kminor}),0)
 $(error Kernel version error: Build kernel version must be >= $(MINKVER).)
 endif
+endif
+endif
 
-ifeq ($(shell expr $(KERNELVER) \>= $(FPATH_MINKVER)),1)
-PXDEFINES:=$(PXDEFINES) -D__PX_FASTPATH__
-$(warning kernel fast path enabled, version $(KVERSION).)
+
+## blkmq checks
+ifeq ($(call verlater,${kmajor},${blkmq_major}),0)
+PXDEFINES += -D__PX_BLKMQ__
+$(warning Kernel version ${KERNELVER} supports blkmq driver model.")
 else
-PXDEFINES += -DUSE_REQUESTQ_MODEL
-$(warning kernel fast path disabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
+ifeq ($(call versame,${kmajor},${blkmq_major}),0)
+ifeq ($(call versameorlater,${kminor},${blkmq_minor}),0)
+PXDEFINES += -D__PX_BLKMQ__
+$(warning Kernel version ${KERNELVER} supports blkmq driver model.")
+endif
+endif
+endif
+
 # EL8 Specific kernel checks
 ifeq ($(shell test "$(KVERSION)" = "4.18.0-80.el8.x86_64"  -o  "$(KVERSION)" = "4.18.0-80.1.2.el8.x86_64" -o "$(KVERSION)" = "4.18.0.el8.x86_64"; echo $$?),0)
 PXDEFINES += -D__PX_BLKMQ__
-$(warning enabling slow path with BLKMQ support)
 endif
 
+## fastpath specific checks
+ifeq ($(call verlater,${kmajor},${fp_major}),0)
+PXDEFINES += -D__PX_FASTPATH__
+px-objs += pxd_fastpath.o
+$(warning kernel fast path enabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
+else
+ifeq ($(call versame,${kmajor},${fp_major}),0)
+ifeq ($(call versameorlater,${kminor},${fp_minor}),0)
+PXDEFINES += -D__PX_FASTPATH__
+px-objs += pxd_fastpath.o
+$(warning kernel fast path enabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
+else
+px-objs += pxd_fastpath_stub.o
+$(warning kernel fast path disabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
 endif
+else
+px-objs += pxd_fastpath_stub.o
+$(warning kernel fast path disabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
+endif
+endif
+
 
 ifdef KERNELOTHER
 KERNELOTHEROPT=O=$(KERNELOTHER)

--- a/Makefile.in
+++ b/Makefile.in
@@ -6,13 +6,6 @@ PXDEFINES := -D__PXKERNEL__
 
 KVERSION=$(shell uname -r)
 
-# EL8 Specific kernel checks
-ifeq ($(shell test "$(KVERSION)" = "4.18.0-80.el8.x86_64"  -o  "$(KVERSION)" = "4.18.0-80.1.2.el8.x86_64" -o "$(KVERSION)" = "4.18.0.el8.x86_64"; echo $$?),0)
-PXDEFINES += -D__PX_BLKMQ__
-endif
-
-ccflags-y := $(ADDCCFLAGS) -Wframe-larger-than=2048 -Werror -I$(src) $(KBUILD_CPPFLAGS) $(PXDEFINES)
-
 ifndef KERNELPATH
 ifeq ($(shell test -d "/usr/src/linux-headers-$(KVERSION)"; echo $$?),0)
      KERNELPATH=/usr/src/linux-headers-$(KVERSION)
@@ -25,17 +18,32 @@ ifeq ($(shell test -d $(KERNELPATH); echo $$?),1)
 $(error Kernel path: $(KERNELPATH)  directory does not exist.)
 endif
 
-ifeq ($(shell test  -f "/usr/bin/bc"; echo $$?),0)
 MINKVER=3.10
-KERNELVER=$(shell echo $(KVERSION) | /bin/sed 's/-.*//' | /bin/sed 's/\(.*\..*\)\..*/\1/')
-ifeq ($(shell echo "$(KERNELVER)>=$(MINKVER)" | /usr/bin/bc),0)
+FPATH_MINKVER=4.0
+KERNELVER=$(shell echo $(KVERSION) | /bin/sed 's/\([0-9].[0-9]\+\).*/\1/g')
+ifeq ($(shell expr $(KERNELVER) \>= $(MINKVER)),0)
 $(error Kernel version error: Build kernel version must be >= $(MINKVER).)
 endif
+
+ifeq ($(shell expr $(KERNELVER) \>= $(FPATH_MINKVER)),1)
+PXDEFINES:=$(PXDEFINES) -D__PX_FASTPATH__
+$(warning kernel fast path enabled, version $(KVERSION).)
+else
+PXDEFINES += -DUSE_REQUESTQ_MODEL
+$(warning kernel fast path disabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
+# EL8 Specific kernel checks
+ifeq ($(shell test "$(KVERSION)" = "4.18.0-80.el8.x86_64"  -o  "$(KVERSION)" = "4.18.0-80.1.2.el8.x86_64" -o "$(KVERSION)" = "4.18.0.el8.x86_64"; echo $$?),0)
+PXDEFINES += -D__PX_BLKMQ__
+$(warning enabling slow path with BLKMQ support)
+endif
+
 endif
 
 ifdef KERNELOTHER
 KERNELOTHEROPT=O=$(KERNELOTHER)
 endif
+
+ccflags-y := $(ADDCCFLAGS) -Wframe-larger-than=2048 -Werror -I$(src) $(KBUILD_CPPFLAGS) $(PXDEFINES)
 
 MAJOR=$(shell echo $(KVERSION) | awk -F. '{print $$1}')
 MINOR=$(shell echo $(KVERSION) | awk -F. '{print $$2}')
@@ -72,7 +80,7 @@ docker-build: docker-build-dev
 	portworx/px-fuse:dev make
 
 px_version.c:
-	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@
+	echo "const char *gitversion = \"$(shell git name-rev --name-only HEAD):$(shell git rev-parse HEAD)\";" > $@
 
 distclean: clean
 	@/bin/rm -f  config.* Makefile

--- a/dev.c
+++ b/dev.c
@@ -838,7 +838,7 @@ static ssize_t fuse_dev_do_write(struct fuse_conn *fc, struct iov_iter *iter)
 #ifdef USE_REQUESTQ_MODEL
 			rq_for_each_segment(bvec, breq, breq_iter) {
 #else
-			rq_for_each_segment(bvec, breq, bvec_iter) {
+			bio_for_each_segment(bvec, breq, bvec_iter) {
 #endif
 				len = BVEC(bvec).bv_len;
 				if (copy_page_from_iter(BVEC(bvec).bv_page,

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -213,6 +213,7 @@ int fuse_conn_init(struct fuse_conn *fc);
 /**
  * Release reference to fuse_conn
  */
+struct fuse_conn *fuse_conn_get(struct fuse_conn *fc);
 void fuse_conn_put(struct fuse_conn *fc);
 
 void fuse_restart_requests(struct fuse_conn *fc);

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -22,6 +22,18 @@
 #include <linux/poll.h>
 #include <linux/workqueue.h>
 #include <linux/hash.h>
+#include <linux/version.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,18,0)
+#include "iov_iter.h"
+
+#define iov_iter_advance __iov_iter_advance
+#define iov_iter __iov_iter
+#define iov_iter_init __iov_iter_init
+#define copy_page_to_iter __copy_page_to_iter
+#define copy_page_from_iter __copy_page_from_iter
+
+#endif
 
 #include "fuse.h"
 #include "pxd.h"
@@ -170,9 +182,6 @@ struct fuse_in {
 	/** The request header */
 	struct fuse_in_header h;
 
-	/** True if the data for the last argument is in req->pages */
-	unsigned argpages:1;
-
 	/** Number of arguments */
 	unsigned numargs;
 
@@ -190,30 +199,6 @@ struct fuse_arg {
 struct fuse_out {
 	/** Header returned from userspace */
 	struct fuse_out_header h;
-
-	/*
-	 * The following bitfields are not changed during the request
-	 * processing
-	 */
-
-	/** Last argument is variable length (can be shorter than
-	    arg->size) */
-	unsigned argvar:1;
-
-	/** Last argument is a list of pages to copy data to */
-	unsigned argpages:1;
-
-	/** Zero partially or not copied pages */
-	unsigned page_zeroing:1;
-
-	/** Pages may be replaced with new ones */
-	unsigned page_replace:1;
-
-	/** Number or arguments */
-	unsigned numargs;
-
-	/** Array of arguments */
-	struct fuse_arg args[3];
 };
 
 /** FUSE page descriptor */
@@ -254,23 +239,8 @@ struct fuse_req {
 	    fuse_conn */
 	struct list_head list;
 
-	/** hash table entry */
-	struct hlist_node hash_entry;
-
-	/*
-	 * The following bitfields are either set once before the
-	 * request is queued or setting/clearing them is protected by
-	 * fuse_conn->lock
-	 */
-
-	/** Request is sent in the background */
-	unsigned background:1;
-
-	/** Request page descriptor is struct request *rq */
-	unsigned bio_pages:1;
-
-	/** State of the request */
-	enum fuse_req_state state;
+	/** Request to use fastpath */
+	unsigned fastpath:1;
 
 	/** The request input */
 	struct fuse_in in;
@@ -278,56 +248,9 @@ struct fuse_req {
 	/** The request output */
 	struct fuse_out out;
 
-	/** Data for asynchronous requests */
-	union {
-		struct {
-			union {
-				struct fuse_release_in in;
-				struct work_struct work;
-			};
-			struct path path;
-		} release;
-		struct fuse_init_in init_in;
-		struct fuse_init_out init_out;
-		struct cuse_init_in cuse_init_in;
-		struct {
-			struct fuse_read_in in;
-			u64 attr_ver;
-		} read;
-		struct {
-			struct fuse_write_in in;
-			struct fuse_write_out out;
-			struct fuse_req *next;
-		} write;
-		struct fuse_notify_retrieve_in retrieve_in;
-		struct fuse_lk_in lk_in;
-		struct pxd_init_in pxd_init_in;
-		struct pxd_init_out pxd_init_out;
-		struct pxd_rdwr_in pxd_rdwr_in;
-	} misc;
-
-	/** page vector */
-	struct page **pages;
-
-	/** page-descriptor vector */
-	struct fuse_page_desc *page_descs;
-
-	/** size of the 'pages' array */
-	unsigned max_pages;
-
-	/** inline page vector */
-	struct page *inline_pages[FUSE_REQ_INLINE_PAGES];
-
-	/** inline page-descriptor vector */
-	struct fuse_page_desc inline_page_descs[FUSE_REQ_INLINE_PAGES];
-
-	/** number of pages in vector */
-	unsigned num_pages;
+	struct pxd_rdwr_in pxd_rdwr_in;
 
 	union {
-		/** AIO control block */
-		struct fuse_io_priv *io;
-
 		/** Associated request structrure. */
 		struct request *rq;
 
@@ -342,6 +265,16 @@ struct fuse_req {
 	struct request_queue *queue;
 };
 
+#define FUSE_MAX_PER_CPU_IDS 256
+
+struct ____cacheline_aligned fuse_per_cpu_ids {
+	/** number of free ids in stack */
+	u32 num_free_ids;
+
+	/** followed by list of free ids */
+	u64 free_ids[FUSE_MAX_PER_CPU_IDS];
+};
+
 /**
  * A Fuse connection.
  *
@@ -353,26 +286,6 @@ struct fuse_conn {
 	/** Lock protecting accessess to  members of this structure */
 	spinlock_t lock;
 
-	/** Refcount */
-	atomic_t count;
-
-	struct rcu_head rcu;
-
-	/** The user id for this mount */
-	kuid_t user_id;
-
-	/** The group id for this mount */
-	kgid_t group_id;
-
-	/** The fuse mount flags for this mount */
-	unsigned flags;
-
-	/** Maximum read size */
-	unsigned max_read;
-
-	/** Maximum write size */
-	unsigned max_write;
-
 	/** Readers of the connection are waiting on this */
 	wait_queue_head_t waitq;
 
@@ -382,182 +295,41 @@ struct fuse_conn {
 	/** The list of requests being processed */
 	struct list_head processing;
 
-	/** The list of requests under I/O */
-	struct list_head io;
+	/** maps request ids to requests */
+	struct fuse_req **request_map;
 
-	/** The next unique kernel file handle */
-	u64 khctr;
+	/** stack of free ids */
+	u64 *free_ids;
 
-	/** rbtree of fuse_files waiting for poll events indexed by ph */
-	struct rb_root polled_files;
+	/** number of free ids in stack */
+	u32 num_free_ids;
 
-	/** Maximum number of outstanding background requests */
-	unsigned max_background;
-
-	/** Number of background requests at which congestion starts */
-	unsigned congestion_threshold;
-
-	/** Number of requests currently in the background */
-	unsigned num_background;
-
-	/** Number of background requests currently queued for userspace */
-	unsigned active_background;
-
-	/** hash table of pending requests */
-	struct hlist_head *hash;
-
-	/** Flag indicating that INIT reply has been received. Allocating
-	 * any fuse request will be suspended until the flag is set */
-	int initialized;
+	/** per cpu id allocators */
+	struct fuse_per_cpu_ids __percpu *per_cpu_ids;
 
 	/** The next unique request id */
 	u64 reqctr;
 
 	/** Connection established, cleared on umount, connection
 	    abort and device release */
-	unsigned connected;
+	bool connected;
 
-	/** open in progress, cleared on completion */
-	unsigned pend_open:1;
+	/* Alow operations on disconnected fuse conenction. */
+	bool allow_disconnected;
 
-	/** Connection failed (version mismatch).  Cannot race with
-	    setting other bitfields since it is only set once in INIT
-	    reply, before any other request, and never cleared */
-	unsigned conn_error:1;
-
-	/** Connection successful.  Only set in INIT */
-	unsigned conn_init:1;
-
-	/** Do readpages asynchronously?  Only set in INIT */
-	unsigned async_read:1;
-
-	/** Do not send separate SETATTR request before open(O_TRUNC)  */
-	unsigned atomic_o_trunc:1;
-
-	/** Filesystem supports NFS exporting.  Only set in INIT */
-	unsigned export_support:1;
-
-	/** Set if bdi is valid */
-	unsigned bdi_initialized:1;
-
-	/** write-back cache policy (default is write-through) */
-	unsigned writeback_cache:1;
-
-	/*
-	 * The following bitfields are only for optimization purposes
-	 * and hence races in setting them will not cause malfunction
-	 */
-
-	/** Is open/release not implemented by fs? */
-	unsigned no_open:1;
-
-	/** Is fsync not implemented by fs? */
-	unsigned no_fsync:1;
-
-	/** Is fsyncdir not implemented by fs? */
-	unsigned no_fsyncdir:1;
-
-	/** Is flush not implemented by fs? */
-	unsigned no_flush:1;
-
-	/** Is setxattr not implemented by fs? */
-	unsigned no_setxattr:1;
-
-	/** Is getxattr not implemented by fs? */
-	unsigned no_getxattr:1;
-
-	/** Is listxattr not implemented by fs? */
-	unsigned no_listxattr:1;
-
-	/** Is removexattr not implemented by fs? */
-	unsigned no_removexattr:1;
-
-	/** Are posix file locking primitives not implemented by fs? */
-	unsigned no_lock:1;
-
-	/** Is access not implemented by fs? */
-	unsigned no_access:1;
-
-	/** Is create not implemented by fs? */
-	unsigned no_create:1;
-
-	/** Is interrupt not implemented by fs? */
-	unsigned no_interrupt:1;
-
-	/** Is bmap not implemented by fs? */
-	unsigned no_bmap:1;
-
-	/** Is poll not implemented by fs? */
-	unsigned no_poll:1;
-
-	/** Do multi-page cached writes */
-	unsigned big_writes:1;
-
-	/** Don't apply umask to creation modes */
-	unsigned dont_mask:1;
-
-	/** Are BSD file locking primitives not implemented by fs? */
-	unsigned no_flock:1;
-
-	/** Is fallocate not implemented by fs? */
-	unsigned no_fallocate:1;
-
-	/** Is rename with flags implemented by fs? */
-	unsigned no_rename2:1;
-
-	/** Use enhanced/automatic page cache invalidation. */
-	unsigned auto_inval_data:1;
-
-	/** Does the filesystem support readdirplus? */
-	unsigned do_readdirplus:1;
-
-	/** Does the filesystem want adaptive readdirplus? */
-	unsigned readdirplus_auto:1;
-
-	/** Does the filesystem support asynchronous direct-IO submission? */
-	unsigned async_dio:1;
-
-	/** Negotiated minor version */
-	unsigned minor;
-
-	/** Backing dev info */
-	struct backing_dev_info bdi;
+	/** Refcount */
+	atomic_t count;
 
 	/** Entry on the fuse_conn_list */
 	struct list_head entry;
 
-	/** Device ID from super block */
-	dev_t dev;
-
-	/** Dentries in the control filesystem */
-	struct dentry *ctl_dentry[FUSE_CTL_NUM_DENTRIES];
-
-	/** number of dentries used in the above array */
-	int ctl_ndents;
-
 	/** O_ASYNC requests */
 	struct fasync_struct *fasync;
-
-	/** Key for lock owner ID scrambling */
-	u32 scramble_key[4];
-
-	/** Reserved request for the DESTROY message */
-	struct fuse_req *destroy_req;
-
-	/** Version counter for attribute changes */
-	u64 attr_version;
 
 	/** Called on final put */
 	void (*release)(struct fuse_conn *);
 
-	/** Super block for this connection. */
-	struct super_block *sb;
 
-	/** Read/write semaphore to hold when accessing sb. */
-	struct rw_semaphore killsb;
-
-	/* Alow operations on disconnected fuse conenction. */
-	int allow_disconnected;
 };
 
 static inline struct fuse_conn *get_fuse_conn_super(struct super_block *sb)
@@ -682,9 +454,9 @@ void __exit fuse_ctl_cleanup(void);
 /**
  * Allocate a request
  */
-struct fuse_req *fuse_request_alloc(unsigned npages);
+struct fuse_req *fuse_request_alloc(void);
 
-struct fuse_req *fuse_request_alloc_nofs(unsigned npages);
+struct fuse_req *fuse_request_alloc_nofs(void);
 
 /**
  * Free a request
@@ -693,25 +465,9 @@ void fuse_request_free(struct fuse_req *req);
 
 /**
  * Get a request, may fail with -ENOMEM,
- * caller should specify # elements in req->pages[] explicitly
  */
-struct fuse_req *fuse_get_req(struct fuse_conn *fc, unsigned npages);
-struct fuse_req *fuse_get_req_for_background(struct fuse_conn *fc,
-					     unsigned npages);
-
-/**
- * Get a request, may fail with -ENOMEM,
- * useful for callers who doesn't use req->pages[]
- */
-static inline struct fuse_req *fuse_get_req_nopages(struct fuse_conn *fc)
-{
-	return fuse_get_req(fc, 0);
-}
-
-/**
- * Send a request to head of pending queue.
- */
-void fuse_request_send_oob(struct fuse_conn *fc, struct fuse_req *req);
+struct fuse_req *fuse_get_req(struct fuse_conn *fc);
+struct fuse_req *fuse_get_req_for_background(struct fuse_conn *fc);
 
 /**
  * Send a request in the background
@@ -829,8 +585,14 @@ int fuse_write_inode(struct inode *inode, struct writeback_control *wbc);
 int fuse_do_setattr(struct inode *inode, struct iattr *attr,
 		    struct file *file);
 
-ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_out *add);
+ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add);
 ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove);
 ssize_t pxd_update_size(struct fuse_conn *fc, struct pxd_update_size_out *update_size);
+ssize_t pxd_update_path(struct fuse_conn *fc, struct pxd_update_path_out *update_path);
+int pxd_set_fastpath(struct fuse_conn *fc, struct pxd_fastpath_out*);
 
+ssize_t pxd_read_init(struct fuse_conn *fc, struct iov_iter *iter);
+
+void fuse_request_init(struct fuse_req *req);
+void fuse_req_init_context(struct fuse_req *req);
 #endif /* _FS_FUSE_I_H */

--- a/pxd.c
+++ b/pxd.c
@@ -2,9 +2,10 @@
 #include <linux/blkdev.h>
 #include <linux/sysfs.h>
 #include <linux/crc32.h>
-#include <linux/miscdevice.h>
+#include <linux/ctype.h>
 #include "fuse_i.h"
 #include "pxd.h"
+#include <linux/uio.h>
 
 #define CREATE_TRACE_POINTS
 #undef TRACE_INCLUDE_PATH
@@ -14,12 +15,10 @@
 #undef CREATE_TRACE_POINTS
 
 #include "pxd_compat.h"
+#include "pxd_core.h"
 
 #ifdef __PX_BLKMQ__
 #include <linux/blk-mq.h>
-#include <linux/workqueue.h>
-
-#define SECTOR_SHIFT    9
 
 static struct workqueue_struct *pxd_wq;
 
@@ -33,14 +32,6 @@ static struct workqueue_struct *pxd_wq;
 #define KTIME_GET_TS(t)
 #endif
 
-#define pxd_printk(args...)
-//#define pxd_printk(args...) printk(KERN_ERR args)
-
-#ifndef SECTOR_SIZE
-#define SECTOR_SIZE 512
-#endif
-#define SEGMENT_SIZE (1024 * 1024)
-
 #define PXD_TIMER_SECS_MIN 30
 #define PXD_TIMER_SECS_MAX 600
 
@@ -51,21 +42,6 @@ extern const char *gitversion;
 static dev_t pxd_major;
 static DEFINE_IDA(pxd_minor_ida);
 
-struct pxd_context {
-	spinlock_t lock;
-	struct list_head list;
-	size_t num_devices;
-	struct fuse_conn fc;
-	struct file_operations fops;
-	char name[256];
-	int id;
-	struct miscdevice miscdev;
-	struct list_head pending_requests;
-	struct timer_list timer;
-	bool init_sent;
-	uint64_t unique;
-};
-
 struct pxd_context *pxd_contexts;
 uint32_t pxd_num_contexts = PXD_NUM_CONTEXTS;
 uint32_t pxd_num_contexts_exported = PXD_NUM_CONTEXT_EXPORTED;
@@ -75,25 +51,6 @@ uint32_t pxd_detect_zero_writes = 0;
 module_param(pxd_num_contexts_exported, uint, 0644);
 module_param(pxd_num_contexts, uint, 0644);
 module_param(pxd_detect_zero_writes, uint, 0644);
-
-struct pxd_device {
-	uint64_t dev_id;
-	int major;
-	int minor;
-	struct gendisk *disk;
-	struct device dev;
-	size_t size;
-	spinlock_t lock;
-	spinlock_t qlock;
-	struct list_head node;
-	int open_count;
-	bool removing;
-	struct pxd_context *ctx;
-
-#ifdef __PX_BLKMQ__
-        struct blk_mq_tag_set tag_set;
-#endif
-};
 
 static int pxd_bus_add_dev(struct pxd_device *pxd_dev);
 
@@ -134,8 +91,18 @@ static void pxd_release(struct gendisk *disk, fmode_t mode)
 	put_device(&pxd_dev->dev);
 }
 
-static long pxd_control_ioctl(
-	struct file *file, unsigned int cmd, unsigned long arg)
+static long pxd_ioctl_init(struct file *file, void __user *argp)
+{
+	struct pxd_context *ctx = container_of(file->f_op, struct pxd_context, fops);
+	struct iov_iter iter;
+	struct iovec iov = {argp, sizeof(struct pxd_ioctl_init_args)};
+
+	iov_iter_init(&iter, WRITE, &iov, 1, sizeof(struct pxd_ioctl_init_args));
+
+	return pxd_read_init(&ctx->fc, &iter);
+}
+
+static long pxd_control_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 {
 	void __user *argp = (void __user *)arg;
 	struct pxd_context *ctx = NULL;
@@ -152,12 +119,7 @@ static long pxd_control_ioctl(
 			}
 			printk(KERN_INFO "%s: pxd_ctx: %s ndevices: %lu",
 				__func__, ctx->name, ctx->num_devices);
-			printk(KERN_INFO "\tFC: connected: %d "
-				 "max: %d threshold: %d nb: %d ab: %d",
-			       ctx->fc.connected, ctx->fc.max_background,
-			       ctx->fc.congestion_threshold,
-			       ctx->fc.num_background,
-			       ctx->fc.active_background);
+			printk(KERN_INFO "\tFC: connected: %d", ctx->fc.connected);
 		}
 		status = 0;
 		break;
@@ -180,6 +142,9 @@ static long pxd_control_ioctl(
 		printk(KERN_INFO "pxd driver at version: %s\n", gitversion);
 		status = 0;
 		break;
+	case PXD_IOC_INIT:
+		status = pxd_ioctl_init(file, argp);
+		break;
 	default:
 		break;
 	}
@@ -196,7 +161,7 @@ static void pxd_update_stats(struct fuse_req *req, int rw, unsigned int count)
 {
         struct pxd_device *pxd_dev = req->queue->queuedata;
 
-#ifdef __PX_BLKMQ__
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0) || defined(__EL8__)
         part_stat_lock();
         part_stat_inc(&pxd_dev->disk->part0, ios[rw]);
         part_stat_add(&pxd_dev->disk->part0, sectors[rw], count);
@@ -205,7 +170,6 @@ static void pxd_update_stats(struct fuse_req *req, int rw, unsigned int count)
         part_stat_inc(cpu, &pxd_dev->disk->part0, ios[rw]);
         part_stat_add(cpu, &pxd_dev->disk->part0, sectors[rw], count);
 #endif
-
         part_stat_unlock();
 }
 
@@ -215,19 +179,12 @@ static void pxd_update_stats(struct fuse_req *req, int rw, unsigned int count)
  * copy of fuse_i.h that uses the older layout.
  */
 #define	REQCTR(fc) (fc)->reqctr
-#if 0
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,2,0)
-#define	REQCTR(fc) (fc)->iq.reqctr
-#else
-#define	REQCTR(fc) (fc)->reqctr
-#endif
-#endif
 
 static void pxd_request_complete(struct fuse_conn *fc, struct fuse_req *req)
 {
 	pxd_printk("%s: receive reply to %p(%lld) at %lld err %d\n",
 			__func__, req, req->in.h.unique,
-			req->misc.pxd_rdwr_in.offset, req->out.h.error);
+			req->pxd_rdwr_in.offset, req->out.h.error);
 }
 
 static void pxd_process_read_reply(struct fuse_conn *fc, struct fuse_req *req)
@@ -273,7 +230,7 @@ static void pxd_process_write_reply_q(struct fuse_conn *fc, struct fuse_req *req
 	pxd_request_complete(fc, req);
 }
 
-static struct fuse_req *pxd_fuse_req(struct pxd_device *pxd_dev, int nr_pages)
+static struct fuse_req *pxd_fuse_req(struct pxd_device *pxd_dev)
 {
 	int eintr = 0;
 	struct fuse_req *req = NULL;
@@ -281,21 +238,23 @@ static struct fuse_req *pxd_fuse_req(struct pxd_device *pxd_dev, int nr_pages)
 	int status;
 
 	while (req == NULL) {
-		req = fuse_get_req_for_background(fc, nr_pages);
+		req = fuse_get_req_for_background(fc);
 		if (IS_ERR(req) && PTR_ERR(req) == -EINTR) {
 			req = NULL;
 			++eintr;
 		}
 	}
 	if (eintr > 0) {
-		printk_ratelimited(KERN_INFO "%s: alloc (%d pages) EINTR retries %d",
-			 __func__, nr_pages, eintr);
+		printk_ratelimited(KERN_INFO "%s: alloc EINTR retries %d",
+			 __func__, eintr);
 	}
 	status = IS_ERR(req) ? PTR_ERR(req) : 0;
 	if (status != 0) {
-		printk_ratelimited(KERN_ERR "%s: request alloc (%d pages) failed: %d",
-			 __func__, nr_pages, status);
+		printk_ratelimited(KERN_ERR "%s: request alloc failed: %d",
+			 __func__, status);
 	}
+
+	req->fastpath = pxd_dev->fastpath;
 	return req;
 }
 
@@ -304,19 +263,18 @@ static void pxd_req_misc(struct fuse_req *req, uint32_t size, uint64_t off,
 {
 	req->in.numargs = 1;
 	req->in.args[0].size = sizeof(struct pxd_rdwr_in);
-	req->in.args[0].value = &req->misc.pxd_rdwr_in;
-	req->bio_pages = true;
+	req->in.args[0].value = &req->pxd_rdwr_in;
 	req->in.h.pid = current->pid;
-	req->misc.pxd_rdwr_in.minor = minor;
-	req->misc.pxd_rdwr_in.offset = off;
-	req->misc.pxd_rdwr_in.size = size;
+	req->pxd_rdwr_in.minor = minor;
+	req->pxd_rdwr_in.offset = off;
+	req->pxd_rdwr_in.size = size;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) || defined(REQ_PREFLUSH)
-	req->misc.pxd_rdwr_in.flags =
+	req->pxd_rdwr_in.flags =
 		((flags & REQ_FUA) ? PXD_FLAGS_FLUSH : 0) |
 		((flags & REQ_PREFLUSH) ? PXD_FLAGS_FLUSH : 0) |
 		((flags & REQ_META) ? PXD_FLAGS_META : 0);
 #else
-	req->misc.pxd_rdwr_in.flags = ((flags & REQ_FLUSH) ? PXD_FLAGS_FLUSH : 0) |
+	req->pxd_rdwr_in.flags = ((flags & REQ_FLUSH) ? PXD_FLAGS_FLUSH : 0) |
 				      ((flags & REQ_FUA) ? PXD_FLAGS_FUA : 0) |
 				      ((flags & REQ_META) ? PXD_FLAGS_META : 0);
 #endif
@@ -326,10 +284,11 @@ static void pxd_read_request(struct fuse_req *req, uint32_t size, uint64_t off,
 			uint32_t minor, uint32_t flags, bool qfn)
 {
 	req->in.h.opcode = PXD_READ;
-	req->out.numargs = 1;
-	req->out.argpages = 1;
-	req->out.args[0].size = size;
-	req->end = qfn ? pxd_process_read_reply_q : pxd_process_read_reply;
+	if (req->fastpath) {
+		req->end = pxd_process_read_reply;
+	} else {
+		req->end = qfn ? pxd_process_read_reply_q : pxd_process_read_reply;
+	}
 
 	pxd_req_misc(req, size, off, minor, flags);
 }
@@ -338,7 +297,11 @@ static void pxd_write_request(struct fuse_req *req, uint32_t size, uint64_t off,
 			uint32_t minor, uint32_t flags, bool qfn)
 {
 	req->in.h.opcode = PXD_WRITE;
-	req->end = qfn ? pxd_process_write_reply_q : pxd_process_write_reply;
+	if (req->fastpath) {
+		req->end = pxd_process_write_reply;
+	} else {
+		req->end = qfn ? pxd_process_write_reply_q : pxd_process_write_reply;
+	}
 
 	pxd_req_misc(req, size, off, minor, flags);
 }
@@ -347,7 +310,11 @@ static void pxd_discard_request(struct fuse_req *req, uint32_t size, uint64_t of
 			uint32_t minor, uint32_t flags, bool qfn)
 {
 	req->in.h.opcode = PXD_DISCARD;
-	req->end = qfn ? pxd_process_write_reply_q : pxd_process_write_reply;
+	if (req->fastpath) {
+		req->end = pxd_process_write_reply;
+	} else {
+		req->end = qfn ? pxd_process_write_reply_q : pxd_process_write_reply;
+	}
 
 	pxd_req_misc(req, size, off, minor, flags);
 }
@@ -356,7 +323,11 @@ static void pxd_write_same_request(struct fuse_req *req, uint32_t size, uint64_t
 			uint32_t minor, uint32_t flags, bool qfn)
 {
 	req->in.h.opcode = PXD_WRITE_SAME;
-	req->end = qfn ? pxd_process_write_reply_q : pxd_process_write_reply;
+	if (req->fastpath) {
+		req->end = pxd_process_write_reply;
+	} else {
+		req->end = qfn ? pxd_process_write_reply_q : pxd_process_write_reply;
+	}
 
 	pxd_req_misc(req, size, off, minor, flags);
 }
@@ -442,13 +413,12 @@ static inline unsigned int get_op_flags(struct bio *bio)
 	return op_flags;
 }
 
-#ifndef USE_REQUESTQ_MODEL
-
+// fastpath uses this path to punt requests to slowpath
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
-static blk_qc_t pxd_make_request(struct request_queue *q, struct bio *bio)
+blk_qc_t pxd_make_request_slowpath(struct request_queue *q, struct bio *bio)
 #define BLK_QC_RETVAL BLK_QC_T_NONE
 #else
-static void pxd_make_request(struct request_queue *q, struct bio *bio)
+void pxd_make_request_slowpath(struct request_queue *q, struct bio *bio)
 #define BLK_QC_RETVAL
 #endif
 {
@@ -465,7 +435,7 @@ static void pxd_make_request(struct request_queue *q, struct bio *bio)
 			BIO_SECTOR(bio) * SECTOR_SIZE, BIO_SIZE(bio),
 			bio->bi_vcnt, flags, get_op_flags(bio));
 
-	req = pxd_fuse_req(pxd_dev, bio->bi_vcnt);
+	req = pxd_fuse_req(pxd_dev);
 	if (IS_ERR(req)) {
 		bio_io_error(bio);
 		return BLK_QC_RETVAL;
@@ -490,9 +460,8 @@ static void pxd_make_request(struct request_queue *q, struct bio *bio)
 	fuse_request_send_nowait(&pxd_dev->ctx->fc, req);
 	return BLK_QC_RETVAL;
 }
-#else
 
-#ifndef __PX_BLKMQ__
+#if !defined(__PX_BLKMQ__)
 static void pxd_rq_fn(struct request_queue *q)
 {
 	struct pxd_device *pxd_dev = q->queuedata;
@@ -519,7 +488,7 @@ static void pxd_rq_fn(struct request_queue *q)
 			blk_rq_pos(rq) * SECTOR_SIZE, blk_rq_bytes(rq),
 			rq->nr_phys_segments, rq->cmd_flags);
 
-		req = pxd_fuse_req(pxd_dev, 0);
+		req = pxd_fuse_req(pxd_dev);
 		if (IS_ERR(req)) {
 			spin_lock_irq(&pxd_dev->qlock);
 			__blk_end_request(rq, -EIO, blk_rq_bytes(rq));
@@ -548,31 +517,32 @@ static void pxd_rq_fn(struct request_queue *q)
 	}
 }
 #else
-static void pxd_queue_workfn(struct work_struct *work)
-{
-	struct request *rq = blk_mq_rq_from_pdu(work);
-	struct pxd_device *pxd_dev = rq->q->queuedata;
-	struct fuse_req *req = NULL;
-	blk_status_t error = BLK_STS_OK;
 
-	if (BLK_RQ_IS_PASSTHROUGH(rq)) {
-		goto err;
-	}
+static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
+		const struct blk_mq_queue_data *bd)
+{
+	struct request *rq = bd->rq;
+	struct pxd_device *pxd_dev = rq->q->queuedata;
+	struct fuse_req *req = blk_mq_rq_to_pdu(rq);
+	struct fuse_conn *fc = &pxd_dev->ctx->fc;
+
+	if (BLK_RQ_IS_PASSTHROUGH(rq))
+		return BLK_STS_IOERR;
+
+	if (!fc->connected && !fc->allow_disconnected)
+		return BLK_STS_IOERR;
 
 	pxd_printk("%s: dev m %d g %lld %s at %ld len %d bytes %d pages "
-		"flags  %llx\n", __func__,
+		   "flags  %llx\n", __func__,
 		pxd_dev->minor, pxd_dev->dev_id,
 		rq_data_dir(rq) == WRITE ? "wr" : "rd",
 		blk_rq_pos(rq) * SECTOR_SIZE, blk_rq_bytes(rq),
 		rq->nr_phys_segments, rq->cmd_flags);
 
-	blk_mq_start_request(rq);
+	fuse_request_init(req);
+	fuse_req_init_context(req);
 
-	req = pxd_fuse_req(pxd_dev, 0);
-	if (IS_ERR(req)) {
-		error = BLK_STS_IOERR;
-		goto err;
-	}
+	blk_mq_start_request(rq);
 
 	if (pxd_request(req, blk_rq_bytes(rq), blk_rq_pos(rq) * SECTOR_SIZE,
 		pxd_dev->minor, req_op(rq), rq->cmd_flags, true,
@@ -581,44 +551,20 @@ static void pxd_queue_workfn(struct work_struct *work)
 		goto err;
 	}
 
-	req->num_pages = 0;
-	req->misc.pxd_rdwr_in.chksum = 0;
-	req->misc.pxd_rdwr_in.pad = 0;
+	req->pxd_rdwr_in.chksum = 0;
+	req->pxd_rdwr_in.pad = 0;
 	req->rq = rq;
 	fuse_request_send_nowait(&pxd_dev->ctx->fc, req);
-	return;
 
-err:
-	blk_mq_end_request(rq, error);
-}
-
-static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
-		const struct blk_mq_queue_data *bd)
-{
-	struct request *rq = bd->rq;
-	struct work_struct *work = blk_mq_rq_to_pdu(rq);
-
-	queue_work(pxd_wq, work);
 	return BLK_STS_OK;
-}
-
-static int pxd_init_request(struct blk_mq_tag_set *set, struct request *rq,
-			    unsigned int hctx_idx, unsigned int numa_node)
-{
-	struct work_struct *work = blk_mq_rq_to_pdu(rq);
-
-	INIT_WORK(work, pxd_queue_workfn);
-	return 0;
 }
 
 static const struct blk_mq_ops pxd_mq_ops = {
 	.queue_rq       = pxd_queue_rq,
-	.init_request   = pxd_init_request,
 };
 #endif
-#endif
 
-static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_out *add)
+static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add)
 {
 	struct gendisk *disk;
 	struct request_queue *q;
@@ -640,24 +586,36 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_out *add)
 	disk->fops = &pxd_bd_ops;
 	disk->private_data = pxd_dev;
 
-	/* cannot be chosen dynamically as other files also need to know how requests are to be processed. */
-#if !defined(USE_REQUESTQ_MODEL)
-	q = blk_alloc_queue(GFP_KERNEL);
-	if (!q) {
-		err = -ENOMEM;
-		goto out_disk;
+#ifndef __PX_FASTPATH__
+	if (pxd_dev->fastpath) {
+		printk(KERN_NOTICE"PX driver does not support fastpath, disabling it.");
+		pxd_dev->fastpath = false;
 	}
-	blk_queue_make_request(q, pxd_make_request);
 #else
+	if (pxd_dev->fastpath) {
+		q = blk_alloc_queue(GFP_KERNEL);
+		if (!q) {
+			err = -ENOMEM;
+			goto out_disk;
+		}
+
+		// add hooks to control congestion only while using fastpath
+		q->backing_dev_info->congested_fn = pxd_device_congested;
+		q->backing_dev_info->congested_data = pxd_dev;
+
+		blk_queue_make_request(q, pxd_make_request_fastpath);
+	} else {
+#endif
+
 #ifdef __PX_BLKMQ__
 	  memset(&pxd_dev->tag_set, 0, sizeof(pxd_dev->tag_set));
 	  pxd_dev->tag_set.ops = &pxd_mq_ops;
 	  pxd_dev->tag_set.queue_depth = PXD_MAX_QDEPTH;
 	  pxd_dev->tag_set.numa_node = NUMA_NO_NODE;
-	  pxd_dev->tag_set.flags = BLK_MQ_F_SHOULD_MERGE | BLK_MQ_F_SG_MERGE;
+	  pxd_dev->tag_set.flags = BLK_MQ_F_SHOULD_MERGE;
 	  pxd_dev->tag_set.nr_hw_queues = 8;
 	  pxd_dev->tag_set.queue_depth = 128;
-	  pxd_dev->tag_set.cmd_size = sizeof(struct work_struct);
+	  pxd_dev->tag_set.cmd_size = sizeof(struct fuse_req);
 
 	  err = blk_mq_alloc_tag_set(&pxd_dev->tag_set);
 	  if (err)
@@ -676,6 +634,9 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_out *add)
 	  	goto out_disk;
 	  }
 #endif
+
+#ifdef __PX_FASTPATH__
+	}
 #endif
 	blk_queue_max_hw_sectors(q, SEGMENT_SIZE / SECTOR_SIZE);
 	blk_queue_max_segment_size(q, SEGMENT_SIZE);
@@ -723,6 +684,7 @@ static void pxd_free_disk(struct pxd_device *pxd_dev)
 	if (!disk)
 		return;
 
+	pxd_fastpath_cleanup(pxd_dev);
 	pxd_dev->disk = NULL;
 	if (disk->flags & GENHD_FL_UP) {
 		del_gendisk(disk);
@@ -735,7 +697,7 @@ static void pxd_free_disk(struct pxd_device *pxd_dev)
 	put_disk(disk);
 }
 
-ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_out *add)
+ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 {
 	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
 	struct pxd_device *pxd_dev = NULL;
@@ -772,10 +734,28 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_out *add)
 	pxd_dev->major = pxd_major;
 	pxd_dev->minor = new_minor;
 	pxd_dev->ctx = ctx;
+	pxd_dev->connected = true; // fuse slow path connection
+	pxd_dev->size = add->size;
+	pxd_dev->mode = add->open_mode;
+	pxd_dev->fastpath = add->enable_fp;
+
+	printk(KERN_INFO"Device %llu added with mode %#x fastpath %d npath %lu\n",
+			add->dev_id, add->open_mode, add->enable_fp, add->paths.size);
+
+	if (pxd_dev->fastpath) {
+		err = pxd_fastpath_init(pxd_dev);
+		if (err)
+			goto out_id;
+
+		printk(KERN_INFO"Device %llu enabling fastpath %d (paths: %lu)\n",
+				add->dev_id, add->enable_fp, add->paths.size);
+	}
 
 	err = pxd_init_disk(pxd_dev, add);
-	if (err)
+	if (err) {
+		if (pxd_dev->fastpath) pxd_fastpath_cleanup(pxd_dev);
 		goto out_id;
+	}
 
 	spin_lock(&ctx->lock);
 	list_for_each_entry(pxd_dev_itr, &ctx->list, node) {
@@ -819,6 +799,9 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 	int err;
 	struct pxd_device *pxd_dev;
 
+	pxd_printk(KERN_INFO"pxd_remove for device %llu\n",
+			remove->dev_id);
+
 	spin_lock(&ctx->lock);
 	list_for_each_entry(pxd_dev, &ctx->list, node) {
 		if (pxd_dev->dev_id == remove->dev_id) {
@@ -845,6 +828,7 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 	}
 
 	pxd_dev->removing = true;
+	pxd_fastpath_cleanup(pxd_dev);
 
 	/* Make sure the req_fn isn't called anymore even if the device hangs around */
 	if (pxd_dev->disk && pxd_dev->disk->queue){
@@ -901,6 +885,126 @@ ssize_t pxd_update_size(struct fuse_conn *fc, struct pxd_update_size_out *update
 
 	return 0;
 out:
+	return err;
+}
+
+ssize_t pxd_read_init(struct fuse_conn *fc, struct iov_iter *iter)
+{
+	size_t copied = 0;
+	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
+	struct pxd_device *pxd_dev;
+	struct pxd_init_in pxd_init;
+
+	spin_lock(&fc->lock);
+
+	pxd_init.num_devices = ctx->num_devices;
+	pxd_init.version = PXD_VERSION;
+
+	if (copy_to_iter(&pxd_init, sizeof(pxd_init), iter) != sizeof(pxd_init)) {
+		printk(KERN_ERR "%s: copy pxd_init error\n", __func__);
+		goto copy_error;
+	}
+	copied += sizeof(pxd_init);
+
+	list_for_each_entry(pxd_dev, &ctx->list, node) {
+		struct pxd_dev_id id;
+		id.dev_id = pxd_dev->dev_id;
+		id.local_minor = pxd_dev->minor;
+		if (copy_to_iter(&id, sizeof(id), iter) != sizeof(id)) {
+			printk(KERN_ERR "%s: copy dev id error copied %ld\n", __func__,
+				copied);
+			goto copy_error;
+		}
+		copied += sizeof(id);
+	}
+
+	spin_unlock(&fc->lock);
+
+	printk(KERN_INFO "%s: pxd-control-%d init OK %d devs version %d\n", __func__,
+		ctx->id, pxd_init.num_devices, pxd_init.version);
+
+	return copied;
+
+copy_error:
+	spin_unlock(&fc->lock);
+	return -EFAULT;
+}
+
+
+static int __pxd_update_path(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path)
+{
+	/// This seems risky to update paths on the fly while the px device is active
+	/// Need to confirm behavior while IOs are active and handle it right!!!!
+	pxd_init_fastpath_target(pxd_dev, update_path);
+	return 0;
+
+}
+
+ssize_t pxd_update_path(struct fuse_conn *fc, struct pxd_update_path_out *update_path)
+{
+	bool found = false;
+	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
+	int err;
+	struct pxd_device *pxd_dev;
+
+	spin_lock(&ctx->lock);
+	list_for_each_entry(pxd_dev, &ctx->list, node) {
+		if ((pxd_dev->dev_id == update_path->dev_id) && !pxd_dev->removing) {
+			spin_lock(&pxd_dev->lock);
+			found = true;
+			break;
+		}
+	}
+	spin_unlock(&ctx->lock);
+
+	if (!found) {
+		err = -ENOENT;
+		goto out;
+	}
+
+	err=__pxd_update_path(pxd_dev, update_path);
+out:
+	if (found) spin_unlock(&pxd_dev->lock);
+	return err;
+}
+
+
+int pxd_set_fastpath(struct fuse_conn *fc, struct pxd_fastpath_out *fp)
+{
+	bool found = false;
+	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
+	struct pxd_device *pxd_dev;
+	int err;
+
+	printk(KERN_WARNING"device %llu, set fastpath enable %d, cleanup %d\n",
+			fp->dev_id, fp->enable, fp->cleanup);
+	spin_lock(&ctx->lock);
+	list_for_each_entry(pxd_dev, &ctx->list, node) {
+		if ((pxd_dev->dev_id == fp->dev_id) && !pxd_dev->removing) {
+			spin_lock(&pxd_dev->lock);
+			found = true;
+			break;
+		}
+	}
+	spin_unlock(&ctx->lock);
+
+	if (!found) {
+		err = -ENOENT;
+		goto out;
+	}
+
+	/* setup whether access is block or file access */
+	if (fp->enable) {
+		enableFastPath(pxd_dev, false);
+	} else {
+		if (fp->cleanup) disableFastPath(pxd_dev);
+	}
+
+	spin_unlock(&pxd_dev->lock);
+
+	return 0;
+out:
+	if (found) spin_unlock(&pxd_dev->lock);
 	return err;
 }
 
@@ -980,16 +1084,269 @@ ssize_t pxd_timeout_store(struct device *dev, struct device_attribute *attr,
 	return count;
 }
 
+static ssize_t pxd_active_show(struct device *dev,
+                     struct device_attribute *attr, char *buf)
+{
+	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
+	char *cp = buf;
+	int ncount;
+	int available = PAGE_SIZE - 1;
+	int i;
+
+	ncount = snprintf(cp, available, "nactive: %u/%u, [write: %u, flush: %u(nop: %u), fua: %u, discard: %u, preflush: %u], switched: %u, slowpath: %u\n",
+                atomic_read(&pxd_dev->fp.ncount), atomic_read(&pxd_dev->fp.ncomplete),
+		atomic_read(&pxd_dev->fp.nio_write),
+		atomic_read(&pxd_dev->fp.nio_flush), atomic_read(&pxd_dev->fp.nio_flush_nop),
+		atomic_read(&pxd_dev->fp.nio_fua), atomic_read(&pxd_dev->fp.nio_discard),
+		atomic_read(&pxd_dev->fp.nio_preflush),
+		atomic_read(&pxd_dev->fp.nswitch), atomic_read(&pxd_dev->fp.nslowPath));
+
+	cp += ncount;
+	available -= ncount;
+	for (i = 0; i < pxd_dev->fp.nfd; i++) {
+		size_t tmp = snprintf(cp, available, "%s\n", pxd_dev->fp.device_path[i]);
+		cp += tmp;
+		available -= tmp;
+		ncount += tmp;
+	}
+
+	return ncount;
+}
+
+static ssize_t pxd_sync_show(struct device *dev,
+                     struct device_attribute *attr, char *buf)
+{
+	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
+	return sprintf(buf, "sync: %u/%u %s\n",
+			atomic_read(&pxd_dev->fp.nsync_active),
+			atomic_read(&pxd_dev->fp.nsync),
+			(pxd_dev->fp.bg_flush_enabled ? "(enabled)" : "(disabled)"));
+}
+
+static ssize_t pxd_sync_store(struct device *dev, struct device_attribute *attr,
+			   const char *buf, size_t count)
+{
+	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
+	int enable = 0;
+
+	sscanf(buf, "%d", &enable);
+
+	if (enable) {
+		pxd_dev->fp.bg_flush_enabled = 1;
+	} else {
+		pxd_dev->fp.bg_flush_enabled = 0;
+	}
+
+	return count;
+}
+
+static ssize_t pxd_mode_show(struct device *dev,
+                     struct device_attribute *attr, char *buf)
+{
+	char modestr[32];
+	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
+
+	decode_mode(pxd_dev->mode, modestr);
+	return sprintf(buf, "mode: %#x/%s\n", pxd_dev->mode, modestr);
+}
+
+static ssize_t pxd_wrsegment_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
+	return sprintf(buf, "write segment size(bytes): %d\n", pxd_dev->fp.n_flush_wrsegs * PXD_LBS);
+}
+
+static ssize_t pxd_wrsegment_store(struct device *dev, struct device_attribute *attr,
+		const char *buf, size_t count)
+{
+	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
+	int nbytes, nsegs;
+
+	sscanf(buf, "%d", &nbytes);
+
+	nsegs = nbytes/PXD_LBS; // num of write segments
+	if (nsegs < MAX_WRITESEGS_FOR_FLUSH) {
+		nsegs = MAX_WRITESEGS_FOR_FLUSH;
+	}
+
+	pxd_dev->fp.n_flush_wrsegs = nsegs;
+	return count;
+}
+
+static ssize_t pxd_congestion_show(struct device *dev,
+                     struct device_attribute *attr, char *buf)
+{
+	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
+
+	return sprintf(buf, "congested: %s (%d/%d)\n",
+			pxd_dev->fp.congested ? "yes" : "no",
+			pxd_dev->fp.nr_congestion_on,
+			pxd_dev->fp.nr_congestion_off);
+}
+
+static ssize_t pxd_congestion_set(struct device *dev, struct device_attribute *attr,
+			   const char *buf, size_t count)
+{
+	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
+	int thresh;
+
+	sscanf(buf, "%d", &thresh);
+
+	if (thresh < 0) {
+		thresh = pxd_dev->fp.qdepth;
+	}
+
+	if (thresh > MAX_CONGESTION_THRESHOLD) {
+		thresh = MAX_CONGESTION_THRESHOLD;
+	}
+
+	spin_lock_irq(&pxd_dev->lock);
+	pxd_dev->fp.qdepth = thresh;
+	spin_unlock_irq(&pxd_dev->lock);
+
+	return count;
+}
+
+static ssize_t pxd_fastpath_state(struct device *dev,
+                     struct device_attribute *attr, char *buf)
+{
+	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
+	return sprintf(buf, "%d\n", pxd_dev->fp.nfd);
+}
+
+static char* __strtok_r(char *src, const char delim, char **saveptr) {
+	char *curr;
+	char *start;
+
+	if (src) {
+		start = src;
+		*saveptr = NULL;
+	} else {
+		start = *saveptr;
+	}
+	curr = start;
+	while (curr && *curr) {
+		if (*curr == delim) {
+			*saveptr = curr+1;
+			*curr = '\0';
+
+			return start;
+		}
+		curr++;
+	}
+
+	return start;
+}
+
+static void __strip_nl(const char *src, char *dst, int maxlen) {
+	char *tmp;
+	int len=strlen(src);
+
+
+	if (!src || !dst) {
+		return;
+	}
+
+	dst[0] = '\0';
+	if (!len) {
+		return;
+	}
+
+	if (len >= maxlen) {
+		// to accomodate null
+		printk(KERN_WARNING"stripping newline output buffer overflow.. src %d(%s), dst %d\n",
+				len, src, maxlen);
+		len = maxlen - 1;
+	}
+
+	// leading space
+	while (src && *src) {
+		if (!isspace(*src) && !iscntrl(*src)) {
+			memcpy(dst,src,len);
+			dst[len]='\0';
+			break;
+		}
+		src++;
+		len--;
+	}
+
+	// trailing space
+	tmp = dst + len - 1;
+	while (len && *tmp) {
+		if (isspace(*tmp) || iscntrl(*tmp)) {
+			*tmp='\0';
+			tmp--;
+			len--;
+			continue;
+		}
+		break;
+	}
+
+	printk(KERN_INFO"stripping newline src=(%s), dst=(%s), len=%d\n",
+			src, dst, len);
+}
+
+static ssize_t pxd_fastpath_update(struct device *dev, struct device_attribute *attr,
+		               const char *buf, size_t count)
+{
+	// format: path,path,path
+	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
+	struct pxd_update_path_out update_out;
+	const char delim = ',';
+	char *token;
+	char *saveptr = NULL;
+	int i;
+	char trimtoken[256];
+
+	char *tmp = kzalloc(count, GFP_KERNEL);
+	if (!tmp) {
+		printk("No memory to process %lu bytes", count);
+		return count;
+	}
+	memcpy(tmp, buf, count);
+
+	i=0;
+	token = __strtok_r(tmp, delim, &saveptr);
+	for (i=0; i<MAX_PXD_BACKING_DEVS && token; i++) {
+		// strip the token of any newline/whitespace
+		__strip_nl(token, trimtoken, sizeof(trimtoken));
+		strncpy(update_out.devpath[i], trimtoken, MAX_PXD_DEVPATH_LEN);
+		update_out.devpath[i][MAX_PXD_DEVPATH_LEN] = '\0';
+
+		token = __strtok_r(0, delim, &saveptr);
+	}
+	update_out.size = i;
+	update_out.dev_id = pxd_dev->dev_id;
+
+	__pxd_update_path(pxd_dev, &update_out);
+	kfree(tmp);
+
+	return count;
+}
+
 static DEVICE_ATTR(size, S_IRUGO, pxd_size_show, NULL);
 static DEVICE_ATTR(major, S_IRUGO, pxd_major_show, NULL);
 static DEVICE_ATTR(minor, S_IRUGO, pxd_minor_show, NULL);
 static DEVICE_ATTR(timeout, S_IRUGO|S_IWUSR, pxd_timeout_show, pxd_timeout_store);
+static DEVICE_ATTR(active, S_IRUGO, pxd_active_show, NULL);
+static DEVICE_ATTR(sync, S_IRUGO|S_IWUSR, pxd_sync_show, pxd_sync_store);
+static DEVICE_ATTR(congested, S_IRUGO|S_IWUSR, pxd_congestion_show, pxd_congestion_set);
+static DEVICE_ATTR(writesegment, S_IRUGO|S_IWUSR, pxd_wrsegment_show, pxd_wrsegment_store);
+static DEVICE_ATTR(fastpath, S_IRUGO|S_IWUSR, pxd_fastpath_state, pxd_fastpath_update);
+static DEVICE_ATTR(mode, S_IRUGO, pxd_mode_show, NULL);
 
 static struct attribute *pxd_attrs[] = {
 	&dev_attr_size.attr,
 	&dev_attr_major.attr,
 	&dev_attr_minor.attr,
 	&dev_attr_timeout.attr,
+	&dev_attr_active.attr,
+	&dev_attr_sync.attr,
+	&dev_attr_congested.attr,
+	&dev_attr_writesegment.attr,
+	&dev_attr_fastpath.attr,
+	&dev_attr_mode.attr,
 	NULL
 };
 
@@ -1058,130 +1415,8 @@ static void pxd_sysfs_exit(void)
 	device_unregister(&pxd_root_dev);
 }
 
-static void pxd_fill_init_desc(struct fuse_page_desc *desc, int num_ids)
-{
-	desc->length = num_ids * sizeof(struct pxd_dev_id);
-	desc->offset = 0;
-}
-
-static void pxd_fill_init(struct fuse_conn *fc, struct fuse_req *req,
-	struct pxd_init_in *in)
-{
-	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
-	int i = 0, j = 0;
-	int num_per_page = PAGE_SIZE / sizeof(struct pxd_dev_id);
-	struct pxd_device *pxd_dev;
-	struct pxd_dev_id *ids = NULL;
-
-	in->version = PXD_VERSION;
-
-	if (!req->num_pages)
-		return;
-
-	spin_lock(&ctx->lock);
-	list_for_each_entry(pxd_dev, &ctx->list, node) {
-		if (i == 0)
-			ids = kmap_atomic(req->pages[j]);
-		ids[i].dev_id = pxd_dev->dev_id;
-		ids[i].local_minor = pxd_dev->minor;
-		++i;
-		if (i == num_per_page) {
-			pxd_fill_init_desc(&req->page_descs[j], i);
-			kunmap_atomic(ids);
-			++j;
-			i = 0;
-		}
-	}
-	in->num_devices = ctx->num_devices;
-	spin_unlock(&ctx->lock);
-
-	if (i < num_per_page) {
-		pxd_fill_init_desc(&req->page_descs[j], i);
-		kunmap_atomic(ids);
-	}
-}
-
-static void pxd_process_init_reply(struct fuse_conn *fc,
-		struct fuse_req *req)
-{
-	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
-
-	printk(KERN_INFO "%s: pxd-control-%d:%llu init OK\n",
-		__func__, ctx->id, req->out.h.unique);
-	pxd_printk("%s: req %p err %d len %d un %lld\n",
-		__func__, req, req->out.h.error,
-		req->out.h.len, req->out.h.unique);
-
-	ctx->unique = req->out.h.unique;
-	if (req->out.h.error != 0)
-		fc->connected = 0;
-	fc->pend_open = 0;
-}
-
-static int pxd_send_init(struct fuse_conn *fc)
-{
-	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
-	int rc;
-	struct fuse_req *req;
-	struct pxd_init_in *arg;
-	void *outarg;
-	int i;
-	int num_per_page = PAGE_SIZE / sizeof(struct pxd_dev_id);
-	int num_pages = (sizeof(struct pxd_dev_id) * ctx->num_devices +
-				num_per_page - 1) / num_per_page;
-
-	req = fuse_get_req(fc, num_pages);
-	if (IS_ERR(req)) {
-		rc = PTR_ERR(req);
-		printk(KERN_ERR "%s: get req error %d\n", __func__, rc);
-		goto err;
-	}
-
-	req->num_pages = num_pages;
-
-	rc = -ENOMEM;
-	for (i = 0; i < req->num_pages; ++i) {
-		req->pages[i] = alloc_page(GFP_KERNEL | __GFP_ZERO);
-		if (!req->pages[i])
-			goto err_free_pages;
-	}
-
-	arg = &req->misc.pxd_init_in;
-	pxd_fill_init(fc, req, arg);
-
-	outarg = kzalloc(sizeof(struct pxd_init_out), GFP_KERNEL);
-	if (!outarg)
-		goto err_free_pages;
-
-	req->in.h.opcode = PXD_INIT;
-	req->in.numargs = 2;
-	req->in.args[0].size = sizeof(struct pxd_init_in);
-	req->in.args[0].value = arg;
-	req->in.args[1].size = sizeof(struct pxd_dev_id) * ctx->num_devices;
-	req->in.args[1].value = NULL;
-	req->in.argpages = 1;
-	req->end = pxd_process_init_reply;
-
-	fuse_request_send_oob(fc, req);
-
-	pxd_printk("%s: version %d num devices %ld(%d)\n", __func__, arg->version,
-		ctx->num_devices, arg->num_devices);
-	return 0;
-
-err_free_pages:
-	printk(KERN_ERR "%s: mem alloc\n", __func__);
-	for (i = 0; i < req->num_pages; ++i) {
-		if (req->pages[i])
-			put_page(req->pages[i]);
-	}
-	fuse_request_free(req);
-err:
-	return rc;
-}
-
 static int pxd_control_open(struct inode *inode, struct file *file)
 {
-	int rc;
 	struct pxd_context *ctx;
 	struct fuse_conn *fc;
 
@@ -1197,12 +1432,9 @@ static int pxd_control_open(struct inode *inode, struct file *file)
 	}
 
 	fc = &ctx->fc;
-	if (fc->pend_open == 1) {
-		printk(KERN_ERR "%s: too many outstanding opened\n", __func__);
-		return -EINVAL;
-	}
 	if (fc->connected == 1) {
-		printk(KERN_ERR "%s: pxd-control-%d already open\n", __func__, ctx->id);
+		printk(KERN_ERR "%s: pxd-control-%d(%lld) already open\n", __func__,
+			ctx->id, ctx->open_seq);
 		return -EINVAL;
 	}
 
@@ -1212,18 +1444,17 @@ static int pxd_control_open(struct inode *inode, struct file *file)
 	fc->connected = 1;
 	spin_unlock(&ctx->lock);
 
-	fc->pend_open = 1;
-	fc->initialized = 1;
 	fc->allow_disconnected = 1;
 	file->private_data = fc;
 
+	pxdctx_set_connected(ctx, true);
 	fuse_restart_requests(fc);
 
-	rc = pxd_send_init(fc);
-	if (rc)
-		return rc;
+	++ctx->open_seq;
 
-	printk(KERN_INFO "%s: pxd-control-%d open OK\n", __func__, ctx->id);
+	printk(KERN_INFO "%s: pxd-control-%d(%lld) open OK\n", __func__, ctx->id,
+		ctx->open_seq);
+
 	return 0;
 }
 
@@ -1241,12 +1472,11 @@ static int pxd_control_release(struct inode *inode, struct file *file)
 		pxd_printk("%s: not opened\n", __func__);
 	else
 		ctx->fc.connected = 0;
-	ctx->fc.pend_open = 0;
 	mod_timer(&ctx->timer, jiffies + (pxd_timeout_secs * HZ));
 	spin_unlock(&ctx->lock);
 
-	printk(KERN_INFO "%s: pxd-control-%d:%llu close OK\n", __func__,
-		ctx->id, ctx->unique);
+	printk(KERN_INFO "%s: pxd-control-%d(%lld) close OK\n", __func__, ctx->id,
+		ctx->open_seq);
 	return 0;
 }
 
@@ -1278,28 +1508,31 @@ static void pxd_timeout(unsigned long args)
 
 	fc->connected = true;
 	fc->allow_disconnected = 0;
+	pxdctx_set_connected(ctx, false);
 	fuse_abort_conn(fc);
-	printk(KERN_INFO "PXD_TIMEOUT (%s:%llu): Aborting all requests...",
-		ctx->name, ctx->unique);
+	printk(KERN_INFO "PXD_TIMEOUT (%s:%u): Aborting all requests...",
+		ctx->name, ctx->id);
 }
 
 int pxd_context_init(struct pxd_context *ctx, int i)
 {
 	int err;
+
 	spin_lock_init(&ctx->lock);
 	ctx->id = i;
+	ctx->open_seq = 0;
 	ctx->fops = fuse_dev_operations;
 	ctx->fops.owner = THIS_MODULE;
 	ctx->fops.open = pxd_control_open;
 	ctx->fops.release = pxd_control_release;
+	ctx->fops.unlocked_ioctl = pxd_control_ioctl;
 
 	if (ctx->id < pxd_num_contexts_exported) {
 		err = fuse_conn_init(&ctx->fc);
 		if (err)
 			return err;
-	} else {
-		ctx->fops.unlocked_ioctl = pxd_control_ioctl;
 	}
+
 	ctx->fc.release = pxd_fuse_conn_release;
 	ctx->fc.allow_disconnected = 1;
 	INIT_LIST_HEAD(&ctx->list);
@@ -1366,18 +1599,11 @@ int pxd_init(void)
 			pxd_miscdev.name, err);
 		goto out_fuse;
 	}
-#ifdef __PX_BLKMQ__
-        pxd_wq = alloc_workqueue("pxd", WQ_MEM_RECLAIM, 0);
-        if (!pxd_wq) {
-                err = -ENOMEM;
-                goto out_misc;
-        }
-#endif
 	pxd_major = register_blkdev(0, "pxd");
 	if (pxd_major < 0) {
 		err = pxd_major;
 		printk(KERN_ERR "pxd: failed to register dev pxd: %d\n", err);
-		goto out_wq;
+		goto out_misc;
 	}
 
 	err = pxd_sysfs_init();
@@ -1386,6 +1612,11 @@ int pxd_init(void)
 		goto out_blkdev;
 	}
 
+	err = fastpath_init();
+	if (err) {
+		printk(KERN_ERR "pxd: fastpath initialization failed: %d\n", err);
+		goto out_blkdev;
+	}
 #ifdef __PX_BLKMQ__
 	printk(KERN_INFO "pxd: blk-mq driver loaded version %s\n", gitversion);
 #else
@@ -1396,11 +1627,7 @@ int pxd_init(void)
 
 out_blkdev:
 	unregister_blkdev(0, "pxd");
-out_wq:
-#ifdef __PX_BLKMQ__
-        destroy_workqueue(pxd_wq);
 out_misc:
-#endif
 	misc_deregister(&pxd_miscdev);
 out_fuse:
 	for (j = 0; j < i; ++j) {
@@ -1417,11 +1644,9 @@ void pxd_exit(void)
 {
 	int i;
 
+	fastpath_cleanup();
 	pxd_sysfs_exit();
 	unregister_blkdev(pxd_major, "pxd");
-#ifdef __PX_BLKMQ__
-        destroy_workqueue(pxd_wq);
-#endif
 	misc_deregister(&pxd_miscdev);
 
 	for (i = 0; i < pxd_num_contexts; ++i) {

--- a/pxd.c
+++ b/pxd.c
@@ -362,7 +362,7 @@ static void pxd_write_same_request(struct fuse_req *req, uint32_t size, uint64_t
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) || defined(REQ_PREFLUSH)
-static void pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
+static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 			uint32_t minor, uint32_t op, uint32_t flags, bool qfn,
 			uint64_t reqctr)
 {
@@ -387,13 +387,15 @@ static void pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 	default:
 		printk(KERN_ERR"[%llu] REQ_OP_UNKNOWN(%#x): size=%d, off=%lld, minor=%d, flags=%#x\n",
 			req->in.h.unique, op, size, off, minor, flags);
-		BUG();
+		return -1;
 	}
+
+	return 0;
 }
 
 #else
 
-static void pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
+static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 	uint32_t minor, uint32_t flags, bool qfn, uint64_t reqctr)
 {
 	trace_pxd_request(reqctr, req->in.h.unique, size, off, minor, flags);
@@ -418,8 +420,10 @@ static void pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 	default:
 		printk(KERN_ERR"[%llu] REQ_OP_UNKNOWN(%#x): size=%d, off=%lld, minor=%d, flags=%#x\n",
 			req->in.h.unique, flags, size, off, minor, flags);
-		BUG();
+		return -1;
 	}
+
+	return 0;
 }
 #endif
 
@@ -468,13 +472,17 @@ static void pxd_make_request(struct request_queue *q, struct bio *bio)
 	}
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) || defined(REQ_PREFLUSH)
-	pxd_request(req, BIO_SIZE(bio), BIO_SECTOR(bio) * SECTOR_SIZE,
-		pxd_dev->minor, bio_op(bio), bio->bi_opf, false, REQCTR(&pxd_dev->ctx->fc));
+	if (pxd_request(req, BIO_SIZE(bio), BIO_SECTOR(bio) * SECTOR_SIZE,
+		pxd_dev->minor, bio_op(bio), bio->bi_opf, false, REQCTR(&pxd_dev->ctx->fc))) {
 #else
-	pxd_request(req, BIO_SIZE(bio), BIO_SECTOR(bio) * SECTOR_SIZE,
+	if (pxd_request(req, BIO_SIZE(bio), BIO_SECTOR(bio) * SECTOR_SIZE,
 		    pxd_dev->minor, bio->bi_rw, false,
-		    REQCTR(&pxd_dev->ctx->fc));
+		    REQCTR(&pxd_dev->ctx->fc))) {
 #endif
+		fuse_request_free(req);
+		bio_io_error(bio);
+		return BLK_QC_RETVAL;
+	}
 
 	req->bio = bio;
 	req->queue = q;
@@ -482,7 +490,7 @@ static void pxd_make_request(struct request_queue *q, struct bio *bio)
 	fuse_request_send_nowait(&pxd_dev->ctx->fc, req);
 	return BLK_QC_RETVAL;
 }
-#endif
+#else
 
 #ifndef __PX_BLKMQ__
 static void pxd_rq_fn(struct request_queue *q)
@@ -513,20 +521,25 @@ static void pxd_rq_fn(struct request_queue *q)
 
 		req = pxd_fuse_req(pxd_dev, 0);
 		if (IS_ERR(req)) {
-  			spin_lock_irq(&pxd_dev->qlock);
+			spin_lock_irq(&pxd_dev->qlock);
 			__blk_end_request(rq, -EIO, blk_rq_bytes(rq));
 			continue;
 		}
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) || defined(REQ_PREFLUSH)
-		pxd_request(req, blk_rq_bytes(rq), blk_rq_pos(rq) * SECTOR_SIZE,
+		if (pxd_request(req, blk_rq_bytes(rq), blk_rq_pos(rq) * SECTOR_SIZE,
 			    pxd_dev->minor, req_op(rq), rq->cmd_flags, true,
-			    REQCTR(&pxd_dev->ctx->fc));
+			    REQCTR(&pxd_dev->ctx->fc))) {
 #else
-		pxd_request(req, blk_rq_bytes(rq), blk_rq_pos(rq) * SECTOR_SIZE,
+		if (pxd_request(req, blk_rq_bytes(rq), blk_rq_pos(rq) * SECTOR_SIZE,
 			    pxd_dev->minor, rq->cmd_flags, true,
-			    REQCTR(&pxd_dev->ctx->fc));
+			    REQCTR(&pxd_dev->ctx->fc))) {
 #endif
+			fuse_request_free(req);
+			spin_lock_irq(&pxd_dev->qlock);
+			__blk_end_request(rq, -EIO, blk_rq_bytes(rq));
+			continue;
+		}
 
 		req->rq = rq;
 		req->queue = q;
@@ -561,9 +574,12 @@ static void pxd_queue_workfn(struct work_struct *work)
 		goto err;
 	}
 
-	pxd_request(req, blk_rq_bytes(rq), blk_rq_pos(rq) * SECTOR_SIZE,
+	if (pxd_request(req, blk_rq_bytes(rq), blk_rq_pos(rq) * SECTOR_SIZE,
 		pxd_dev->minor, req_op(rq), rq->cmd_flags, true,
-		REQCTR(&pxd_dev->ctx->fc));
+		REQCTR(&pxd_dev->ctx->fc))) {
+		error = BLK_STS_IOERR;
+		goto err;
+	}
 
 	req->num_pages = 0;
 	req->misc.pxd_rdwr_in.chksum = 0;
@@ -599,6 +615,7 @@ static const struct blk_mq_ops pxd_mq_ops = {
 	.queue_rq       = pxd_queue_rq,
 	.init_request   = pxd_init_request,
 };
+#endif
 #endif
 
 static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_out *add)

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -34,7 +34,38 @@
 #define BVEC(bvec) (*(bvec))
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
+#define REQUEST_GET_SECTORS(bio)  (BIO_SIZE(bio) >> 9)
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)
+#define BIO_OP(bio)   bio_op(bio)
+#define SUBMIT_BIO(bio) submit_bio(bio)
+#else
+// only supports read or write
+#define BIO_OP(bio)   (bio->bi_rw & 1)
+#define SUBMIT_BIO(bio)  submit_bio(BIO_OP(bio), bio)
+#endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+#define BIOSET_CREATE(sz, pad)   bioset_create(sz, pad, 0)
+#else
+#define BIOSET_CREATE(sz, pad)   bioset_create(sz, pad)
+#endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
+#define BIO_SET_DEV(bio, bdev)  bio_set_dev(bio, bdev)
+#else
+#define BIO_SET_DEV(bio, bdev)  \
+	do { \
+		(bio)->bi_bdev = (bdev); \
+	} while (0)
+#endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
+#define BIO_ENDIO(bio, err) do {                \
+    bio->bi_status = err;                       \
+    bio_endio(bio);                             \
+} while (0)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
 #define BIO_ENDIO(bio, err) do { 		\
 	if (err != 0) { 			\
 		bio_io_error((bio)); 		\

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -41,7 +41,7 @@
 #define SUBMIT_BIO(bio) submit_bio(bio)
 #else
 // only supports read or write
-#define BIO_OP(bio)   (bio->bi_rw & 1)
+#define BIO_OP(bio)   ((bio)->bi_rw & 1)
 #define SUBMIT_BIO(bio)  submit_bio(BIO_OP(bio), bio)
 #endif
 

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -1,0 +1,100 @@
+#ifndef _PXD_CORE_H_
+#define _PXD_CORE_H_
+
+#include <linux/miscdevice.h>
+#ifdef __PX_BLKMQ__
+#include <linux/blk-mq.h>
+#endif
+
+#include "pxd_fastpath.h"
+#include "fuse_i.h"
+struct pxd_context {
+	spinlock_t lock;
+	struct list_head list;
+	size_t num_devices;
+	struct fuse_conn fc;
+	struct file_operations fops;
+	char name[256];
+	int id;
+	struct miscdevice miscdev;
+	struct list_head pending_requests;
+	struct timer_list timer;
+	uint64_t open_seq;
+};
+
+struct pxd_device {
+	uint64_t dev_id;
+	int major;
+	int minor;
+	struct gendisk *disk;
+	struct device dev;
+	size_t size;
+	spinlock_t lock;
+	spinlock_t qlock;
+	struct list_head node;
+	int open_count;
+	bool removing;
+	struct pxd_fastpath_extension fp;
+	struct pxd_context *ctx;
+	bool connected;
+	mode_t mode;
+	bool fastpath;
+#ifdef __PX_BLKMQ__
+        struct blk_mq_tag_set tag_set;
+#endif
+};
+
+#define pxd_printk(args...)
+//#define pxd_printk(args, ...) printk(KERN_ERR args, ##__VA_ARGS__)
+
+#define pxd_io_printk(args...)
+//#define pxd_io_printk(args, ...) printk(KERN_ERR args, ##__VA_ARGS__)
+
+#ifndef SECTOR_SIZE
+#define SECTOR_SIZE 512
+#endif
+#ifndef SECTOR_SHIFT
+#define SECTOR_SHIFT (9)
+#endif
+
+#define SEGMENT_SIZE (1024 * 1024)
+#define MAX_WRITESEGS_FOR_FLUSH ((4*SEGMENT_SIZE)/PXD_LBS)
+
+// slow path make request io entry point
+struct request_queue;
+struct bio;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
+blk_qc_t pxd_make_request_slowpath(struct request_queue *q, struct bio *bio);
+#else
+void pxd_make_request_slowpath(struct request_queue *q, struct bio *bio);
+#endif
+
+
+static inline
+mode_t open_mode(mode_t mode) {
+	mode_t m = O_LARGEFILE | O_NOATIME; // default
+	if (mode & O_RDONLY) {
+		m |= O_RDONLY;
+	} else {
+		m |= O_RDWR;
+	}
+
+	if (mode & O_SYNC) m |= O_SYNC;
+	if (mode & O_DIRECT) m |= O_DIRECT;
+
+	return m;
+}
+
+static inline
+void decode_mode(mode_t mode, char *out) {
+	if (mode & O_LARGEFILE) *out++ = 'L';
+	if (mode & O_NOATIME) *out++ = 'A';
+	if (mode & O_DIRECT) *out++='D';
+	if (mode & O_RDONLY) *out++='R';
+	if (mode & O_RDWR) *out++ = 'W';
+	if (mode & O_SYNC) *out++ = 'S';
+
+	*out = '\0';
+}
+
+#endif /* _PXD_CORE_H_ */

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -19,6 +19,7 @@ struct pxd_context {
 	struct miscdevice miscdev;
 	struct list_head pending_requests;
 	struct timer_list timer;
+	struct work_struct abort_work;
 	uint64_t open_seq;
 };
 

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1,0 +1,1309 @@
+#include <linux/types.h>
+#include <linux/delay.h>
+
+#include "pxd.h"
+#include "pxd_core.h"
+#include "pxd_compat.h"
+
+// cached info at px loadtime, to gracefully handle hot plugging cpus
+static int __px_ncpus;
+
+// A private global bio mempool for punting requests bypassing vfs
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0)
+static struct bio_set pxd_bio_set;
+#endif
+#define PXD_MIN_POOL_PAGES (128)
+static struct bio_set* ppxd_bio_set;
+
+// global thread contexts
+static struct thread_context *g_tc;
+
+// forward decl
+static int pxd_io_writer(void *data);
+static int pxd_io_reader(void *data);
+static void __pxd_cleanup_block_io(struct pxd_io_tracker *head);
+static struct pxd_io_tracker* pxd_get_io(struct thread_context *tc, int rw);
+#define pxd_get_writeio(tc)  pxd_get_io(tc, WRITE)
+#define pxd_get_readio(tc)   pxd_get_io(tc, READ)
+
+// congestion callback from kernel writeback module
+int pxd_device_congested(void *data, int bits)
+{
+	struct pxd_device *pxd_dev = data;
+	int ncount = atomic_read(&pxd_dev->fp.ncount);
+
+	// notify congested if device is suspended as well.
+	// modified under lock, read outside lock.
+	if (pxd_dev->fp.suspend) {
+		return 1;
+	}
+
+	// does not care about async or sync request.
+	if (ncount > pxd_dev->fp.qdepth) {
+		spin_lock_irq(&pxd_dev->lock);
+		if (!pxd_dev->fp.congested) {
+			pxd_dev->fp.congested = true;
+			pxd_dev->fp.nr_congestion_on++;
+		}
+		spin_unlock_irq(&pxd_dev->lock);
+		return 1;
+	}
+
+	if (pxd_dev->fp.congested) {
+		if (ncount < (3*pxd_dev->fp.qdepth)/4) {
+			spin_lock_irq(&pxd_dev->lock);
+			if (pxd_dev->fp.congested) {
+				pxd_dev->fp.congested = false;
+				pxd_dev->fp.nr_congestion_off++;
+			}
+			spin_unlock_irq(&pxd_dev->lock);
+			return 0;
+		}
+		return 1;
+	}
+
+	return 0;
+}
+
+static inline
+int pxd_io_empty(struct thread_context *tc, int rw)
+{
+	int empty;
+
+	if (rw == WRITE) {
+		spin_lock_irq(&tc->write_lock);
+		empty = list_empty(&tc->iot_writers);
+		spin_unlock_irq(&tc->write_lock);
+	} else {
+		spin_lock_irq(&tc->read_lock);
+		empty = list_empty(&tc->iot_readers);
+		spin_unlock_irq(&tc->read_lock);
+	}
+
+	return empty;
+}
+
+static inline
+void pxd_wait_io(struct thread_context *tc, int rw)
+{
+	if (rw == READ) {
+		wait_event_interruptible(tc->read_event,
+                            !pxd_io_empty(tc, rw) || kthread_should_stop());
+	} else {
+		wait_event_interruptible(tc->write_event,
+                            !pxd_io_empty(tc, rw) || kthread_should_stop());
+	}
+}
+
+static int fastpath_global_threadctx_init(struct thread_context *tc, int cpuid)
+{
+	int i;
+	int err;
+	int node = cpu_to_node(cpuid);
+
+	spin_lock_init(&tc->read_lock);
+	init_waitqueue_head(&tc->read_event);
+	INIT_LIST_HEAD(&tc->iot_readers);
+
+	spin_lock_init(&tc->write_lock);
+	init_waitqueue_head(&tc->write_event);
+	INIT_LIST_HEAD(&tc->iot_writers);
+
+	// setup readers
+	for (i = 0; i < PXD_MAX_THREAD_PER_CPU; i++) {
+		// set dedicated thread function
+		tc->reader[i] = kthread_create_on_node(pxd_io_reader, tc,
+				node, "pxwr%d:%d:%d", node, cpuid, i);
+		if (IS_ERR(tc->reader[i])) {
+			pxd_printk("Init global reader kthread for cpu %d failed %lu\n",
+				cpuid, PTR_ERR(tc->reader[i]));
+			err = -EINVAL;
+			goto fail_rd;
+		}
+
+		//  bind readers on any cpu but on same numa node
+		set_cpus_allowed_ptr(tc->reader[i], cpumask_of_node(node));
+		set_user_nice(tc->reader[i], MIN_NICE);
+		wake_up_process(tc->reader[i]);
+	}
+
+	// setup writers
+	for (i = 0; i < PXD_MAX_THREAD_PER_CPU; i++) {
+		// set dedicated thread function
+		tc->writer[i] = kthread_create_on_node(pxd_io_writer, tc,
+				node, "pxrd%d:%d:%d", node, cpuid, i);
+		if (IS_ERR(tc->writer[i])) {
+			pxd_printk("Init global writer kthread for cpu %d failed %lu\n",
+				cpuid, PTR_ERR(tc->writer[i]));
+			err = -EINVAL;
+			goto fail_wr;
+		}
+
+		//  bind all writers on the same cpu
+		kthread_bind(tc->writer[i], cpuid);
+		set_user_nice(tc->writer[i], MIN_NICE);
+		wake_up_process(tc->writer[i]);
+	}
+
+	return 0;
+
+fail_wr:
+	for(;i >= 0; i--) {
+		if (tc->writer[i]) kthread_stop(tc->writer[i]);
+	}
+	i = PXD_MAX_THREAD_PER_CPU;
+fail_rd:
+	for(;i >= 0; i--) {
+		if (tc->reader[i]) kthread_stop(tc->reader[i]);
+	}
+	return err;
+}
+
+static void fastpath_global_threadctx_cleanup(void)
+{
+	int i,t;
+	struct pxd_io_tracker *head;
+	struct thread_context *tc;
+
+	if (!g_tc) return;
+
+	for (i = 0; i < __px_ncpus; i++) {
+		tc = &g_tc[i];
+		for (t=0;t<PXD_MAX_THREAD_PER_CPU; t++) {
+			if (tc->writer[t]) kthread_stop(tc->writer[t]);
+			if (tc->reader[t]) kthread_stop(tc->reader[t]);
+		}
+
+		// fail all enqueue'd IOs
+		while ((head = pxd_get_readio(tc)) != NULL) {
+			if (head->orig) BIO_ENDIO(head->orig, -ENXIO);
+			__pxd_cleanup_block_io(head);
+		}
+
+		while ((head = pxd_get_writeio(tc)) != NULL) {
+			if (head->orig) BIO_ENDIO(head->orig, -ENXIO);
+			__pxd_cleanup_block_io(head);
+		}
+	}
+}
+
+int fastpath_init(void)
+{
+	int i, err;
+
+	// cache the count of cpu information at module load time.
+	// if there is any subsequent hot plugging of cpus, will still handle gracefully.
+	__px_ncpus = nr_cpu_ids;
+
+	printk(KERN_INFO"CPU %d/%d, NUMA nodes %d/%d\n", __px_ncpus, NR_CPUS, nr_node_ids, MAX_NUMNODES);
+	g_tc = kzalloc(sizeof(struct thread_context) * __px_ncpus, GFP_KERNEL);
+	if (!g_tc) {
+		printk(KERN_ERR "pxd: failed to initialize global thread context: -ENOMEM\n");
+		return -ENOMEM;
+	}
+
+	// capturing all the cpu's on a given numa node during run-time
+	for (i = 0; i < __px_ncpus; i++) {
+		// initialize global thread context
+		err = fastpath_global_threadctx_init(&g_tc[i], i);
+		if (err) {
+			fastpath_global_threadctx_cleanup();
+			kfree(g_tc);
+			return err;
+		}
+	}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0)
+	if (bioset_init(&pxd_bio_set, PXD_MIN_POOL_PAGES,
+			offsetof(struct pxd_io_tracker, clone), 0)) {
+		printk(KERN_ERR "pxd: failed to initialize bioset_init: -ENOMEM\n");
+		fastpath_global_threadctx_cleanup();
+		kfree(g_tc);
+		return -ENOMEM;
+	}
+	ppxd_bio_set = &pxd_bio_set;
+#else
+	ppxd_bio_set = BIOSET_CREATE(PXD_MIN_POOL_PAGES, offsetof(struct pxd_io_tracker, clone));
+#endif
+
+	if (!ppxd_bio_set) {
+		printk(KERN_ERR "pxd: bioset init failed");
+		fastpath_global_threadctx_cleanup();
+		kfree(g_tc);
+		return -ENOMEM;
+	}
+
+	return 0;
+}
+
+void fastpath_cleanup(void)
+{
+	fastpath_global_threadctx_cleanup();
+
+	if (ppxd_bio_set) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0)
+		bioset_exit(ppxd_bio_set);
+#else
+		bioset_free(ppxd_bio_set);
+#endif
+	}
+
+	if (g_tc) kfree(g_tc);
+	ppxd_bio_set = NULL;
+	g_tc = NULL;
+}
+
+static int _pxd_flush(struct pxd_device *pxd_dev, struct file *file)
+{
+	int ret = 0;
+
+	// pxd_dev is opened in o_sync mode. all writes are complete with implicit sync.
+	// explicit sync can be treated nop
+	if (pxd_dev->mode & O_SYNC) {
+		atomic_inc(&pxd_dev->fp.nio_flush_nop);
+		return 0;
+	}
+
+	ret = vfs_fsync(file, 0);
+	if (unlikely(ret && ret != -EINVAL && ret != -EIO)) {
+		ret = -EIO;
+	}
+	atomic_inc(&pxd_dev->fp.nio_flush);
+	atomic_set(&pxd_dev->fp.nwrite_counter, 0);
+	return ret;
+}
+
+static int pxd_should_flush(struct pxd_device *pxd_dev, int *active)
+{
+	*active = atomic_read(&pxd_dev->fp.nsync_active);
+	if (pxd_dev->fp.bg_flush_enabled &&
+		(atomic_read(&pxd_dev->fp.nwrite_counter) > pxd_dev->fp.n_flush_wrsegs) &&
+		!*active) {
+		atomic_set(&pxd_dev->fp.nsync_active, 1);
+		return 1;
+	}
+	return 0;
+}
+
+static void pxd_issue_sync(struct pxd_device *pxd_dev, struct file *file)
+{
+	struct block_device *bdev = bdget_disk(pxd_dev->disk, 0);
+	int ret;
+
+	if (!bdev) return;
+
+	ret = vfs_fsync(file, 0);
+	if (unlikely(ret && ret != -EINVAL && ret != -EIO)) {
+		printk(KERN_WARNING"device %llu fsync failed with %d\n",
+				pxd_dev->dev_id, ret);
+	}
+
+	spin_lock_irq(&pxd_dev->fp.sync_lock);
+	atomic_set(&pxd_dev->fp.nwrite_counter, 0);
+	atomic_set(&pxd_dev->fp.nsync_active, 0);
+	atomic_inc(&pxd_dev->fp.nsync);
+	spin_unlock_irq(&pxd_dev->fp.sync_lock);
+
+	wake_up(&pxd_dev->fp.sync_event);
+}
+
+static void pxd_check_write_cache_flush(struct pxd_device *pxd_dev, struct file *file)
+{
+	int sync_wait, sync_now;
+	spin_lock_irq(&pxd_dev->fp.sync_lock);
+	sync_now = pxd_should_flush(pxd_dev, &sync_wait);
+
+	if (sync_wait) {
+		wait_event_lock_irq(pxd_dev->fp.sync_event,
+				!atomic_read(&pxd_dev->fp.nsync_active),
+				pxd_dev->fp.sync_lock);
+	}
+	spin_unlock_irq(&pxd_dev->fp.sync_lock);
+
+	if (sync_now) pxd_issue_sync(pxd_dev, file);
+}
+
+static int _pxd_bio_discard(struct pxd_device *pxd_dev, struct file *file, struct bio *bio, loff_t pos)
+{
+	int mode = FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE;
+	int ret;
+
+	atomic_inc(&pxd_dev->fp.nio_discard);
+
+	if ((!file->f_op->fallocate)) {
+		return -EOPNOTSUPP;
+	}
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
+	ret = file->f_op->fallocate(file, mode, pos, bio->bi_iter.bi_size);
+#else
+	ret = file->f_op->fallocate(file, mode, pos, bio->bi_size);
+#endif
+	if (unlikely(ret && ret != -EINVAL && ret != -EOPNOTSUPP))
+		return -EIO;
+
+	return 0;
+}
+
+static int _pxd_write(uint64_t dev_id, struct file *file, struct bio_vec *bvec, loff_t *pos)
+{
+	ssize_t bw;
+	mm_segment_t old_fs = get_fs();
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
+	struct iov_iter i;
+#else
+	void *kaddr = kmap(bvec->bv_page) + bvec->bv_offset;
+#endif
+
+	pxd_printk("device %llu pxd_write entry offset %lld, length %d entered\n",
+			dev_id, *pos, bvec->bv_len);
+
+	if (unlikely(bvec->bv_len != PXD_LBS)) {
+		printk(KERN_ERR"Unaligned block writes %d bytes\n", bvec->bv_len);
+	}
+	set_fs(get_ds());
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,20,0)
+	iov_iter_bvec(&i, WRITE, bvec, 1, bvec->bv_len);
+	file_start_write(file);
+	bw = vfs_iter_write(file, &i, pos, 0);
+	file_end_write(file);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+	iov_iter_bvec(&i, ITER_BVEC | WRITE, bvec, 1, bvec->bv_len);
+	file_start_write(file);
+	bw = vfs_iter_write(file, &i, pos, 0);
+	file_end_write(file);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
+	iov_iter_bvec(&i, ITER_BVEC | WRITE, bvec, 1, bvec->bv_len);
+	file_start_write(file);
+	bw = vfs_iter_write(file, &i, pos);
+	file_end_write(file);
+#else
+	bw = vfs_write(file, kaddr, bvec->bv_len, pos);
+	kunmap(bvec->bv_page);
+#endif
+	set_fs(old_fs);
+
+	if (likely(bw == bvec->bv_len)) {
+		return 0;
+	}
+
+	printk(KERN_ERR "device %llu Write error at byte offset %llu, length %i.\n",
+                        dev_id, (unsigned long long)*pos, bvec->bv_len);
+	if (bw >= 0) bw = -EIO;
+	return bw;
+}
+
+static int pxd_send(struct pxd_device *pxd_dev, struct file *file, struct bio *bio, loff_t pos)
+{
+	int ret = 0;
+	int nsegs = 0;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
+	struct bio_vec bvec;
+	struct bvec_iter i;
+#else
+	struct bio_vec *bvec;
+	int i;
+#endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
+	bio_for_each_segment(bvec, bio, i) {
+		nsegs++;
+		ret = _pxd_write(pxd_dev->dev_id, file, &bvec, &pos);
+		if (ret < 0) {
+			printk(KERN_ERR"do_pxd_write pos %lld page %p, off %u for len %d FAILED %d\n",
+				pos, bvec.bv_page, bvec.bv_offset, bvec.bv_len, ret);
+			return ret;
+		}
+
+		cond_resched();
+	}
+#else
+	bio_for_each_segment(bvec, bio, i) {
+		nsegs++;
+		ret = _pxd_write(pxd_dev->dev_id, file, bvec, &pos);
+		if (ret < 0) {
+			pxd_printk("device %llu: do_pxd_write pos %lld page %p, off %u for len %d FAILED %d\n",
+				pxd_dev->dev_id, pos, bvec->bv_page, bvec->bv_offset, bvec->bv_len, ret);
+			return ret;
+		}
+
+		cond_resched();
+	}
+#endif
+	atomic_add(nsegs, &pxd_dev->fp.nwrite_counter);
+	atomic_inc(&pxd_dev->fp.nio_write);
+	return 0;
+}
+
+static
+ssize_t _pxd_read(uint64_t dev_id, struct file *file, struct bio_vec *bvec, loff_t *pos)
+{
+	int result = 0;
+
+    /* read from file at offset pos into the buffer */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,20,0)
+	struct iov_iter i;
+
+	iov_iter_bvec(&i, READ, bvec, 1, bvec->bv_len);
+	result = vfs_iter_read(file, &i, pos, 0);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+	struct iov_iter i;
+
+	iov_iter_bvec(&i, ITER_BVEC|READ, bvec, 1, bvec->bv_len);
+	result = vfs_iter_read(file, &i, pos, 0);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
+	struct iov_iter i;
+
+	iov_iter_bvec(&i, ITER_BVEC|READ, bvec, 1, bvec->bv_len);
+	result = vfs_iter_read(file, &i, pos);
+#else
+	mm_segment_t old_fs = get_fs();
+	void *kaddr = kmap(bvec->bv_page) + bvec->bv_offset;
+
+	set_fs(get_ds());
+	result = vfs_read(file, kaddr, bvec->bv_len, pos);
+	set_fs(old_fs);
+	kunmap(bvec->bv_page);
+#endif
+	if (result < 0)
+		printk(KERN_ERR "device %llu: __vfs_read return %d\n", dev_id, result);
+	return result;
+}
+
+static ssize_t pxd_receive(struct pxd_device *pxd_dev, struct file *file, struct bio *bio, loff_t *pos)
+{
+	ssize_t s;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
+	struct bio_vec bvec;
+	struct bvec_iter i;
+#else
+	struct bio_vec *bvec;
+	int i;
+#endif
+
+	bio_for_each_segment(bvec, bio, i) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
+		s = _pxd_read(pxd_dev->dev_id, file, &bvec, pos);
+		if (s < 0) return s;
+
+		if (s != bvec.bv_len) {
+			zero_fill_bio(bio);
+			break;
+		}
+#else
+		s = _pxd_read(pxd_dev->dev_id, file, bvec, pos);
+		if (s < 0) return s;
+
+		if (s != bvec->bv_len) {
+			zero_fill_bio(bio);
+			break;
+		}
+#endif
+	}
+	return 0;
+}
+
+static void __pxd_cleanup_block_io(struct pxd_io_tracker *head)
+{
+	while (!list_empty(&head->replicas)) {
+		struct pxd_io_tracker *repl = list_first_entry(&head->replicas, struct pxd_io_tracker, item);
+		pxd_printk("__pxd_cleanup_block_io for head %p, repl %p\n", head, repl);
+		list_del(&repl->item);
+		bio_put(&repl->clone);
+	}
+
+	pxd_printk("__pxd_cleanup_block_io freeing head %p\n", head);
+	bio_put(&head->clone);
+}
+
+static void pxd_complete_io(struct bio* bio)
+{
+	struct pxd_io_tracker *iot = container_of(bio, struct pxd_io_tracker, clone);
+	struct pxd_device *pxd_dev = bio->bi_private;
+	struct pxd_io_tracker *head = iot->head;
+
+	pxd_io_printk("%s: dev m %d g %lld %s at %ld len %d bytes %d pages "
+			"flags 0x%x op %#x op_flags 0x%x\n", __func__,
+			pxd_dev->minor, pxd_dev->dev_id,
+			bio_data_dir(bio) == WRITE ? "wr" : "rd",
+			BIO_SECTOR(bio) * SECTOR_SIZE, BIO_SIZE(bio),
+			bio->bi_vcnt, bio->bi_flags,
+			(bio->bi_opf & REQ_OP_MASK),
+			((bio->bi_opf & ~REQ_OP_MASK) >> REQ_OP_BITS));
+
+	pxd_printk("pxd_complete_io for bio %p (pxd %p) with head %p active %d\n",
+			bio, pxd_dev, head, atomic_read(&head->active));
+
+	if (!atomic_dec_and_test(&head->active)) {
+		// not all responses have come back
+		// but update head status if this is a failure
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
+		if (bio->bi_status) {
+			atomic_inc(&head->fails);
+		}
+#else
+		if (bio->bi_error) {
+			atomic_inc(&head->fails);
+		}
+#endif
+		pxd_printk("pxd_complete_io for bio %p (pxd %p) with head %p active %d error %d early return\n",
+			bio, pxd_dev, head, atomic_read(&head->active), atomic_read(&head->fails));
+
+		return;
+	}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
+	generic_end_io_acct(pxd_dev->disk->queue, bio_op(bio), &pxd_dev->disk->part0, iot->start);
+#else
+	generic_end_io_acct(bio_data_dir(bio), &pxd_dev->disk->part0, iot->start);
+#endif
+
+	pxd_printk("pxd_complete_io for bio %p (pxd %p) with head %p active %d - completing orig %p\n",
+			bio, pxd_dev, head, atomic_read(&head->active), iot->orig);
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
+{
+	iot->orig->bi_status = bio->bi_status;
+	if (atomic_read(&head->fails)) {
+		iot->orig->bi_status = -EIO; // mark failure
+	}
+	bio_endio(iot->orig);
+}
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
+{
+	int status = bio->bi_error;
+	if (atomic_read(&head->fails)) {
+		status = -EIO; // mark failure
+	}
+	if (status) {
+		bio_io_error(iot->orig);
+	} else {
+		bio_endio(iot->orig);
+	}
+}
+#else
+{
+	int status = bio->bi_error;
+	if (atomic_read(&head->fails)) {
+		status = -EIO; // mark failure
+	}
+	bio_endio(iot->orig, status);
+}
+#endif
+
+	__pxd_cleanup_block_io(head);
+
+	atomic_dec(&pxd_dev->fp.ncount);
+	atomic_inc(&pxd_dev->fp.ncomplete);
+}
+
+static struct pxd_io_tracker* __pxd_init_block_replica(struct pxd_device *pxd_dev,
+		struct bio *bio, struct file *fileh) {
+	struct bio* clone_bio;
+	struct pxd_io_tracker* iot;
+	struct address_space *mapping = fileh->f_mapping;
+	struct inode *inode = mapping->host;
+	struct block_device *bdi = I_BDEV(inode);
+
+	pxd_printk("pxd %p:__pxd_init_block_replica entering with bio %p, fileh %p with blkg %p\n",
+			pxd_dev, bio, fileh, bio->bi_blkg);
+
+	clone_bio = bio_clone_fast(bio, GFP_KERNEL, ppxd_bio_set);
+	if (!clone_bio) {
+		pxd_printk(KERN_ERR"No memory for io context");
+		return NULL;
+	}
+
+	iot = container_of(clone_bio, struct pxd_io_tracker, clone);
+
+	iot->pxd_dev = pxd_dev;
+	iot->head = iot;
+	INIT_LIST_HEAD(&iot->replicas);
+	INIT_LIST_HEAD(&iot->item);
+	iot->orig = bio;
+	iot->start = jiffies;
+	atomic_set(&iot->active, 0);
+	atomic_set(&iot->fails, 0);
+	iot->file = fileh;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)
+	iot->read = (bio_op(bio) == REQ_OP_READ);
+#else
+	iot->read = (bio_data_dir(bio) == READ);
+#endif
+
+	pxd_printk("pxd %p:__pxd_init_block_replica clone bio %p (blkg %p), resetting backing block dev to %p\n",
+			pxd_dev, clone_bio, clone_bio->bi_blkg, bdi);
+
+	if (S_ISBLK(inode->i_mode)) {
+		BIO_SET_DEV(clone_bio, bdi);
+	}
+	clone_bio->bi_private = pxd_dev;
+	clone_bio->bi_end_io = pxd_complete_io;
+
+	pxd_printk("pxd %p:__pxd_init_block_replica allocated repl %p for orig bio %p\n",
+			pxd_dev, iot, bio);
+
+	return iot;
+}
+
+static
+struct pxd_io_tracker* __pxd_init_block_head(struct pxd_device *pxd_dev, struct bio* bio) {
+	struct pxd_io_tracker* head;
+	struct pxd_io_tracker *repl;
+	int index;
+
+	pxd_printk("pxd %p:__pxd_init_block_replica to allocate iotracker for bio %p\n",
+			pxd_dev, bio);
+
+	head = __pxd_init_block_replica(pxd_dev, bio, pxd_dev->fp.file[0]);
+	if (!head) {
+		return NULL;
+	}
+	// initialize the replicas only if the request is non-read
+	if (!head->read) {
+		for (index=1; index<pxd_dev->fp.nfd; index++) {
+			repl = __pxd_init_block_replica(pxd_dev, bio, pxd_dev->fp.file[index]);
+			if (!repl) {
+				goto repl_cleanup;
+			}
+
+			repl->head = head;
+			list_add(&repl->item, &head->replicas);
+		}
+	}
+
+	pxd_printk("pxd %p:__pxd_init_block_head allocated head %p for orig bio %p nfd %d\n",
+			pxd_dev, head, bio, pxd_dev->fp.nfd);
+	return head;
+
+repl_cleanup:
+	__pxd_cleanup_block_io(head);
+	return NULL;
+}
+
+static void _pxd_setup(struct pxd_device *pxd_dev, bool enable)
+{
+	if (!enable) {
+		printk(KERN_NOTICE "device %llu called to disable IO\n", pxd_dev->dev_id);
+		pxd_dev->connected = false;
+	} else {
+		printk(KERN_NOTICE "device %llu called to enable IO\n", pxd_dev->dev_id);
+	}
+
+	if (enable) {
+		spin_lock_irq(&pxd_dev->lock);
+		enableFastPath(pxd_dev, true);
+		spin_unlock_irq(&pxd_dev->lock);
+	}
+
+	if (enable) pxd_dev->connected = true;
+}
+
+void pxdctx_set_connected(struct pxd_context *ctx, bool enable)
+{
+	struct list_head *cur;
+	spin_lock(&ctx->lock);
+	list_for_each(cur, &ctx->list) {
+		struct pxd_device *pxd_dev = container_of(cur, struct pxd_device, node);
+
+		_pxd_setup(pxd_dev, enable);
+	}
+	spin_unlock(&ctx->lock);
+}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)
+static int __do_bio_filebacked(struct pxd_device *pxd_dev, struct pxd_io_tracker *iot)
+{
+	struct bio *bio = &iot->clone;
+	loff_t pos;
+	unsigned int op = bio_op(bio);
+	int ret;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
+	generic_start_io_acct(pxd_dev->disk->queue, bio_op(bio), REQUEST_GET_SECTORS(bio), &pxd_dev->disk->part0);
+#else
+	generic_start_io_acct(bio_data_dir(bio), REQUEST_GET_SECTORS(bio), &pxd_dev->disk->part0);
+#endif
+
+	pxd_printk("do_bio_filebacked for new bio (pending %u)\n",
+				atomic_read(&pxd_dev->fp.ncount));
+	pos = ((loff_t) bio->bi_iter.bi_sector << SECTOR_SHIFT);
+
+	switch (op) {
+	case REQ_OP_READ:
+		ret = pxd_receive(pxd_dev, iot->file, bio, &pos);
+		goto out;
+	case REQ_OP_WRITE:
+
+		if (bio->bi_opf & REQ_PREFLUSH) {
+			atomic_inc(&pxd_dev->fp.nio_preflush);
+			ret = _pxd_flush(pxd_dev, iot->file);
+			if (ret < 0) goto out;
+		}
+
+		/* Before any newer writes happen, make sure previous write/sync complete */
+		pxd_check_write_cache_flush(pxd_dev, iot->file);
+
+		ret = pxd_send(pxd_dev, iot->file, bio, pos);
+		if (ret < 0) goto out;
+
+		if (bio->bi_opf & REQ_FUA) {
+			atomic_inc(&pxd_dev->fp.nio_fua);
+			ret = _pxd_flush(pxd_dev, iot->file);
+			if (ret < 0) goto out;
+		}
+
+		ret = 0; goto out;
+
+	case REQ_OP_FLUSH:
+		ret = _pxd_flush(pxd_dev, iot->file);
+		goto out;
+	case REQ_OP_DISCARD:
+	case REQ_OP_WRITE_ZEROES:
+		ret = _pxd_bio_discard(pxd_dev, iot->file, bio, pos);
+		goto out;
+	default:
+		WARN_ON_ONCE(1);
+		ret = -EIO;
+		goto out;
+	}
+
+out:
+	if (ret < 0) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
+		bio->bi_status = ret;
+#else
+		bio->bi_error = ret;
+#endif
+	}
+	pxd_complete_io(bio);
+
+	return ret;
+}
+
+#else
+static int __do_bio_filebacked(struct pxd_device *pxd_dev, struct pxd_io_tracker *iot)
+{
+	loff_t pos;
+	int ret;
+	struct bio *bio = &iot->clone;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
+	pos = ((loff_t) bio->bi_iter.bi_sector << SECTOR_SHIFT);
+#else
+	pos = ((loff_t) bio->bi_sector << SECTOR_SHIFT);
+#endif
+
+	// mark status all good to begin with!
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
+	bio->bi_status = 0;
+#else
+	bio->bi_error = 0;
+#endif
+	if (bio_data_dir(bio) == WRITE) {
+		pxd_printk("bio bi_rw %#lx, flush %#llx, fua %#llx, discard %#llx\n",
+				bio->bi_rw, REQ_FLUSH, REQ_FUA, REQ_DISCARD);
+
+		if (bio->bi_rw & REQ_DISCARD) {
+			ret = _pxd_bio_discard(pxd_dev, iot->file, bio, pos);
+			goto out;
+		}
+		/* Before any newer writes happen, make sure previous write/sync complete */
+		pxd_check_write_cache_flush(pxd_dev, iot->file);
+		ret = pxd_send(pxd_dev, iot->file, bio, pos);
+
+		if (!ret) {
+			if ((bio->bi_rw & REQ_FUA)) {
+				atomic_inc(&pxd_dev->fp.nio_fua);
+				ret = _pxd_flush(pxd_dev, iot->file);
+				if (ret < 0) goto out;
+			} else if ((bio->bi_rw & REQ_FLUSH)) {
+				ret = _pxd_flush(pxd_dev, iot->file);
+				if (ret < 0) goto out;
+			}
+		}
+
+	} else {
+		ret = pxd_receive(pxd_dev, iot->file, bio, &pos);
+	}
+
+out:
+	if (ret < 0) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
+		bio->bi_status = ret;
+#else
+		bio->bi_error = ret;
+#endif
+	}
+	pxd_complete_io(bio);
+
+	return ret;
+}
+
+#endif
+
+static inline int pxd_handle_io(struct thread_context *tc, struct pxd_io_tracker *head)
+{
+	struct pxd_device *pxd_dev = head->pxd_dev;
+	struct bio *bio = head->orig;
+
+	//
+	// Based on the nfd mapped on pxd_dev, that many cloned bios shall be
+	// setup, then each replica takes its own processing path, which could be
+	// either file backup or block device backup.
+	//
+	struct pxd_io_tracker *curr;
+
+	// NOTE NOTE NOTE accessing out of lock
+	if (!pxd_dev->connected) {
+		printk(KERN_ERR"px is disconnected, failing IO.\n");
+		__pxd_cleanup_block_io(head);
+		BIO_ENDIO(bio, -ENXIO);
+		return -ENXIO;
+	}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
+	generic_start_io_acct(pxd_dev->disk->queue, bio_op(bio), REQUEST_GET_SECTORS(bio), &pxd_dev->disk->part0);
+#else
+	generic_start_io_acct(bio_data_dir(bio), REQUEST_GET_SECTORS(bio), &pxd_dev->disk->part0);
+#endif
+
+	// initialize active io to configured replicas
+	if (!head->read) {
+		atomic_set(&head->active, pxd_dev->fp.nfd);
+		// submit all replicas linked from head, if not read
+		list_for_each_entry(curr, &head->replicas, item) {
+			if (S_ISBLK(curr->file->f_inode->i_mode)) {
+				SUBMIT_BIO(&curr->clone);
+				atomic_inc(&pxd_dev->fp.nswitch);
+			} else {
+				__do_bio_filebacked(pxd_dev, curr);
+			}
+		}
+	} else {
+		atomic_set(&head->active, 1);
+	}
+
+	// submit head bio the last
+	if (S_ISBLK(head->file->f_inode->i_mode)) {
+		SUBMIT_BIO(&head->clone);
+		atomic_inc(&pxd_dev->fp.nswitch);
+	} else {
+		__do_bio_filebacked(pxd_dev, head);
+	}
+
+	return 0; // all good
+}
+
+static void pxd_add_io(struct thread_context *tc, struct pxd_io_tracker *head, int rw)
+{
+	if (rw != READ) {
+		spin_lock_irq(&tc->write_lock);
+		list_add(&head->item, &tc->iot_writers);
+		spin_unlock_irq(&tc->write_lock);
+		wake_up(&tc->write_event);
+	} else {
+		spin_lock_irq(&tc->read_lock);
+		list_add(&head->item, &tc->iot_readers);
+		spin_unlock_irq(&tc->read_lock);
+
+		wake_up(&tc->read_event);
+	}
+}
+
+static struct pxd_io_tracker* pxd_get_io(struct thread_context *tc, int rw)
+{
+	struct pxd_io_tracker* head = NULL;
+
+	if (rw != READ) {
+		spin_lock_irq(&tc->write_lock);
+		if (!list_empty(&tc->iot_writers)) {
+			head = list_first_entry(&tc->iot_writers, struct pxd_io_tracker, item);
+			list_del(&head->item);
+		}
+		spin_unlock_irq(&tc->write_lock);
+	} else {
+		spin_lock_irq(&tc->read_lock);
+		if (!list_empty(&tc->iot_readers)) {
+			head = list_first_entry(&tc->iot_readers, struct pxd_io_tracker, item);
+			list_del(&head->item);
+		}
+		spin_unlock_irq(&tc->read_lock);
+	}
+
+	return head;
+}
+
+static int pxd_io_thread(void *data, int rw)
+{
+	struct thread_context *tc = data;
+	struct pxd_io_tracker *head;
+
+	while (!kthread_should_stop()) {
+		pxd_wait_io(tc, rw);
+
+		head = pxd_get_io(tc, rw);
+		if (!head) {
+			continue;
+		}
+
+		if (unlikely(pxd_handle_io(tc, head) != 0)) {
+			/* if early fail, then force wakeup */
+
+			struct pxd_device *pxd_dev = head->pxd_dev;
+			BUG_ON(!pxd_dev);
+
+			atomic_dec(&pxd_dev->fp.ncount);
+			atomic_inc(&pxd_dev->fp.ncomplete);
+		}
+	}
+	return 0;
+}
+
+static int pxd_io_reader(void *data)
+{
+	return pxd_io_thread(data, READ);
+}
+
+static int pxd_io_writer(void *data)
+{
+	return pxd_io_thread(data, WRITE);
+}
+
+static void pxd_suspend_io(struct pxd_device *pxd_dev)
+{
+	int need_flush = 0;
+	spin_lock_irq(&pxd_dev->fp.suspend_lock);
+	if (!pxd_dev->fp.suspend++) {
+		printk("For pxd device %llu IO suspended\n", pxd_dev->dev_id);
+		need_flush = 1;
+	} else {
+		printk("For pxd device %llu IO already suspended\n", pxd_dev->dev_id);
+	}
+	spin_unlock_irq(&pxd_dev->fp.suspend_lock);
+
+	// need to wait for inflight IOs to complete
+	if (need_flush) {
+		do {
+			int nactive = atomic_read(&pxd_dev->fp.ncount);
+			if (!nactive) break;
+			printk(KERN_WARNING"pxd device %llu still has %d active IO, waiting completion to suspend",
+					pxd_dev->dev_id, nactive);
+			msleep_interruptible(100);
+		} while (1);
+	}
+}
+
+static void pxd_resume_io(struct pxd_device *pxd_dev)
+{
+	spin_lock_irq(&pxd_dev->fp.suspend_lock);
+	pxd_dev->fp.suspend--;
+	if (!pxd_dev->fp.suspend) {
+		printk("For pxd device %llu IO resumed\n", pxd_dev->dev_id);
+		wake_up(&pxd_dev->fp.suspend_wait);
+	} else {
+		printk("For pxd device %llu IO still suspended(%d)\n",
+				pxd_dev->dev_id, pxd_dev->fp.suspend);
+	}
+	spin_unlock_irq(&pxd_dev->fp.suspend_lock);
+}
+
+/*
+ * shall get called last when new device is added/updated or when fuse connection is lost
+ * and re-estabilished.
+ */
+void enableFastPath(struct pxd_device *pxd_dev, bool force)
+{
+	struct file *f;
+	struct inode *inode;
+	int i;
+	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
+	int nfd = fp->nfd;
+	mode_t mode = open_mode(pxd_dev->mode);
+	char modestr[32];
+
+	pxd_suspend_io(pxd_dev);
+
+	decode_mode(mode, modestr);
+	printk("device %llu mode %s\n", pxd_dev->dev_id, modestr);
+	for (i = 0; i < nfd; i++) {
+		if (fp->file[i] > 0) { /* valid fd exists already */
+			if (force) {
+				filp_close(fp->file[i], NULL);
+				f = filp_open(fp->device_path[i], mode, 0600);
+				if (IS_ERR_OR_NULL(f)) {
+					printk(KERN_ERR"Failed attaching path: device %llu, path %s err %ld\n",
+						pxd_dev->dev_id, fp->device_path[i], PTR_ERR(f));
+					goto out_file_failed;
+				}
+			} else {
+				f = fp->file[i];
+			}
+		} else {
+			f = filp_open(fp->device_path[i], mode, 0600);
+			if (IS_ERR_OR_NULL(f)) {
+				printk(KERN_ERR"Failed attaching path: device %llu, path %s err %ld\n",
+					pxd_dev->dev_id, fp->device_path[i], PTR_ERR(f));
+				goto out_file_failed;
+			}
+		}
+
+		fp->file[i] = f;
+
+		inode = f->f_inode;
+		printk(KERN_INFO"device %lld:%d, inode %lu mode %#x\n", pxd_dev->dev_id, i, inode->i_ino, mode);
+		if (S_ISREG(inode->i_mode)) {
+			printk(KERN_INFO"device[%lld:%d] is a regular file - inode %lu\n",
+					pxd_dev->dev_id, i, inode->i_ino);
+		} else if (S_ISBLK(inode->i_mode)) {
+			printk(KERN_INFO"device[%lld:%d] is a block device - inode %lu\n",
+				pxd_dev->dev_id, i, inode->i_ino);
+		} else {
+			printk(KERN_INFO"device[%lld:%d] inode %lu unknown device %#x\n",
+				pxd_dev->dev_id, i, inode->i_ino, inode->i_mode);
+		}
+	}
+
+	pxd_resume_io(pxd_dev);
+
+	printk(KERN_INFO"pxd_dev %llu mode %#x setting up with %d backing volumes, [%p,%p,%p]\n",
+		pxd_dev->dev_id, mode, fp->nfd,
+		fp->file[0], fp->file[1], fp->file[2]);
+
+	return;
+
+out_file_failed:
+	fp->nfd = 0;
+	for (i = 0; i < nfd; i++) {
+		if (fp->file[i] > 0) filp_close(fp->file[i], NULL);
+	}
+	memset(fp->file, 0, sizeof(fp->file));
+	memset(fp->device_path, 0, sizeof(fp->device_path));
+
+	pxd_resume_io(pxd_dev);
+	printk(KERN_INFO"Device %llu no backing volume setup, will take slow path\n",
+		pxd_dev->dev_id);
+}
+
+void disableFastPath(struct pxd_device *pxd_dev)
+{
+	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
+	int nfd = fp->nfd;
+	int i;
+
+	pxd_suspend_io(pxd_dev);
+
+	for (i = 0; i < nfd; i++) {
+		if (fp->file[i] > 0) filp_close(fp->file[i], NULL);
+	}
+	fp->nfd=0;
+
+	pxd_resume_io(pxd_dev);
+}
+
+int pxd_fastpath_init(struct pxd_device *pxd_dev)
+{
+	int i;
+	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
+
+	fp->nfd = 0; // will take slow path, if additional info not provided.
+
+	pxd_printk("Number of cpu ids %d\n", __px_ncpus);
+#if 0
+	// configure bg flush based on passed mode of operation
+	if (pxd_dev->mode & O_DIRECT) {
+		fp->bg_flush_enabled = false; // avoids high latency
+		printk("For pxd device %llu background flush disabled\n", pxd_dev->dev_id);
+	} else {
+		fp->bg_flush_enabled = true; // introduces high latency
+		printk("For pxd device %llu background flush enabled\n", pxd_dev->dev_id);
+	}
+#else
+	fp->bg_flush_enabled = false; // avoids high latency
+#endif
+
+	fp->n_flush_wrsegs = MAX_WRITESEGS_FOR_FLUSH;
+
+	// device temporary IO suspend
+	init_waitqueue_head(&fp->suspend_wait);
+	spin_lock_init(&fp->suspend_lock);
+	fp->suspend = 0;
+
+	// congestion init
+	// hard coded congestion limits within driver
+	fp->congested = false;
+	fp->qdepth = DEFAULT_CONGESTION_THRESHOLD;
+	fp->nr_congestion_on = 0;
+	fp->nr_congestion_off = 0;
+
+	init_waitqueue_head(&fp->sync_event);
+	spin_lock_init(&fp->sync_lock);
+
+	atomic_set(&fp->nsync_active, 0);
+	atomic_set(&fp->nsync, 0);
+	atomic_set(&fp->nio_discard, 0);
+	atomic_set(&fp->nio_flush, 0);
+	atomic_set(&fp->nio_flush_nop, 0);
+	atomic_set(&fp->nio_preflush, 0);
+	atomic_set(&fp->nio_fua, 0);
+	atomic_set(&fp->nio_write, 0);
+	atomic_set(&fp->ncount,0);
+	atomic_set(&fp->nswitch,0);
+	atomic_set(&fp->nslowPath,0);
+	atomic_set(&fp->ncomplete,0);
+	atomic_set(&fp->nwrite_counter,0);
+
+	for (i = 0; i < nr_node_ids; i++) {
+		atomic_set(&fp->index[i], 0);
+	}
+
+	enableFastPath(pxd_dev, true);
+
+	return 0;
+}
+
+void pxd_fastpath_cleanup(struct pxd_device *pxd_dev)
+{
+	disableFastPath(pxd_dev);
+}
+
+int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path)
+{
+	mode_t mode = 0;
+	int err = 0;
+	int i;
+	struct file* f;
+
+	mode = open_mode(pxd_dev->mode);
+	for (i = 0; i < update_path->size; i++) {
+		if (!strcmp(pxd_dev->fp.device_path[i], update_path->devpath[i])) {
+			// if previous paths are same.. then skip anymore config
+			printk(KERN_INFO"pxd%llu already configured for path %s\n",
+				pxd_dev->dev_id, pxd_dev->fp.device_path[i]);
+			continue;
+		}
+
+		if (pxd_dev->fp.file[i] > 0) filp_close(pxd_dev->fp.file[i], NULL);
+		f = filp_open(update_path->devpath[i], mode, 0600);
+		if (IS_ERR_OR_NULL(f)) {
+			printk(KERN_ERR"Failed attaching path: device %llu, path %s, err %ld\n",
+				pxd_dev->dev_id, update_path->devpath[i], PTR_ERR(f));
+			err = PTR_ERR(f);
+			goto out_file_failed;
+		}
+		pxd_dev->fp.file[i] = f;
+		strncpy(pxd_dev->fp.device_path[i], update_path->devpath[i],MAX_PXD_DEVPATH_LEN);
+		pxd_dev->fp.device_path[i][MAX_PXD_DEVPATH_LEN] = '\0';
+	}
+	pxd_dev->fp.nfd = update_path->size;
+
+	/* setup whether access is block or file access */
+	enableFastPath(pxd_dev, false);
+
+	return 0;
+out_file_failed:
+	for (i = 0; i < pxd_dev->fp.nfd; i++) {
+		if (pxd_dev->fp.file[i] > 0) filp_close(pxd_dev->fp.file[i], NULL);
+	}
+	pxd_dev->fp.nfd = 0;
+	memset(pxd_dev->fp.file, 0, sizeof(pxd_dev->fp.file));
+	memset(pxd_dev->fp.device_path, 0, sizeof(pxd_dev->fp.device_path));
+
+	// even if there are errors setting up fastpath, initialize to take slow path,
+	// do not report failure outside
+	return 0;
+}
+
+/* fast path make request function, io entry point */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
+blk_qc_t pxd_make_request_fastpath(struct request_queue *q, struct bio *bio)
+#else
+void pxd_make_request_fastpath(struct request_queue *q, struct bio *bio)
+#endif
+{
+	struct pxd_device *pxd_dev = q->queuedata;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+	unsigned int rw = bio_op(bio);
+#else
+	unsigned int rw = bio_rw(bio);
+#endif
+	int cpu = smp_processor_id();
+	int thread = cpu % __px_ncpus;
+
+	struct pxd_io_tracker *head;
+	struct thread_context *tc;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+	if (!pxd_dev) {
+#else
+	if (rw == READA) rw = READ;
+	if (!pxd_dev || (rw != READ && rw != WRITE)) {
+#endif
+		printk(KERN_ERR"pxd basic sanity fail, pxd_device %p (%llu), rw %#x\n",
+				pxd_dev, (pxd_dev? pxd_dev->dev_id: (uint64_t)0), rw);
+		bio_io_error(bio);
+		return BLK_QC_RETVAL;
+	}
+
+	if (!pxd_dev->connected) {
+		printk(KERN_ERR"px is disconnected, failing IO.\n");
+		bio_io_error(bio);
+		return BLK_QC_RETVAL;
+	}
+
+	// If IO suspended, then hang IO onto the suspend wait queue
+	{
+		spin_lock_irq(&pxd_dev->fp.suspend_lock);
+		if (pxd_dev->fp.suspend) {
+			printk("pxd device %llu is suspended, IO blocked until device activated[bio %p, wr %d]\n",
+				pxd_dev->dev_id, bio, (bio_data_dir(bio) == WRITE));
+			wait_event_lock_irq(pxd_dev->fp.suspend_wait, !pxd_dev->fp.suspend, pxd_dev->fp.suspend_lock);
+			printk("pxd device %llu re-activated, IO resumed[bio %p, wr %d]\n",
+				pxd_dev->dev_id, bio, (bio_data_dir(bio) == WRITE));
+		}
+		spin_unlock_irq(&pxd_dev->fp.suspend_lock);
+	}
+
+	if (!pxd_dev->fp.nfd) {
+		pxd_printk("px has no backing path yet, should take slow path IO.\n");
+		atomic_inc(&pxd_dev->fp.nslowPath);
+		return pxd_make_request_slowpath(q, bio);
+	}
+
+	pxd_printk("pxd_make_fastpath_request for device %llu queueing with thread %d\n", pxd_dev->dev_id, thread);
+
+	pxd_io_printk("%s: dev m %d g %lld %s at %ld len %d bytes %d pages "
+			"flags 0x%x op %#x op_flags 0x%x\n", __func__,
+			pxd_dev->minor, pxd_dev->dev_id,
+			bio_data_dir(bio) == WRITE ? "wr" : "rd",
+			BIO_SECTOR(bio) * SECTOR_SIZE, BIO_SIZE(bio),
+			bio->bi_vcnt, bio->bi_flags,
+			(bio->bi_opf & REQ_OP_MASK),
+			((bio->bi_opf & ~REQ_OP_MASK) >> REQ_OP_BITS));
+
+#if 0
+	/* keep writes on same cpu, but allow reads to spread but within same numa node */
+	if (rw == READ) {
+		int node = cpu_to_node(cpu);
+		thread = getnextcpu(node, atomic_add_return(1, &pxd_dev->fp.index[node]));
+	}
+#endif
+
+	head = __pxd_init_block_head(pxd_dev, bio);
+	if (!head) {
+		BIO_ENDIO(bio, -ENOMEM);
+
+		// non-trivial high memory pressure failing IO
+		spin_lock_irq(&pxd_dev->lock);
+		atomic_dec(&pxd_dev->fp.ncount);
+		spin_unlock_irq(&pxd_dev->lock);
+
+		return BLK_QC_RETVAL;
+	}
+
+	tc = &g_tc[thread];
+	BUG_ON(!tc);
+	pxd_add_io(tc, head, rw);
+
+	pxd_printk("pxd_make_request for device %llu done\n", pxd_dev->dev_id);
+	return BLK_QC_RETVAL;
+}

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -1,0 +1,130 @@
+#ifndef _PXD_FASTPATH_H_
+#define _PXD_FASTPATH_H_
+
+#include <linux/atomic.h>
+#include <linux/blkdev.h>
+#include <linux/uio.h>
+#include <linux/kthread.h>
+#include <linux/dma-mapping.h>
+#include <linux/statfs.h>
+#include <linux/file.h>
+#include <linux/splice.h>
+#include <linux/fs.h>
+#include <linux/falloc.h>
+#include <linux/bio.h>
+
+// atleast 2 per cpu
+// create two pool of PXD_MAX_THREAD_PER_CPU threads on each cpu, dedicated for writes and reads
+// writer threads are pinned on the same cpu.
+// reader threads are pinned on the same numa node
+#define PXD_MAX_THREAD_PER_CPU (4)
+
+struct pxd_device;
+struct pxd_context;
+
+// A one-time built, static lookup table to distribute requests to cpu within
+// same numa node
+struct node_cpu_map {
+	int cpu[NR_CPUS];
+	int ncpu;
+};
+
+// Added metadata for each bio
+struct pxd_io_tracker {
+	struct pxd_device *pxd_dev; // back pointer to pxd device
+	struct pxd_io_tracker *head; // back pointer to head copy [ALL]
+	struct list_head replicas; // only replica needs this
+	struct list_head item; // only HEAD needs this
+	atomic_t active; // only HEAD has refs to all active IO
+	atomic_t fails; // should be zero, non-zero indicates atleast one path failed
+	struct file* file;
+	int read; // if read is from the first target only
+
+	unsigned long start; // start time [HEAD]
+	struct bio *orig;    // original request bio [HEAD]
+
+	// THIS SHOULD BE LAST ITEM
+	struct bio clone;    // cloned bio [ALL]
+};
+
+struct pxd_device;
+struct thread_context {
+	spinlock_t  	    read_lock;
+	wait_queue_head_t   read_event;
+	struct list_head iot_readers;
+	struct task_struct *reader[PXD_MAX_THREAD_PER_CPU];
+
+	spinlock_t  	    write_lock;
+	wait_queue_head_t   write_event;
+	struct list_head iot_writers;
+	struct task_struct *writer[PXD_MAX_THREAD_PER_CPU];
+};
+
+struct pxd_fastpath_extension {
+	// Extended information
+	int bg_flush_enabled; // dynamically enable bg flush from driver
+	int n_flush_wrsegs; // num of PXD_LBS write segments to force flush
+
+	// Below information has to be set through new PXD_UPDATE_PATH ioctl
+	int nfd;
+	struct file *file[MAX_PXD_BACKING_DEVS];
+	char device_path[MAX_PXD_BACKING_DEVS][MAX_PXD_DEVPATH_LEN+1];
+
+	struct thread_context *tc;
+	unsigned int qdepth;
+	bool congested;
+	unsigned int nr_congestion_on;
+	unsigned int nr_congestion_off;
+
+	// if set, then newer IOs shall block, until reactivated.
+	int suspend;
+	wait_queue_head_t  suspend_wait;
+	spinlock_t suspend_lock;
+
+	wait_queue_head_t   sync_event;
+	spinlock_t   	sync_lock;
+	atomic_t nsync_active; // [global] currently active?
+	atomic_t nsync; // [global] number of forced syncs completed
+	atomic_t nio_discard;
+	atomic_t nio_preflush;
+	atomic_t nio_flush;
+	atomic_t nio_flush_nop;
+	atomic_t nio_fua;
+	atomic_t nio_write;
+	atomic_t ncount; // [global] total active requests, always modify with pxd_dev.lock
+	atomic_t nswitch; // [global] total number of requests through bio switch path
+	atomic_t nslowPath; // [global] total requests through slow path
+	atomic_t ncomplete; // [global] total completed requests
+	atomic_t nwrite_counter; // [global] completed writes, gets cleared on a threshold
+	atomic_t index[MAX_NUMNODES]; // [global] read path IO optimization - last cpu
+};
+
+// global initialization during module init for fastpath
+int fastpath_init(void);
+void fastpath_cleanup(void);
+
+struct pxd_update_path_out;
+int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path);
+
+// per device initialization for fastpath
+int pxd_fastpath_init(struct pxd_device *pxd_dev);
+void pxd_fastpath_cleanup(struct pxd_device *pxd_dev);
+
+void pxdctx_set_connected(struct pxd_context *ctx, bool enable);
+
+// IO entry point
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
+blk_qc_t pxd_make_request_fastpath(struct request_queue *q, struct bio *bio);
+#define BLK_QC_RETVAL BLK_QC_T_NONE
+#else
+void pxd_make_request_fastpath(struct request_queue *q, struct bio *bio);
+#define BLK_QC_RETVAL
+#endif
+
+void enableFastPath(struct pxd_device *pxd_dev, bool force);
+void disableFastPath(struct pxd_device *pxd_dev);
+
+// congestion
+int pxd_device_congested(void *, int);
+
+#endif /* _PXD_FASTPATH_H_ */

--- a/pxd_fastpath_stub.c
+++ b/pxd_fastpath_stub.c
@@ -1,0 +1,27 @@
+/* Enable stub action if fastpath is not enabled */
+#ifndef __PX_FASTPATH__
+
+#include "pxd.h"
+#include "pxd_core.h"
+#include "pxd_fastpath.h"
+
+int pxd_device_congested(void *data, int cond) { return 0; }
+int fastpath_init(void) { return 0; }
+void fastpath_cleanup(void) {}
+
+// per device initialization for fastpath
+int pxd_fastpath_init(struct pxd_device *pxd_dev) { return 0; }
+void pxd_fastpath_cleanup(struct pxd_device *pxd_dev) {}
+
+void pxdctx_set_connected(struct pxd_context *ctx, bool enable) {}
+
+void enableFastPath(struct pxd_device *pxd_dev, bool force) {}
+void disableFastPath(struct pxd_device *pxd_dev) {}
+int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path)
+{
+	// unsupported
+	printk(KERN_WARNING"px driver does not support fastpath - kernel version not supported\n");
+	return 0; // cannot fail
+}
+
+#endif


### PR DESCRIPTION
This is a series of PRs to get fast path driver changes into mainline, revised to latest master again.

This series addresses:
1/ kernel version checks - enable fastpath only if kernel > 4.0
2/ extend to support backing file open mode (direct or buffered etc)
3/ some additional statistics.

This initial PR prepares the fuse driver for fast path integration