### PR TITLE
merge ibm perf patch changes back into review code.

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -905,6 +905,7 @@ ssize_t pxd_update_path(struct fuse_conn *fc, struct pxd_update_path_out *update
 		strncpy(pxd_dev->fp.device_path[i], update_path->devpath[i],MAX_PXD_DEVPATH_LEN);
 		pxd_dev->fp.device_path[i][MAX_PXD_DEVPATH_LEN] = (char) 0;
 	}
+	pxd_dev->fp.nfd = update_path->size;
 
 	/* setup whether access is block or file access */
 	enableFastPath(pxd_dev, false);

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -823,7 +823,7 @@ int pxd_fastpath_init(struct pxd_device *pxd_dev) {
 		// NOTE this has to change for small sized, small queuedepth sync io.
 		// ibm mq issue. Will come in separate PR
 		//
-		kthread_bind(tc->pxd_thread, i);
+		// HACK FOR IBM: kthread_bind(tc->pxd_thread, i);
 		set_user_nice(tc->pxd_thread, MIN_NICE);
 		wake_up_process(tc->pxd_thread);
 	}

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -8,6 +8,7 @@
 // within same numa node
 static struct node_cpu_map *node_cpu_map;
 
+static
 int getnextcpu(int node, int pos) {
 	const struct node_cpu_map *map = &node_cpu_map[node];
 	if (map->ncpu == 0) { return 0; }
@@ -807,11 +808,12 @@ int pxd_fastpath_init(struct pxd_device *pxd_dev) {
 
 	for (i=0; i<MAX_THREADS; i++) {
 		struct thread_context *tc = &fp->tc[i];
+		int node = cpu_to_node(i);
 		tc->pxd_dev = pxd_dev;
 		spin_lock_init(&tc->lock);
 		init_waitqueue_head(&tc->pxd_event);
-		tc->pxd_thread = kthread_create_on_node(pxd_io_thread, tc, cpu_to_node(i),
-				"pxd%d:%llu", i, pxd_dev->dev_id);
+		tc->pxd_thread = kthread_create_on_node(pxd_io_thread, tc,
+				node, "pxd%d:%llu", i, pxd_dev->dev_id);
 		if (IS_ERR(tc->pxd_thread)) {
 			pxd_printk("Init kthread for device %llu failed %lu\n",
 				pxd_dev->dev_id, PTR_ERR(tc->pxd_thread));
@@ -820,10 +822,10 @@ int pxd_fastpath_init(struct pxd_device *pxd_dev) {
 		}
 
 		//
-		// NOTE this has to change for small sized, small queuedepth sync io.
-		// ibm mq issue. Will come in separate PR
+		// Each px volume, creates a 'cpu' number of threads, that
+		// are bound to the numa node mask.
 		//
-		// HACK FOR IBM: kthread_bind(tc->pxd_thread, i);
+		set_cpus_allowed_ptr(tc->pxd_thread, cpumask_of_node(node));
 		set_user_nice(tc->pxd_thread, MIN_NICE);
 		wake_up_process(tc->pxd_thread);
 	}

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -75,7 +75,6 @@ struct pxd_fastpath_extension {
 
 // helpers
 struct file* getFile(struct pxd_device *pxd_dev, int index);
-int getnextcpu(int node, int pos);
 
 // global initialization during module init for fastpath
 int fastpath_init(void);


### PR DESCRIPTION
IBM mq fio profile (iodepth=1), with fdatasync=1 has very poor performance even with fastpath enabled. The reason is mainly attributed to scheduling delay because further work is scheduled on the same cpu to keep cache active. But the performance hit of moving within the same numa node is minimal, and also, if the current cpu is active, other cpu in the same numa node can schedule further processing of IO and complete it fast. This change improves the performance to expected levels.

iops kernel IO:
                   4k      8k     64k
ext4 on device: 42012   36426   14395
px with ext4:    5082    4375    1912
px faspath ext4: 30.8k|25.7k|10.3k 