### PR TITLE
fuse init call has no bio, handle exception (5/8)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -14,6 +14,16 @@ else
 endif
 endif
 
+# Check for version in KERNELPATH version release file
+ifeq ($(shell test -f "$(KERNELPATH)/include/generated/utsrelease.h"; echo $$?),0)
+CHK_KVER=$(shell sed -n 's/.* *UTS_RELEASE *"\(.*\)".*/\1/p' $(KERNELPATH)/include/generated/utsrelease.h)
+endif
+
+# If no KERNELPATH version found or extract fails use $(KVERSION)
+ifeq ($(CHK_KVER),)
+CHK_KVER=$(KVERSION)
+endif
+
 ifeq ($(shell test -d $(KERNELPATH); echo $$?),1)
 $(error Kernel path: $(KERNELPATH)  directory does not exist.)
 endif
@@ -67,8 +77,8 @@ endif
 endif
 
 # EL8 Specific kernel checks
-ifeq ($(shell test "$(KVERSION)" = "4.18.0-80.el8.x86_64"  -o  "$(KVERSION)" = "4.18.0-80.1.2.el8.x86_64" -o "$(KVERSION)" = "4.18.0.el8.x86_64"; echo $$?),0)
-PXDEFINES += -D__PX_BLKMQ__
+ifeq ($(shell echo "$(CHK_KVER)" | grep -Eq '.*\.el8.*\.x86_64'; echo $$?),0)
+PXDEFINES += -D__PX_BLKMQ__ -D__EL8__
 endif
 
 ## fastpath specific checks
@@ -97,15 +107,15 @@ ifdef KERNELOTHER
 KERNELOTHEROPT=O=$(KERNELOTHER)
 endif
 
-ccflags-y := $(ADDCCFLAGS) -Wframe-larger-than=2048 -Werror -I$(src) $(KBUILD_CPPFLAGS) $(PXDEFINES)
+MAJOR=$(shell echo $(CHK_KVER) | awk -F. '{print $$1}')
+MINOR=$(shell echo $(CHK_KVER) | awk -F. '{print $$2}')
+PATCH=$(shell echo $(CHK_KVER) | awk -F. '{print $$3}' | awk -F- '{print $$1}')
+export REVISION=$(shell echo $(CHK_KVER) | awk -F. '{print $$3}' |  awk -F- '{print $$2}')
 
-MAJOR=$(shell echo $(KVERSION) | awk -F. '{print $$1}')
-MINOR=$(shell echo $(KVERSION) | awk -F. '{print $$2}')
-PATCH=$(shell echo $(KVERSION) | awk -F. '{print $$3}' | awk -F- '{print $$1}')
-export REVISION=$(shell echo $(KVERSION) | awk -F. '{print $$3}' |  awk -F- '{print $$2}')
 export VERSION=$(MAJOR).$(MINOR).$(PATCH)
 export KERNELPATH
 export OUTPATH
+ccflags-y := $(ADDCCFLAGS) -Wframe-larger-than=2048 -Werror -I$(src) $(KBUILD_CPPFLAGS) $(PXDEFINES)
 
 .PHONY: rpm
 

--- a/dev.c
+++ b/dev.c
@@ -25,17 +25,6 @@
 #include <linux/blkdev.h>
 #include "pxd_compat.h"
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,18,0)
-#include "iov_iter.h"
-
-#define iov_iter_advance __iov_iter_advance
-#define iov_iter __iov_iter
-#define iov_iter_init __iov_iter_init
-#define copy_page_to_iter __copy_page_to_iter
-#define copy_page_from_iter __copy_page_from_iter
-
-#endif
-
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)
 #define PAGE_CACHE_GET(page) get_page(page)
 #define PAGE_CACHE_RELEASE(page) put_page(page)
@@ -47,10 +36,7 @@
 /** Maximum number of outstanding background requests */
 #define FUSE_DEFAULT_MAX_BACKGROUND (PXD_MAX_QDEPTH * PXD_MAX_DEVICES)
 
-/** Congestion starts at 75% of maximum */
-#define FUSE_DEFAULT_CONGESTION_THRESHOLD (FUSE_DEFAULT_MAX_BACKGROUND * 3 / 4)
-
-#define FUSE_HASH_SIZE FUSE_DEFAULT_MAX_BACKGROUND
+#define FUSE_MAX_REQUEST_IDS (2 * FUSE_DEFAULT_MAX_BACKGROUND)
 
 static struct kmem_cache *fuse_req_cachep;
 
@@ -63,78 +49,46 @@ static struct fuse_conn *fuse_get_conn(struct file *file)
 	return file->private_data;
 }
 
-static void fuse_request_init(struct fuse_req *req, struct page **pages,
-			      struct fuse_page_desc *page_descs,
-			      unsigned npages)
+void fuse_request_init(struct fuse_req *req)
 {
 	memset(req, 0, sizeof(*req));
-	memset(pages, 0, sizeof(*pages) * npages);
-	memset(page_descs, 0, sizeof(*page_descs) * npages);
 	INIT_LIST_HEAD(&req->list);
-	INIT_HLIST_NODE(&req->hash_entry);
-	req->pages = pages;
-	req->page_descs = page_descs;
-	req->max_pages = npages;
 }
 
-static struct fuse_req *__fuse_request_alloc(unsigned npages, gfp_t flags)
+static struct fuse_req *__fuse_request_alloc(gfp_t flags)
 {
 	struct fuse_req *req = kmem_cache_alloc(fuse_req_cachep, flags);
 
 	if (req) {
-		struct page **pages;
-		struct fuse_page_desc *page_descs;
-
-		if (npages <= FUSE_REQ_INLINE_PAGES) {
-			pages = req->inline_pages;
-			page_descs = req->inline_page_descs;
-		} else {
-			pages = kmalloc(sizeof(struct page *) * npages, flags);
-			page_descs = kmalloc(sizeof(struct fuse_page_desc) *
-					     npages, flags);
-
-			if (!pages || !page_descs) {
-				kfree(pages);
-				kfree(page_descs);
-				kmem_cache_free(fuse_req_cachep, req);
-				return NULL;
-			}
-		}
-
-		fuse_request_init(req, pages, page_descs, npages);
+		fuse_request_init(req);
 	}
 
 	return req;
 }
 
-struct fuse_req *fuse_request_alloc(unsigned npages)
+struct fuse_req *fuse_request_alloc()
 {
-	return __fuse_request_alloc(npages, GFP_NOIO);
+	return __fuse_request_alloc(GFP_NOIO);
 }
 
-struct fuse_req *fuse_request_alloc_nofs(unsigned npages)
+struct fuse_req *fuse_request_alloc_nofs()
 {
-	return __fuse_request_alloc(npages, GFP_NOFS);
+	return __fuse_request_alloc(GFP_NOFS);
 }
 
 void fuse_request_free(struct fuse_req *req)
 {
-	if (req->pages != req->inline_pages) {
-		kfree(req->pages);
-		kfree(req->page_descs);
-	}
 	kmem_cache_free(fuse_req_cachep, req);
 }
 
-static void fuse_req_init_context(struct fuse_req *req)
+void fuse_req_init_context(struct fuse_req *req)
 {
 	req->in.h.uid = from_kuid_munged(&init_user_ns, current_fsuid());
 	req->in.h.gid = from_kgid_munged(&init_user_ns, current_fsgid());
 	req->in.h.pid = current->pid;
 }
 
-static struct fuse_req *__fuse_get_req(struct fuse_conn *fc, unsigned npages,
-				       bool for_background)
+static struct fuse_req *__fuse_get_req(struct fuse_conn *fc)
 {
 	struct fuse_req *req;
 	int err;
@@ -144,29 +98,27 @@ static struct fuse_req *__fuse_get_req(struct fuse_conn *fc, unsigned npages,
 		goto out;
 	}
 
-	req = fuse_request_alloc(npages);
+	req = fuse_request_alloc();
 	if (!req) {
 		err = -ENOMEM;
 		goto out;
 	}
 
 	fuse_req_init_context(req);
-	req->background = for_background;
 	return req;
 
  out:
 	return ERR_PTR(err);
 }
 
-struct fuse_req *fuse_get_req(struct fuse_conn *fc, unsigned npages)
+struct fuse_req *fuse_get_req(struct fuse_conn *fc)
 {
-	return __fuse_get_req(fc, npages, false);
+	return __fuse_get_req(fc);
 }
 
-struct fuse_req *fuse_get_req_for_background(struct fuse_conn *fc,
-					     unsigned npages)
+struct fuse_req *fuse_get_req_for_background(struct fuse_conn *fc)
 {
-	return __fuse_get_req(fc, npages, true);
+	return __fuse_get_req(fc);
 }
 
 static unsigned len_args(unsigned numargs, struct fuse_arg *args)
@@ -182,42 +134,76 @@ static unsigned len_args(unsigned numargs, struct fuse_arg *args)
 
 static u64 fuse_get_unique(struct fuse_conn *fc)
 {
-	fc->reqctr++;
-	/* zero is special */
-	if (unlikely(fc->reqctr == 0))
-		fc->reqctr = 1;
+	struct fuse_per_cpu_ids *my_ids;
+	u64 uid;
+	int num_alloc;
 
-	return fc->reqctr;
+	int cpu = get_cpu();
+
+	my_ids = per_cpu_ptr(fc->per_cpu_ids, cpu);
+
+	if (unlikely(my_ids->num_free_ids == 0)) {
+		spin_lock(&fc->lock);
+		BUG_ON(fc->num_free_ids == 0);
+		num_alloc = min(fc->num_free_ids, (u32)FUSE_MAX_PER_CPU_IDS / 2);
+		memcpy(my_ids->free_ids, &fc->free_ids[fc->num_free_ids - num_alloc],
+			num_alloc * sizeof(u64));
+		fc->num_free_ids -= num_alloc;
+		spin_unlock(&fc->lock);
+
+		my_ids->num_free_ids = num_alloc;
+	}
+
+	uid = my_ids->free_ids[--my_ids->num_free_ids];
+
+	put_cpu();
+
+	uid += FUSE_MAX_REQUEST_IDS;
+
+	/* zero is special */
+	if (uid == 0)
+		uid += FUSE_MAX_REQUEST_IDS;
+
+	return uid;
+}
+
+static void fuse_put_unique(struct fuse_conn *fc, u64 uid)
+{
+	struct fuse_per_cpu_ids *my_ids;
+	int num_free;
+	int cpu = get_cpu();
+
+	my_ids = per_cpu_ptr(fc->per_cpu_ids, cpu);
+
+	if (unlikely(my_ids->num_free_ids == FUSE_MAX_PER_CPU_IDS)) {
+		num_free = FUSE_MAX_PER_CPU_IDS / 2;
+		spin_lock(&fc->lock);
+		BUG_ON(fc->num_free_ids + num_free > FUSE_MAX_REQUEST_IDS);
+		memcpy(&fc->free_ids[fc->num_free_ids],
+			&my_ids->free_ids[my_ids->num_free_ids - num_free],
+			num_free * sizeof(u64));
+		fc->num_free_ids += num_free;
+		spin_unlock(&fc->lock);
+
+		my_ids->num_free_ids -= num_free;
+	}
+
+	my_ids->free_ids[my_ids->num_free_ids++] = uid;
+
+	fc->request_map[uid & (FUSE_MAX_REQUEST_IDS - 1)] = NULL;
+
+	put_cpu();
 }
 
 static void queue_request(struct fuse_conn *fc, struct fuse_req *req)
 {
 	list_add_tail(&req->list, &fc->pending);
-	if (hlist_unhashed(&req->hash_entry))
-		hlist_add_head(&req->hash_entry,
-			       &fc->hash[req->in.h.unique % FUSE_HASH_SIZE]);
 }
 
 static void fuse_conn_wakeup(struct fuse_conn *fc)
 {
 	wake_up(&fc->waitq);
 	kill_fasync(&fc->fasync, SIGIO, POLL_IN);
-}
-
-void fuse_request_send_oob(struct fuse_conn *fc, struct fuse_req *req)
-{
-	req->in.h.len = sizeof(struct fuse_in_header) +
-		len_args(req->in.numargs, (struct fuse_arg *) req->in.args);
-	req->state = FUSE_REQ_PENDING;
-	spin_lock(&fc->lock);
-	req->in.h.unique = fuse_get_unique(fc);
-	list_add(&req->list, &fc->pending);
-	if (hlist_unhashed(&req->hash_entry))
-		hlist_add_head(&req->hash_entry,
-			       &fc->hash[req->in.h.unique % FUSE_HASH_SIZE]);
-	spin_unlock(&fc->lock);
-
-	fuse_conn_wakeup(fc);
 }
 
 /*
@@ -234,40 +220,25 @@ static void request_end(struct fuse_conn *fc, struct fuse_req *req,
                         bool lock)
 __releases(fc->lock)
 {
+	u64 uid;
+
 	if (likely(lock)) {
 		spin_lock(&fc->lock);
 	}
-	if (!hlist_unhashed(&req->hash_entry))
-		hlist_del_init(&req->hash_entry);
 	list_del(&req->list);
-	if (req->background) {
-		if (fc->num_background == fc->congestion_threshold &&
-		    fc->connected && fc->bdi_initialized) {
-			clear_bdi_congested(&fc->bdi, BLK_RW_SYNC);
-			clear_bdi_congested(&fc->bdi, BLK_RW_ASYNC);
-		}
-		fc->num_background--;
-		fc->active_background--;
-	}
 	spin_unlock(&fc->lock);
-	req->state = FUSE_REQ_FINISHED;
+	uid = req->in.h.unique;
 	if (req->end)
 		req->end(fc, req);
+	fuse_put_unique(fc, uid);
+#ifndef __PX_BLKMQ__
 	fuse_request_free(req);
+#endif
 }
 
 static void fuse_request_send_nowait_locked(struct fuse_conn *fc,
 					    struct fuse_req *req)
 {
-	BUG_ON(!req->background);
-	fc->num_background++;
-	if (fc->num_background == fc->congestion_threshold &&
-	    fc->bdi_initialized) {
-		set_bdi_congested(&fc->bdi, BLK_RW_SYNC);
-		set_bdi_congested(&fc->bdi, BLK_RW_ASYNC);
-	}
-	fc->active_background++;
-	req->in.h.unique = fuse_get_unique(fc);
 	queue_request(fc, req);
 }
 
@@ -275,12 +246,13 @@ void fuse_request_send_nowait(struct fuse_conn *fc, struct fuse_req *req)
 {
 	req->in.h.len = sizeof(struct fuse_in_header) +
 		len_args(req->in.numargs, (struct fuse_arg *)req->in.args);
-	req->state = FUSE_REQ_PENDING;
+
+	req->in.h.unique = fuse_get_unique(fc);
+	fc->request_map[req->in.h.unique & (FUSE_MAX_REQUEST_IDS - 1)] = req;
+
 	spin_lock(&fc->lock);
+
 	if (fc->connected || fc->allow_disconnected) {
-		if (unlikely(!fc->connected)) {
-			printk(KERN_INFO "%s: Request on disconnected FC", __func__);
-		}
 		fuse_request_send_nowait_locked(fc, req);
 		spin_unlock(&fc->lock);
 
@@ -334,39 +306,38 @@ ssize_t fuse_copy_req_read(struct fuse_req *req, struct iov_iter *iter)
 	}
 	copied += len;
 
-	if (unlikely(req->num_pages)) {
-		int i;
-		for (i = 0; i < req->num_pages; ++i) {
-			len = req->page_descs[i].length;
-			if (copy_page_to_iter(req->pages[i],
-					      req->page_descs[i].offset,
-					      len, iter) != len) {
-				printk(KERN_ERR "%s: copy page arg %d of %d error\n",
-				       __func__, i, req->num_pages);
-				return -EFAULT;
-			}
-			copied += len;
-		}
-	}
-
 	return copied;
 }
 
 extern uint32_t pxd_detect_zero_writes;
 
+static bool __check_zero_page_write(char *base, size_t len) {
+	uint8_t wsize = sizeof(uint64_t);
+	char *p;
+	size_t i;
+	uint64_t *q;
+
+	p = base;
+	q = (uint64_t *)p;
+	for (i = 0; i < (len / wsize); i++) {
+		if (q[i]) {
+			return false;
+		}
+	}
+	for (i = len - (len % wsize); i < len; i++) {
+		if (p[i]) {
+			return false;
+		}
+	}
+	return true;
+}
+
 /* Check if the request is writing zeroes and if so, convert it as a discard
  * request.
  */
-static void fuse_convert_zero_writes(struct fuse_req *req)
+static void __fuse_convert_zero_writes_slowpath(struct fuse_req *req)
 {
-	uint8_t wsize = sizeof(uint64_t);
-#ifdef USE_REQUESTQ_MODEL
 	struct req_iterator breq_iter;
-#elif defined(HAVE_BVEC_ITER)
-	struct bvec_iter bvec_iter;
-#else
-	int bvec_iter;
-#endif
 
 #ifdef HAVE_BVEC_ITER
 	struct bio_vec bvec;
@@ -374,33 +345,53 @@ static void fuse_convert_zero_writes(struct fuse_req *req)
 	struct bio_vec *bvec = NULL;
 #endif
 	char *kaddr, *p;
-	size_t i, len;
-	uint64_t *q;
+	size_t len;
 
-#ifdef USE_REQUESTQ_MODEL
 	rq_for_each_segment(bvec, req->rq, breq_iter) {
-#else
-	bio_for_each_segment(bvec, req->bio, bvec_iter) {
-#endif
 		kaddr = kmap_atomic(BVEC(bvec).bv_page);
 		p = kaddr + BVEC(bvec).bv_offset;
-		q = (uint64_t *)p;
 		len = BVEC(bvec).bv_len;
-		for (i = 0; i < (len / wsize); i++) {
-			if (q[i]) {
-				kunmap_atomic(kaddr);
-				return;
-			}
-		}
-		for (i = len - (len % wsize); i < len; i++) {
-			if (p[i]) {
-				kunmap_atomic(kaddr);
-				return;
-			}
+		if (!__check_zero_page_write(p, len)) {
+			kunmap_atomic(kaddr);
+			return;
 		}
 		kunmap_atomic(kaddr);
 	}
 	req->in.h.opcode = PXD_DISCARD;
+}
+
+static void __fuse_convert_zero_writes_fastpath(struct fuse_req *req)
+{
+#if defined(HAVE_BVEC_ITER)
+	struct bvec_iter bvec_iter;
+	struct bio_vec bvec;
+#else
+	int bvec_iter;
+	struct bio_vec *bvec = NULL;
+#endif
+	char *kaddr, *p;
+	size_t len;
+
+	bio_for_each_segment(bvec, req->bio, bvec_iter) {
+		kaddr = kmap_atomic(BVEC(bvec).bv_page);
+		p = kaddr + BVEC(bvec).bv_offset;
+		len = BVEC(bvec).bv_len;
+		if (!__check_zero_page_write(p, len)) {
+			kunmap_atomic(kaddr);
+			return;
+		}
+		kunmap_atomic(kaddr);
+	}
+	req->in.h.opcode = PXD_DISCARD;
+}
+
+static void fuse_convert_zero_writes(struct fuse_req *req)
+{
+	if (req->fastpath) {
+		__fuse_convert_zero_writes_fastpath(req);
+	} else {
+		__fuse_convert_zero_writes_slowpath(req);
+	}
 }
 
 /*
@@ -444,7 +435,6 @@ retry:
 	while (entry != &fc->pending) {
 		req = list_entry(entry, struct fuse_req, list);
 		if (req->in.h.len <= remain) {
-			req->state = FUSE_REQ_SENT;
 			last = entry;
 			remain -= req->in.h.len;
 			entry = entry->next;
@@ -469,8 +459,8 @@ retry:
 
 		/* Check if a write request is writing zeroes */
 		if (pxd_detect_zero_writes && (req->in.h.opcode == PXD_WRITE) &&
-			req->misc.pxd_rdwr_in.size &&
-			!(req->misc.pxd_rdwr_in.flags & PXD_FLAGS_SYNC)) {
+		    req->pxd_rdwr_in.size &&
+		    !(req->pxd_rdwr_in.flags & PXD_FLAGS_SYNC)) {
 			fuse_convert_zero_writes(req);
 		}
 		next = entry->next;
@@ -560,6 +550,23 @@ static int fuse_notify_add(struct fuse_conn *conn, unsigned int size,
 		struct iov_iter *iter)
 {
 	struct pxd_add_out add;
+	struct pxd_add_ext_out add_ext;
+	size_t len = sizeof(add);
+
+	if (copy_from_iter(&add, len, iter) != len) {
+		printk(KERN_ERR "%s: can't copy arg\n", __func__);
+		return -EFAULT;
+	}
+
+	memset(&add_ext, 0, sizeof(add_ext));
+	memcpy(&add_ext, &add, sizeof(add));
+	return pxd_add(conn, &add_ext);
+}
+
+static int fuse_notify_add_ext(struct fuse_conn *conn, unsigned int size,
+		struct iov_iter *iter)
+{
+	struct pxd_add_ext_out add;
 	size_t len = sizeof(add);
 
 	if (copy_from_iter(&add, len, iter) != len) {
@@ -569,17 +576,21 @@ static int fuse_notify_add(struct fuse_conn *conn, unsigned int size,
 	return pxd_add(conn, &add);
 }
 
+
 /* Look up request on processing list by unique ID */
 static struct fuse_req *request_find(struct fuse_conn *fc, u64 unique)
 {
-	struct fuse_req *req;
-
-	hlist_for_each_entry(req, &fc->hash[unique % FUSE_HASH_SIZE],
-			     hash_entry)
-		if (req->in.h.unique == unique)
-			return req;
-
-	return NULL;
+	u32 index = unique & (FUSE_MAX_REQUEST_IDS - 1);
+	struct fuse_req *req = fc->request_map[index];
+	if (req == NULL) {
+		printk(KERN_ERR "no request unique %llx", unique);
+		return req;
+	}
+	if (req->in.h.unique != unique) {
+		printk(KERN_ERR "id mismatch got %llx need %llx", req->in.h.unique, unique);
+		return NULL;
+	}
+	return req;
 }
 
 #define IOV_BUF_SIZE 64
@@ -607,29 +618,143 @@ static int copy_in_read_data_iovec(struct iov_iter *iter,
 	return 0;
 }
 
+static int __fuse_notify_read_data_slowpath(struct fuse_conn *conn,
+		struct fuse_req *req,
+		struct pxd_read_data_out *read_data_p, struct iov_iter *iter)
+{
+	struct iovec iov[IOV_BUF_SIZE];
+	struct iov_iter data_iter;
+#ifdef HAVE_BVEC_ITER
+	struct bio_vec bvec;
+#else
+	struct bio_vec *bvec = NULL;
+#endif
+	struct req_iterator breq_iter;
+	size_t copied, skipped = 0;
+	int ret;
+
+	ret = copy_in_read_data_iovec(iter, read_data_p, iov, &data_iter);
+	if (ret)
+		return ret;
+
+	/* advance the iterator if data is unaligned */
+	if (unlikely(req->pxd_rdwr_in.offset & PXD_LBS_MASK))
+		iov_iter_advance(&data_iter,
+				 req->pxd_rdwr_in.offset & PXD_LBS_MASK);
+
+	rq_for_each_segment(bvec, req->rq, breq_iter) {
+		ssize_t len = BVEC(bvec).bv_len;
+		copied = 0;
+		if (skipped < read_data_p->offset) {
+			if (read_data_p->offset - skipped >= len) {
+				skipped += len;
+				copied = len;
+			} else {
+				copied = read_data_p->offset - skipped;
+				skipped = read_data_p->offset;
+			}
+		}
+		if (copied < len) {
+			size_t copy_this = copy_page_to_iter(BVEC(bvec).bv_page,
+				BVEC(bvec).bv_offset + copied,
+				len - copied, &data_iter);
+			if (copy_this != len - copied) {
+				if (!iter->count)
+					return 0;
+
+				/* out of space in destination, copy more iovec */
+				ret = copy_in_read_data_iovec(iter, read_data_p,
+					iov, &data_iter);
+				if (ret)
+					return ret;
+				len -= copied;
+				copied = copy_page_to_iter(BVEC(bvec).bv_page,
+					BVEC(bvec).bv_offset + copied + copy_this,
+					len, &data_iter);
+				if (copied != len) {
+					printk(KERN_ERR "%s: copy failed new iovec\n",
+						__func__);
+					return -EFAULT;
+				}
+			}
+		}
+	}
+
+	return 0;
+}
+
+static int __fuse_notify_read_data_fastpath(struct fuse_conn *conn,
+		struct fuse_req *req,
+		struct pxd_read_data_out *read_data_p, struct iov_iter *iter)
+{
+	struct iovec iov[IOV_BUF_SIZE];
+	struct iov_iter data_iter;
+#ifdef HAVE_BVEC_ITER
+	struct bio_vec bvec;
+	struct bvec_iter bvec_iter;
+#else
+	struct bio_vec *bvec = NULL;
+	int bvec_iter;
+#endif
+	size_t copied, skipped = 0;
+	int ret;
+
+	ret = copy_in_read_data_iovec(iter, read_data_p, iov, &data_iter);
+	if (ret)
+		return ret;
+
+	/* advance the iterator if data is unaligned */
+	if (unlikely(req->pxd_rdwr_in.offset & PXD_LBS_MASK))
+		iov_iter_advance(&data_iter,
+				 req->pxd_rdwr_in.offset & PXD_LBS_MASK);
+
+	bio_for_each_segment(bvec, req->bio, bvec_iter) {
+		ssize_t len = BVEC(bvec).bv_len;
+		copied = 0;
+		if (skipped < read_data_p->offset) {
+			if (read_data_p->offset - skipped >= len) {
+				skipped += len;
+				copied = len;
+			} else {
+				copied = read_data_p->offset - skipped;
+				skipped = read_data_p->offset;
+			}
+		}
+		if (copied < len) {
+			size_t copy_this = copy_page_to_iter(BVEC(bvec).bv_page,
+				BVEC(bvec).bv_offset + copied,
+				len - copied, &data_iter);
+			if (copy_this != len - copied) {
+				if (!iter->count)
+					return 0;
+
+				/* out of space in destination, copy more iovec */
+				ret = copy_in_read_data_iovec(iter, read_data_p,
+					iov, &data_iter);
+				if (ret)
+					return ret;
+				len -= copied;
+				copied = copy_page_to_iter(BVEC(bvec).bv_page,
+					BVEC(bvec).bv_offset + copied + copy_this,
+					len, &data_iter);
+				if (copied != len) {
+					printk(KERN_ERR "%s: copy failed new iovec\n",
+						__func__);
+					return -EFAULT;
+				}
+			}
+		}
+	}
+
+	return 0;
+}
+
 static int fuse_notify_read_data(struct fuse_conn *conn, unsigned int size,
 				struct iov_iter *iter)
 {
 	struct pxd_read_data_out read_data;
 	size_t len = sizeof(read_data);
 	struct fuse_req *req;
-	struct iovec iov[IOV_BUF_SIZE];
-#ifdef HAVE_BVEC_ITER
-	struct bio_vec bvec;
-#else
-	struct bio_vec *bvec = NULL;
-#endif
-
-#ifdef USE_REQUESTQ_MODEL
-	struct req_iterator breq_iter;
-#elif defined(HAVE_BVEC_ITER)
-	struct bvec_iter bvec_iter;
-#else
-	int bvec_iter;
-#endif
-	struct iov_iter data_iter;
-	size_t copied, skipped = 0;
-	int ret;
 
 	if (copy_from_iter(&read_data, len, iter) != len) {
 		printk(KERN_ERR "%s: can't copy read_data arg\n", __func__);
@@ -652,59 +777,13 @@ static int fuse_notify_read_data(struct fuse_conn *conn, unsigned int size,
 		return -EINVAL;
 	}
 
-	ret = copy_in_read_data_iovec(iter, &read_data, iov, &data_iter);
-	if (ret)
-		return ret;
-
-	/* advance the iterator if data is unaligned */
-	if (unlikely(req->misc.pxd_rdwr_in.offset & PXD_LBS_MASK))
-		iov_iter_advance(&data_iter,
-				 req->misc.pxd_rdwr_in.offset & PXD_LBS_MASK);
-
-#ifdef USE_REQUESTQ_MODEL
-	rq_for_each_segment(bvec, req->rq, breq_iter) {
-#else
-	bio_for_each_segment(bvec, req->bio, bvec_iter) {
-#endif
-		copied = 0;
-		len = BVEC(bvec).bv_len;
-		if (skipped < read_data.offset) {
-			if (read_data.offset - skipped >= len) {
-				skipped += len;
-				copied = len;
-			} else {
-				copied = read_data.offset - skipped;
-				skipped = read_data.offset;
-			}
-		}
-		if (copied < len) {
-			size_t copy_this = copy_page_to_iter(BVEC(bvec).bv_page,
-				BVEC(bvec).bv_offset + copied,
-				len - copied, &data_iter);
-			if (copy_this != len - copied) {
-				if (!iter->count)
-					return 0;
-
-				/* out of space in destination, copy more iovec */
-				ret = copy_in_read_data_iovec(iter, &read_data,
-					iov, &data_iter);
-				if (ret)
-					return ret;
-				len -= copied;
-				copied = copy_page_to_iter(BVEC(bvec).bv_page,
-					BVEC(bvec).bv_offset + copied + copy_this,
-					len, &data_iter);
-				if (copied != len) {
-					printk(KERN_ERR "%s: copy failed new iovec\n",
-						__func__);
-					return -EFAULT;
-				}
-			}
-		}
+	if (req->fastpath) {
+		return __fuse_notify_read_data_fastpath(conn, req, &read_data, iter);
 	}
 
-	return 0;
+	return __fuse_notify_read_data_slowpath(conn, req, &read_data, iter);
 }
+
 
 static int fuse_notify_remove(struct fuse_conn *conn, unsigned int size,
 		struct iov_iter *iter)
@@ -745,6 +824,30 @@ static int fuse_notify_update_path(struct fuse_conn *conn, unsigned int size,
 	return pxd_update_path(conn, &update_path);
 }
 
+static int fuse_notify_set_fastpath(struct fuse_conn *conn, unsigned int size,
+		struct iov_iter *iter) {
+	struct pxd_fastpath_out fp;
+	size_t len = sizeof(fp);
+
+	if (copy_from_iter(&fp, len, iter) != len) {
+		printk(KERN_ERR "%s: can't copy arg\n", __func__);
+		return -EFAULT;
+	}
+
+	return pxd_set_fastpath(conn, &fp);
+}
+
+static int fuse_notify_get_features(struct fuse_conn *conn, unsigned int size,
+		struct iov_iter *iter) {
+	int features = 0;
+
+#ifdef __PX_FASTPATH__
+	features |= PXD_FEATURE_FASTPATH;
+#endif
+
+	return features;
+}
+
 static int fuse_notify(struct fuse_conn *fc, enum fuse_notify_code code,
 		       unsigned int size, struct iov_iter *iter)
 {
@@ -755,10 +858,16 @@ static int fuse_notify(struct fuse_conn *fc, enum fuse_notify_code code,
 		return fuse_notify_add(fc, size, iter);
 	case PXD_REMOVE:
 		return fuse_notify_remove(fc, size, iter);
+	case PXD_ADD_EXT:
+		return fuse_notify_add_ext(fc, size, iter);
 	case PXD_UPDATE_SIZE:
 		return fuse_notify_update_size(fc, size, iter);
 	case PXD_UPDATE_PATH:
 		return fuse_notify_update_path(fc, size, iter);
+	case PXD_SET_FASTPATH:
+		return fuse_notify_set_fastpath(fc, size, iter);
+	case PXD_GET_FEATURES:
+		return fuse_notify_get_features(fc, size, iter);
 	default:
 		return -EINVAL;
 	}
@@ -771,6 +880,73 @@ static int fuse_notify(struct fuse_conn *fc, enum fuse_notify_code code,
  * it from the list and copy the rest of the buffer to the request.
  * The request is finished by calling request_end()
  */
+static int __fuse_dev_do_write_slowpath(struct fuse_conn *fc,
+		struct fuse_req *req, struct iov_iter *iter)
+{
+	if (req->in.h.opcode == PXD_READ && iter->count > 0) {
+#ifdef HAVE_BVEC_ITER
+		struct bio_vec bvec;
+#else
+		struct bio_vec *bvec = NULL;
+#endif
+		struct request *breq = req->rq;
+		struct req_iterator breq_iter;
+		int nsegs = breq->nr_phys_segments;
+
+		if (nsegs) {
+			int i = 0;
+			rq_for_each_segment(bvec, breq, breq_iter) {
+				ssize_t len = BVEC(bvec).bv_len;
+				if (copy_page_from_iter(BVEC(bvec).bv_page,
+							BVEC(bvec).bv_offset,
+							len, iter) != len) {
+					printk(KERN_ERR "%s: copy page %d of %d error\n",
+					       __func__, i, nsegs);
+					return -EFAULT;
+				}
+				i++;
+			}
+		}
+	}
+	request_end(fc, req, true);
+	return 0;
+}
+
+static int __fuse_dev_do_write_fastpath(struct fuse_conn *fc,
+		struct fuse_req *req, struct iov_iter *iter)
+{
+#if defined(HAVE_BVEC_ITER)
+	struct bio_vec bvec;
+	struct bio *breq = req->bio;
+	int nsegs = bio_segments(breq);
+	struct bvec_iter bvec_iter;
+#else
+	struct bio_vec *bvec = NULL;
+	struct bio *breq = req->bio;
+	int nsegs = bio_segments(breq);
+	int bvec_iter;
+#endif
+
+	if (req->in.h.opcode == PXD_READ && iter->count > 0) {
+		if (nsegs) {
+			int i = 0;
+			bio_for_each_segment(bvec, breq, bvec_iter) {
+				ssize_t len = BVEC(bvec).bv_len;
+				if (copy_page_from_iter(BVEC(bvec).bv_page,
+							BVEC(bvec).bv_offset,
+							len, iter) != len) {
+					printk(KERN_ERR "%s: copy page %d of %d error\n",
+					       __func__, i, nsegs);
+					return -EFAULT;
+				}
+				i++;
+			}
+		}
+	}
+	request_end(fc, req, true);
+	return 0;
+}
+
 static ssize_t fuse_dev_do_write(struct fuse_conn *fc, struct iov_iter *iter)
 {
 	int err;
@@ -804,65 +980,32 @@ static ssize_t fuse_dev_do_write(struct fuse_conn *fc, struct iov_iter *iter)
 		return -EINVAL;
 
 	err = -ENOENT;
-	spin_lock(&fc->lock);
-	if (!fc->connected)
-		goto err_unlock;
 
 	req = request_find(fc, oh.unique);
-	if (!req)
-		goto err_unlock;
+	if (!req) {
+		printk(KERN_ERR "%s: request %lld not found\n", __func__, oh.unique);
+		return -ENOENT;
+	}
+
+	spin_lock(&fc->lock);
+	if (!fc->connected) {
+		spin_unlock(&fc->lock);
+		return err;
+	}
 
 	list_del_init(&req->list);
 	spin_unlock(&fc->lock);
-	req->state = FUSE_REQ_WRITING;
+
 	req->out.h = oh;
 
-	if (req->bio_pages && req->out.numargs && iter->count > 0) {
-#ifdef HAVE_BVEC_ITER
-		struct bio_vec bvec;
-#else
-		struct bio_vec *bvec = NULL;
-#endif
-
-#ifdef USE_REQUESTQ_MODEL
-		struct request *breq = req->rq;
-		struct req_iterator breq_iter;
-		int nsegs = breq->nr_phys_segments;
-#elif defined(HAVE_BVEC_ITER)
-		struct bio *breq = req->bio;
-		int nsegs = bio_phys_segments(req->queue, breq);
-		struct bvec_iter bvec_iter;
-#else
-		struct bio *breq = req->bio;
-		int nsegs = bio_phys_segments(req->queue, breq);
-		int bvec_iter;
-#endif
-
-		if (nsegs && req->in.h.opcode == PXD_READ) {
-			int i = 0;
-#ifdef USE_REQUESTQ_MODEL
-			rq_for_each_segment(bvec, breq, breq_iter) {
-#else
-			bio_for_each_segment(bvec, breq, bvec_iter) {
-#endif
-				len = BVEC(bvec).bv_len;
-				if (copy_page_from_iter(BVEC(bvec).bv_page,
-							BVEC(bvec).bv_offset,
-							len, iter) != len) {
-					printk(KERN_ERR "%s: copy page %d of %d error\n",
-					       __func__, i, nsegs);
-					return -EFAULT;
-				}
-				i++;
-			}
-		}
+	if (req->fastpath) {
+		err = __fuse_dev_do_write_fastpath(fc, req, iter);
+	} else {
+		err = __fuse_dev_do_write_slowpath(fc, req, iter);
 	}
-	request_end(fc, req, true);
-	return nbytes;
 
- err_unlock:
-	spin_unlock(&fc->lock);
-	return err;
+	if (err) return err;
+	return nbytes;
 }
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0)
@@ -937,61 +1080,75 @@ static void end_queued_requests(struct fuse_conn *fc)
 __releases(fc->lock)
 __acquires(fc->lock)
 {
-	fc->max_background = UINT_MAX;
 	end_requests(fc, &fc->pending);
 	end_requests(fc, &fc->processing);
 }
 
-static void end_polls(struct fuse_conn *fc)
+static void fuse_conn_free_allocs(struct fuse_conn *fc)
 {
-	struct rb_node *p;
-
-	p = rb_first(&fc->polled_files);
-
-	while (p) {
-		struct fuse_file *ff;
-		ff = rb_entry(p, struct fuse_file, polled_node);
-		wake_up_interruptible_all(&ff->poll_wait);
-
-		p = rb_next(p);
-	}
+	if (fc->per_cpu_ids)
+		free_percpu(fc->per_cpu_ids);
+	if (fc->free_ids)
+		kfree(fc->free_ids);
+	if (fc->request_map)
+		kfree(fc->request_map);
 }
 
 int fuse_conn_init(struct fuse_conn *fc)
 {
-	int i;
+	int i, rc;
+	int cpu;
 
 	memset(fc, 0, sizeof(*fc));
 	spin_lock_init(&fc->lock);
-	init_rwsem(&fc->killsb);
 	atomic_set(&fc->count, 1);
 	init_waitqueue_head(&fc->waitq);
 	INIT_LIST_HEAD(&fc->pending);
 	INIT_LIST_HEAD(&fc->processing);
 	INIT_LIST_HEAD(&fc->entry);
-	fc->hash = kmalloc(FUSE_HASH_SIZE * sizeof(*fc->hash), GFP_KERNEL);
-	if (!fc->hash)
-		return -ENOMEM;
-	for (i = 0; i < FUSE_HASH_SIZE; ++i)
-		INIT_HLIST_HEAD(&fc->hash[i]);
-	fc->max_background = FUSE_DEFAULT_MAX_BACKGROUND;
-	fc->congestion_threshold = FUSE_DEFAULT_CONGESTION_THRESHOLD;
-	fc->khctr = 0;
-	fc->polled_files = RB_ROOT;
+	fc->request_map = kmalloc(FUSE_MAX_REQUEST_IDS * sizeof(struct fuse_req*),
+		GFP_KERNEL);
+
+	rc = -ENOMEM;
+	if (!fc->request_map) {
+		printk(KERN_ERR "failed to allocate request map");
+		goto err_out;
+	}
+	memset(fc->request_map, 0,
+		FUSE_MAX_REQUEST_IDS * sizeof(struct fuse_req*));
+
+	fc->free_ids = kmalloc(FUSE_MAX_REQUEST_IDS * sizeof(u64), GFP_KERNEL);
+	if (!fc->free_ids) {
+		printk(KERN_ERR "failed to allocate free requests");
+		goto err_out;
+	}
+	for (i = 0; i < FUSE_MAX_REQUEST_IDS; ++i) {
+		fc->free_ids[i] = FUSE_MAX_REQUEST_IDS - i - 1;
+	}
+	fc->num_free_ids = FUSE_MAX_REQUEST_IDS;
+
+	fc->per_cpu_ids = alloc_percpu(struct fuse_per_cpu_ids);
+	if (!fc->per_cpu_ids) {
+		printk(KERN_ERR "failed to allocate per cpu ids");
+		goto err_out;
+	}
+
+	for_each_possible_cpu(cpu) {
+		struct fuse_per_cpu_ids *my_ids = per_cpu_ptr(fc->per_cpu_ids, cpu);
+		memset(my_ids, 0, sizeof(*my_ids));
+	}
+
 	fc->reqctr = 0;
-	fc->initialized = 0;
-	fc->attr_version = 1;
-	get_random_bytes(&fc->scramble_key, sizeof(fc->scramble_key));
 	return 0;
+err_out:
+	fuse_conn_free_allocs(fc);
+	return rc;
 }
 
 void fuse_conn_put(struct fuse_conn *fc)
 {
 	if (atomic_dec_and_test(&fc->count)) {
-		if (fc->destroy_req)
-			fuse_request_free(fc->destroy_req);
-		if (fc->hash)
-			kfree(fc->hash);
+		fuse_conn_free_allocs(fc);
 		fc->release(fc);
 	}
 }
@@ -1026,9 +1183,7 @@ void fuse_abort_conn(struct fuse_conn *fc)
 	spin_lock(&fc->lock);
 	if (fc->connected) {
 		fc->connected = 0;
-		fc->initialized = 1;
 		end_queued_requests(fc);
-		end_polls(fc);
 		wake_up_all(&fc->waitq);
 		kill_fasync(&fc->fasync, SIGIO, POLL_IN);
 	}
@@ -1041,9 +1196,7 @@ int fuse_dev_release(struct inode *inode, struct file *file)
 	if (fc) {
 		spin_lock(&fc->lock);
 		fc->connected = 0;
-		fc->initialized = 1;
 		end_queued_requests(fc);
-		end_polls(fc);
 		spin_unlock(&fc->lock);
 		fuse_conn_put(fc);
 	}
@@ -1053,11 +1206,7 @@ int fuse_dev_release(struct inode *inode, struct file *file)
 
 void fuse_restart_requests(struct fuse_conn *fc)
 {
-	struct fuse_req *req;
-
 	spin_lock(&fc->lock);
-	list_for_each_entry(req, &fc->processing, list)
-		req->state = FUSE_REQ_PENDING;
 	list_splice_init(&fc->processing, &fc->pending);
 	wake_up(&fc->waitq);
 	kill_fasync(&fc->fasync, SIGIO, POLL_IN);

--- a/pxd.c
+++ b/pxd.c
@@ -2,8 +2,10 @@
 #include <linux/blkdev.h>
 #include <linux/sysfs.h>
 #include <linux/crc32.h>
+#include <linux/ctype.h>
 #include "fuse_i.h"
 #include "pxd.h"
+#include <linux/uio.h>
 
 #define CREATE_TRACE_POINTS
 #undef TRACE_INCLUDE_PATH
@@ -17,7 +19,6 @@
 
 #ifdef __PX_BLKMQ__
 #include <linux/blk-mq.h>
-#include <linux/workqueue.h>
 
 static struct workqueue_struct *pxd_wq;
 
@@ -90,8 +91,18 @@ static void pxd_release(struct gendisk *disk, fmode_t mode)
 	put_device(&pxd_dev->dev);
 }
 
-static long pxd_control_ioctl(
-	struct file *file, unsigned int cmd, unsigned long arg)
+static long pxd_ioctl_init(struct file *file, void __user *argp)
+{
+	struct pxd_context *ctx = container_of(file->f_op, struct pxd_context, fops);
+	struct iov_iter iter;
+	struct iovec iov = {argp, sizeof(struct pxd_ioctl_init_args)};
+
+	iov_iter_init(&iter, WRITE, &iov, 1, sizeof(struct pxd_ioctl_init_args));
+
+	return pxd_read_init(&ctx->fc, &iter);
+}
+
+static long pxd_control_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 {
 	void __user *argp = (void __user *)arg;
 	struct pxd_context *ctx = NULL;
@@ -108,12 +119,7 @@ static long pxd_control_ioctl(
 			}
 			printk(KERN_INFO "%s: pxd_ctx: %s ndevices: %lu",
 				__func__, ctx->name, ctx->num_devices);
-			printk(KERN_INFO "\tFC: connected: %d "
-				 "max: %d threshold: %d nb: %d ab: %d",
-			       ctx->fc.connected, ctx->fc.max_background,
-			       ctx->fc.congestion_threshold,
-			       ctx->fc.num_background,
-			       ctx->fc.active_background);
+			printk(KERN_INFO "\tFC: connected: %d", ctx->fc.connected);
 		}
 		status = 0;
 		break;
@@ -136,6 +142,9 @@ static long pxd_control_ioctl(
 		printk(KERN_INFO "pxd driver at version: %s\n", gitversion);
 		status = 0;
 		break;
+	case PXD_IOC_INIT:
+		status = pxd_ioctl_init(file, argp);
+		break;
 	default:
 		break;
 	}
@@ -152,7 +161,7 @@ static void pxd_update_stats(struct fuse_req *req, int rw, unsigned int count)
 {
         struct pxd_device *pxd_dev = req->queue->queuedata;
 
-#ifdef __PX_BLKMQ__
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0) || defined(__EL8__)
         part_stat_lock();
         part_stat_inc(&pxd_dev->disk->part0, ios[rw]);
         part_stat_add(&pxd_dev->disk->part0, sectors[rw], count);
@@ -161,7 +170,6 @@ static void pxd_update_stats(struct fuse_req *req, int rw, unsigned int count)
         part_stat_inc(cpu, &pxd_dev->disk->part0, ios[rw]);
         part_stat_add(cpu, &pxd_dev->disk->part0, sectors[rw], count);
 #endif
-
         part_stat_unlock();
 }
 
@@ -171,19 +179,12 @@ static void pxd_update_stats(struct fuse_req *req, int rw, unsigned int count)
  * copy of fuse_i.h that uses the older layout.
  */
 #define	REQCTR(fc) (fc)->reqctr
-#if 0
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,2,0)
-#define	REQCTR(fc) (fc)->iq.reqctr
-#else
-#define	REQCTR(fc) (fc)->reqctr
-#endif
-#endif
 
 static void pxd_request_complete(struct fuse_conn *fc, struct fuse_req *req)
 {
 	pxd_printk("%s: receive reply to %p(%lld) at %lld err %d\n",
 			__func__, req, req->in.h.unique,
-			req->misc.pxd_rdwr_in.offset, req->out.h.error);
+			req->pxd_rdwr_in.offset, req->out.h.error);
 }
 
 static void pxd_process_read_reply(struct fuse_conn *fc, struct fuse_req *req)
@@ -229,7 +230,7 @@ static void pxd_process_write_reply_q(struct fuse_conn *fc, struct fuse_req *req
 	pxd_request_complete(fc, req);
 }
 
-static struct fuse_req *pxd_fuse_req(struct pxd_device *pxd_dev, int nr_pages)
+static struct fuse_req *pxd_fuse_req(struct pxd_device *pxd_dev)
 {
 	int eintr = 0;
 	struct fuse_req *req = NULL;
@@ -237,21 +238,23 @@ static struct fuse_req *pxd_fuse_req(struct pxd_device *pxd_dev, int nr_pages)
 	int status;
 
 	while (req == NULL) {
-		req = fuse_get_req_for_background(fc, nr_pages);
+		req = fuse_get_req_for_background(fc);
 		if (IS_ERR(req) && PTR_ERR(req) == -EINTR) {
 			req = NULL;
 			++eintr;
 		}
 	}
 	if (eintr > 0) {
-		printk_ratelimited(KERN_INFO "%s: alloc (%d pages) EINTR retries %d",
-			 __func__, nr_pages, eintr);
+		printk_ratelimited(KERN_INFO "%s: alloc EINTR retries %d",
+			 __func__, eintr);
 	}
 	status = IS_ERR(req) ? PTR_ERR(req) : 0;
 	if (status != 0) {
-		printk_ratelimited(KERN_ERR "%s: request alloc (%d pages) failed: %d",
-			 __func__, nr_pages, status);
+		printk_ratelimited(KERN_ERR "%s: request alloc failed: %d",
+			 __func__, status);
 	}
+
+	req->fastpath = pxd_dev->fastpath;
 	return req;
 }
 
@@ -260,19 +263,18 @@ static void pxd_req_misc(struct fuse_req *req, uint32_t size, uint64_t off,
 {
 	req->in.numargs = 1;
 	req->in.args[0].size = sizeof(struct pxd_rdwr_in);
-	req->in.args[0].value = &req->misc.pxd_rdwr_in;
-	req->bio_pages = true;
+	req->in.args[0].value = &req->pxd_rdwr_in;
 	req->in.h.pid = current->pid;
-	req->misc.pxd_rdwr_in.minor = minor;
-	req->misc.pxd_rdwr_in.offset = off;
-	req->misc.pxd_rdwr_in.size = size;
+	req->pxd_rdwr_in.minor = minor;
+	req->pxd_rdwr_in.offset = off;
+	req->pxd_rdwr_in.size = size;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) || defined(REQ_PREFLUSH)
-	req->misc.pxd_rdwr_in.flags =
+	req->pxd_rdwr_in.flags =
 		((flags & REQ_FUA) ? PXD_FLAGS_FLUSH : 0) |
 		((flags & REQ_PREFLUSH) ? PXD_FLAGS_FLUSH : 0) |
 		((flags & REQ_META) ? PXD_FLAGS_META : 0);
 #else
-	req->misc.pxd_rdwr_in.flags = ((flags & REQ_FLUSH) ? PXD_FLAGS_FLUSH : 0) |
+	req->pxd_rdwr_in.flags = ((flags & REQ_FLUSH) ? PXD_FLAGS_FLUSH : 0) |
 				      ((flags & REQ_FUA) ? PXD_FLAGS_FUA : 0) |
 				      ((flags & REQ_META) ? PXD_FLAGS_META : 0);
 #endif
@@ -282,10 +284,11 @@ static void pxd_read_request(struct fuse_req *req, uint32_t size, uint64_t off,
 			uint32_t minor, uint32_t flags, bool qfn)
 {
 	req->in.h.opcode = PXD_READ;
-	req->out.numargs = 1;
-	req->out.argpages = 1;
-	req->out.args[0].size = size;
-	req->end = qfn ? pxd_process_read_reply_q : pxd_process_read_reply;
+	if (req->fastpath) {
+		req->end = pxd_process_read_reply;
+	} else {
+		req->end = qfn ? pxd_process_read_reply_q : pxd_process_read_reply;
+	}
 
 	pxd_req_misc(req, size, off, minor, flags);
 }
@@ -294,7 +297,11 @@ static void pxd_write_request(struct fuse_req *req, uint32_t size, uint64_t off,
 			uint32_t minor, uint32_t flags, bool qfn)
 {
 	req->in.h.opcode = PXD_WRITE;
-	req->end = qfn ? pxd_process_write_reply_q : pxd_process_write_reply;
+	if (req->fastpath) {
+		req->end = pxd_process_write_reply;
+	} else {
+		req->end = qfn ? pxd_process_write_reply_q : pxd_process_write_reply;
+	}
 
 	pxd_req_misc(req, size, off, minor, flags);
 }
@@ -303,7 +310,11 @@ static void pxd_discard_request(struct fuse_req *req, uint32_t size, uint64_t of
 			uint32_t minor, uint32_t flags, bool qfn)
 {
 	req->in.h.opcode = PXD_DISCARD;
-	req->end = qfn ? pxd_process_write_reply_q : pxd_process_write_reply;
+	if (req->fastpath) {
+		req->end = pxd_process_write_reply;
+	} else {
+		req->end = qfn ? pxd_process_write_reply_q : pxd_process_write_reply;
+	}
 
 	pxd_req_misc(req, size, off, minor, flags);
 }
@@ -312,7 +323,11 @@ static void pxd_write_same_request(struct fuse_req *req, uint32_t size, uint64_t
 			uint32_t minor, uint32_t flags, bool qfn)
 {
 	req->in.h.opcode = PXD_WRITE_SAME;
-	req->end = qfn ? pxd_process_write_reply_q : pxd_process_write_reply;
+	if (req->fastpath) {
+		req->end = pxd_process_write_reply;
+	} else {
+		req->end = qfn ? pxd_process_write_reply_q : pxd_process_write_reply;
+	}
 
 	pxd_req_misc(req, size, off, minor, flags);
 }
@@ -399,8 +414,6 @@ static inline unsigned int get_op_flags(struct bio *bio)
 }
 
 // fastpath uses this path to punt requests to slowpath
-#if !defined(USE_REQUESTQ_MODEL) || defined(__PX_FASTPATH__)
-
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 blk_qc_t pxd_make_request_slowpath(struct request_queue *q, struct bio *bio)
 #define BLK_QC_RETVAL BLK_QC_T_NONE
@@ -422,7 +435,7 @@ void pxd_make_request_slowpath(struct request_queue *q, struct bio *bio)
 			BIO_SECTOR(bio) * SECTOR_SIZE, BIO_SIZE(bio),
 			bio->bi_vcnt, flags, get_op_flags(bio));
 
-	req = pxd_fuse_req(pxd_dev, bio->bi_vcnt);
+	req = pxd_fuse_req(pxd_dev);
 	if (IS_ERR(req)) {
 		bio_io_error(bio);
 		return BLK_QC_RETVAL;
@@ -447,7 +460,8 @@ void pxd_make_request_slowpath(struct request_queue *q, struct bio *bio)
 	fuse_request_send_nowait(&pxd_dev->ctx->fc, req);
 	return BLK_QC_RETVAL;
 }
-#elif !defined(__PX_BLKMQ__)
+
+#if !defined(__PX_BLKMQ__)
 static void pxd_rq_fn(struct request_queue *q)
 {
 	struct pxd_device *pxd_dev = q->queuedata;
@@ -474,7 +488,7 @@ static void pxd_rq_fn(struct request_queue *q)
 			blk_rq_pos(rq) * SECTOR_SIZE, blk_rq_bytes(rq),
 			rq->nr_phys_segments, rq->cmd_flags);
 
-		req = pxd_fuse_req(pxd_dev, 0);
+		req = pxd_fuse_req(pxd_dev);
 		if (IS_ERR(req)) {
 			spin_lock_irq(&pxd_dev->qlock);
 			__blk_end_request(rq, -EIO, blk_rq_bytes(rq));
@@ -503,31 +517,32 @@ static void pxd_rq_fn(struct request_queue *q)
 	}
 }
 #else
-static void pxd_queue_workfn(struct work_struct *work)
-{
-	struct request *rq = blk_mq_rq_from_pdu(work);
-	struct pxd_device *pxd_dev = rq->q->queuedata;
-	struct fuse_req *req = NULL;
-	blk_status_t error = BLK_STS_OK;
 
-	if (BLK_RQ_IS_PASSTHROUGH(rq)) {
-		goto err;
-	}
+static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
+		const struct blk_mq_queue_data *bd)
+{
+	struct request *rq = bd->rq;
+	struct pxd_device *pxd_dev = rq->q->queuedata;
+	struct fuse_req *req = blk_mq_rq_to_pdu(rq);
+	struct fuse_conn *fc = &pxd_dev->ctx->fc;
+
+	if (BLK_RQ_IS_PASSTHROUGH(rq))
+		return BLK_STS_IOERR;
+
+	if (!fc->connected && !fc->allow_disconnected)
+		return BLK_STS_IOERR;
 
 	pxd_printk("%s: dev m %d g %lld %s at %ld len %d bytes %d pages "
-		"flags  %llx\n", __func__,
+		   "flags  %llx\n", __func__,
 		pxd_dev->minor, pxd_dev->dev_id,
 		rq_data_dir(rq) == WRITE ? "wr" : "rd",
 		blk_rq_pos(rq) * SECTOR_SIZE, blk_rq_bytes(rq),
 		rq->nr_phys_segments, rq->cmd_flags);
 
-	blk_mq_start_request(rq);
+	fuse_request_init(req);
+	fuse_req_init_context(req);
 
-	req = pxd_fuse_req(pxd_dev, 0);
-	if (IS_ERR(req)) {
-		error = BLK_STS_IOERR;
-		goto err;
-	}
+	blk_mq_start_request(rq);
 
 	if (pxd_request(req, blk_rq_bytes(rq), blk_rq_pos(rq) * SECTOR_SIZE,
 		pxd_dev->minor, req_op(rq), rq->cmd_flags, true,
@@ -536,43 +551,20 @@ static void pxd_queue_workfn(struct work_struct *work)
 		goto err;
 	}
 
-	req->num_pages = 0;
-	req->misc.pxd_rdwr_in.chksum = 0;
-	req->misc.pxd_rdwr_in.pad = 0;
+	req->pxd_rdwr_in.chksum = 0;
+	req->pxd_rdwr_in.pad = 0;
 	req->rq = rq;
 	fuse_request_send_nowait(&pxd_dev->ctx->fc, req);
-	return;
 
-err:
-	blk_mq_end_request(rq, error);
-}
-
-static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
-		const struct blk_mq_queue_data *bd)
-{
-	struct request *rq = bd->rq;
-	struct work_struct *work = blk_mq_rq_to_pdu(rq);
-
-	queue_work(pxd_wq, work);
 	return BLK_STS_OK;
-}
-
-static int pxd_init_request(struct blk_mq_tag_set *set, struct request *rq,
-			    unsigned int hctx_idx, unsigned int numa_node)
-{
-	struct work_struct *work = blk_mq_rq_to_pdu(rq);
-
-	INIT_WORK(work, pxd_queue_workfn);
-	return 0;
 }
 
 static const struct blk_mq_ops pxd_mq_ops = {
 	.queue_rq       = pxd_queue_rq,
-	.init_request   = pxd_init_request,
 };
 #endif
 
-static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_out *add)
+static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add)
 {
 	struct gendisk *disk;
 	struct request_queue *q;
@@ -594,31 +586,36 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_out *add)
 	disk->fops = &pxd_bd_ops;
 	disk->private_data = pxd_dev;
 
-	/* cannot choose io processing model dynamically based on queue size.
-	 * Because other files also need to know how requests are to be processed.
-	 */
-#if !defined(USE_REQUESTQ_MODEL)
-	q = blk_alloc_queue(GFP_KERNEL);
-	if (!q) {
-		err = -ENOMEM;
-		goto out_disk;
+#ifndef __PX_FASTPATH__
+	if (pxd_dev->fastpath) {
+		printk(KERN_NOTICE"PX driver does not support fastpath, disabling it.");
+		pxd_dev->fastpath = false;
 	}
-#ifdef __PX_FASTPATH__
-	blk_queue_make_request(q, pxd_make_request_fastpath);
 #else
-	blk_queue_make_request(q, pxd_make_request_slowpath);
+	if (pxd_dev->fastpath) {
+		q = blk_alloc_queue(GFP_KERNEL);
+		if (!q) {
+			err = -ENOMEM;
+			goto out_disk;
+		}
+
+		// add hooks to control congestion only while using fastpath
+		q->backing_dev_info->congested_fn = pxd_device_congested;
+		q->backing_dev_info->congested_data = pxd_dev;
+
+		blk_queue_make_request(q, pxd_make_request_fastpath);
+	} else {
 #endif
 
-#else
 #ifdef __PX_BLKMQ__
 	  memset(&pxd_dev->tag_set, 0, sizeof(pxd_dev->tag_set));
 	  pxd_dev->tag_set.ops = &pxd_mq_ops;
 	  pxd_dev->tag_set.queue_depth = PXD_MAX_QDEPTH;
 	  pxd_dev->tag_set.numa_node = NUMA_NO_NODE;
-	  pxd_dev->tag_set.flags = BLK_MQ_F_SHOULD_MERGE | BLK_MQ_F_SG_MERGE;
+	  pxd_dev->tag_set.flags = BLK_MQ_F_SHOULD_MERGE;
 	  pxd_dev->tag_set.nr_hw_queues = 8;
 	  pxd_dev->tag_set.queue_depth = 128;
-	  pxd_dev->tag_set.cmd_size = sizeof(struct work_struct);
+	  pxd_dev->tag_set.cmd_size = sizeof(struct fuse_req);
 
 	  err = blk_mq_alloc_tag_set(&pxd_dev->tag_set);
 	  if (err)
@@ -637,6 +634,9 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_out *add)
 	  	goto out_disk;
 	  }
 #endif
+
+#ifdef __PX_FASTPATH__
+	}
 #endif
 	blk_queue_max_hw_sectors(q, SEGMENT_SIZE / SECTOR_SIZE);
 	blk_queue_max_segment_size(q, SEGMENT_SIZE);
@@ -697,7 +697,7 @@ static void pxd_free_disk(struct pxd_device *pxd_dev)
 	put_disk(disk);
 }
 
-ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_out *add)
+ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 {
 	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
 	struct pxd_device *pxd_dev = NULL;
@@ -737,14 +737,23 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_out *add)
 	pxd_dev->connected = true; // fuse slow path connection
 	pxd_dev->size = add->size;
 	pxd_dev->mode = add->open_mode;
+	pxd_dev->fastpath = add->enable_fp;
 
-	err = pxd_fastpath_init(pxd_dev);
-	if (err)
-		goto out_id;
+	printk(KERN_INFO"Device %llu added with mode %#x fastpath %d npath %lu\n",
+			add->dev_id, add->open_mode, add->enable_fp, add->paths.size);
+
+	if (pxd_dev->fastpath) {
+		err = pxd_fastpath_init(pxd_dev);
+		if (err)
+			goto out_id;
+
+		printk(KERN_INFO"Device %llu enabling fastpath %d (paths: %lu)\n",
+				add->dev_id, add->enable_fp, add->paths.size);
+	}
 
 	err = pxd_init_disk(pxd_dev, add);
 	if (err) {
-		pxd_fastpath_cleanup(pxd_dev);
+		if (pxd_dev->fastpath) pxd_fastpath_cleanup(pxd_dev);
 		goto out_id;
 	}
 
@@ -789,6 +798,9 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 	int found = false;
 	int err;
 	struct pxd_device *pxd_dev;
+
+	pxd_printk(KERN_INFO"pxd_remove for device %llu\n",
+			remove->dev_id);
 
 	spin_lock(&ctx->lock);
 	list_for_each_entry(pxd_dev, &ctx->list, node) {
@@ -876,15 +888,64 @@ out:
 	return err;
 }
 
+ssize_t pxd_read_init(struct fuse_conn *fc, struct iov_iter *iter)
+{
+	size_t copied = 0;
+	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
+	struct pxd_device *pxd_dev;
+	struct pxd_init_in pxd_init;
+
+	spin_lock(&fc->lock);
+
+	pxd_init.num_devices = ctx->num_devices;
+	pxd_init.version = PXD_VERSION;
+
+	if (copy_to_iter(&pxd_init, sizeof(pxd_init), iter) != sizeof(pxd_init)) {
+		printk(KERN_ERR "%s: copy pxd_init error\n", __func__);
+		goto copy_error;
+	}
+	copied += sizeof(pxd_init);
+
+	list_for_each_entry(pxd_dev, &ctx->list, node) {
+		struct pxd_dev_id id;
+		id.dev_id = pxd_dev->dev_id;
+		id.local_minor = pxd_dev->minor;
+		if (copy_to_iter(&id, sizeof(id), iter) != sizeof(id)) {
+			printk(KERN_ERR "%s: copy dev id error copied %ld\n", __func__,
+				copied);
+			goto copy_error;
+		}
+		copied += sizeof(id);
+	}
+
+	spin_unlock(&fc->lock);
+
+	printk(KERN_INFO "%s: pxd-control-%d init OK %d devs version %d\n", __func__,
+		ctx->id, pxd_init.num_devices, pxd_init.version);
+
+	return copied;
+
+copy_error:
+	spin_unlock(&fc->lock);
+	return -EFAULT;
+}
+
+
+static int __pxd_update_path(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path)
+{
+	/// This seems risky to update paths on the fly while the px device is active
+	/// Need to confirm behavior while IOs are active and handle it right!!!!
+	pxd_init_fastpath_target(pxd_dev, update_path);
+	return 0;
+
+}
+
 ssize_t pxd_update_path(struct fuse_conn *fc, struct pxd_update_path_out *update_path)
 {
 	bool found = false;
 	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
 	int err;
 	struct pxd_device *pxd_dev;
-	int i;
-	struct file* f;
-	mode_t mode = 0;
 
 	spin_lock(&ctx->lock);
 	list_for_each_entry(pxd_dev, &ctx->list, node) {
@@ -901,44 +962,47 @@ ssize_t pxd_update_path(struct fuse_conn *fc, struct pxd_update_path_out *update
 		goto out;
 	}
 
-	mode = open_mode(pxd_dev->mode);
-	for (i = 0; i < update_path->size; i++) {
-		if (!strcmp(pxd_dev->fp.device_path[i], update_path->devpath[i])) {
-			// if previous paths are same.. then skip anymore config
-			printk(KERN_INFO"pxd%llu already configured for path %s\n",
-				pxd_dev->dev_id, pxd_dev->fp.device_path[i]);
-			continue;
-		}
+	err=__pxd_update_path(pxd_dev, update_path);
+out:
+	if (found) spin_unlock(&pxd_dev->lock);
+	return err;
+}
 
-		if (pxd_dev->fp.file[i] > 0) filp_close(pxd_dev->fp.file[i], NULL);
-		f = filp_open(update_path->devpath[i], mode, 0600);
-		if (IS_ERR_OR_NULL(f)) {
-			printk(KERN_ERR"Failed attaching path: device %llu, path %s, err %ld\n",
-				pxd_dev->dev_id, update_path->devpath[i], PTR_ERR(f));
-			goto out_file_failed;
+
+int pxd_set_fastpath(struct fuse_conn *fc, struct pxd_fastpath_out *fp)
+{
+	bool found = false;
+	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
+	struct pxd_device *pxd_dev;
+	int err;
+
+	printk(KERN_WARNING"device %llu, set fastpath enable %d, cleanup %d\n",
+			fp->dev_id, fp->enable, fp->cleanup);
+	spin_lock(&ctx->lock);
+	list_for_each_entry(pxd_dev, &ctx->list, node) {
+		if ((pxd_dev->dev_id == fp->dev_id) && !pxd_dev->removing) {
+			spin_lock(&pxd_dev->lock);
+			found = true;
+			break;
 		}
-		pxd_dev->fp.file[i] = f;
-		strncpy(pxd_dev->fp.device_path[i], update_path->devpath[i],MAX_PXD_DEVPATH_LEN);
-		pxd_dev->fp.device_path[i][MAX_PXD_DEVPATH_LEN] = (char) 0;
 	}
-	pxd_dev->fp.nfd = update_path->size;
+	spin_unlock(&ctx->lock);
+
+	if (!found) {
+		err = -ENOENT;
+		goto out;
+	}
 
 	/* setup whether access is block or file access */
-	enableFastPath(pxd_dev, false);
+	if (fp->enable) {
+		enableFastPath(pxd_dev, false);
+	} else {
+		if (fp->cleanup) disableFastPath(pxd_dev);
+	}
+
 	spin_unlock(&pxd_dev->lock);
 
-	printk(KERN_INFO"Success attaching path to device %llu [nfd:%d]\n",
-		pxd_dev->dev_id, pxd_dev->fp.nfd);
 	return 0;
-
-out_file_failed:
-	for (i = 0; i < pxd_dev->fp.nfd; i++) {
-		if (pxd_dev->fp.file[i] > 0) filp_close(pxd_dev->fp.file[i], NULL);
-	}
-	pxd_dev->fp.nfd = 0;
-	memset(pxd_dev->fp.file, 0, sizeof(pxd_dev->fp.file));
-	memset(pxd_dev->fp.device_path, 0, sizeof(pxd_dev->fp.device_path));
-
 out:
 	if (found) spin_unlock(&pxd_dev->lock);
 	return err;
@@ -1027,6 +1091,7 @@ static ssize_t pxd_active_show(struct device *dev,
 	char *cp = buf;
 	int ncount;
 	int available = PAGE_SIZE - 1;
+	int i;
 
 	ncount = snprintf(cp, available, "nactive: %u/%u, [write: %u, flush: %u(nop: %u), fua: %u, discard: %u, preflush: %u], switched: %u, slowpath: %u\n",
                 atomic_read(&pxd_dev->fp.ncount), atomic_read(&pxd_dev->fp.ncomplete),
@@ -1035,6 +1100,15 @@ static ssize_t pxd_active_show(struct device *dev,
 		atomic_read(&pxd_dev->fp.nio_fua), atomic_read(&pxd_dev->fp.nio_discard),
 		atomic_read(&pxd_dev->fp.nio_preflush),
 		atomic_read(&pxd_dev->fp.nswitch), atomic_read(&pxd_dev->fp.nslowPath));
+
+	cp += ncount;
+	available -= ncount;
+	for (i = 0; i < pxd_dev->fp.nfd; i++) {
+		size_t tmp = snprintf(cp, available, "%s\n", pxd_dev->fp.device_path[i]);
+		cp += tmp;
+		available -= tmp;
+		ncount += tmp;
+	}
 
 	return ncount;
 }
@@ -1066,6 +1140,16 @@ static ssize_t pxd_sync_store(struct device *dev, struct device_attribute *attr,
 	return count;
 }
 
+static ssize_t pxd_mode_show(struct device *dev,
+                     struct device_attribute *attr, char *buf)
+{
+	char modestr[32];
+	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
+
+	decode_mode(pxd_dev->mode, modestr);
+	return sprintf(buf, "mode: %#x/%s\n", pxd_dev->mode, modestr);
+}
+
 static ssize_t pxd_wrsegment_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
@@ -1094,19 +1178,150 @@ static ssize_t pxd_congestion_show(struct device *dev,
                      struct device_attribute *attr, char *buf)
 {
 	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
-	struct request_queue *q = pxd_dev->disk->queue;
 
-	bool congested = atomic_read(&pxd_dev->fp.ncount) >= q->nr_congestion_on;
-	return sprintf(buf, "congested: %d/%d\n", congested, atomic_read(&pxd_dev->fp.ncongested));
+	return sprintf(buf, "congested: %s (%d/%d)\n",
+			pxd_dev->fp.congested ? "yes" : "no",
+			pxd_dev->fp.nr_congestion_on,
+			pxd_dev->fp.nr_congestion_off);
 }
 
-static ssize_t pxd_congestion_clear(struct device *dev, struct device_attribute *attr,
+static ssize_t pxd_congestion_set(struct device *dev, struct device_attribute *attr,
 			   const char *buf, size_t count)
 {
 	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
+	int thresh;
 
-	// debug interface to force wakeup of congestion wait threads
-	wake_up(&pxd_dev->fp.congestion_wait);
+	sscanf(buf, "%d", &thresh);
+
+	if (thresh < 0) {
+		thresh = pxd_dev->fp.qdepth;
+	}
+
+	if (thresh > MAX_CONGESTION_THRESHOLD) {
+		thresh = MAX_CONGESTION_THRESHOLD;
+	}
+
+	spin_lock_irq(&pxd_dev->lock);
+	pxd_dev->fp.qdepth = thresh;
+	spin_unlock_irq(&pxd_dev->lock);
+
+	return count;
+}
+
+static ssize_t pxd_fastpath_state(struct device *dev,
+                     struct device_attribute *attr, char *buf)
+{
+	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
+	return sprintf(buf, "%d\n", pxd_dev->fp.nfd);
+}
+
+static char* __strtok_r(char *src, const char delim, char **saveptr) {
+	char *curr;
+	char *start;
+
+	if (src) {
+		start = src;
+		*saveptr = NULL;
+	} else {
+		start = *saveptr;
+	}
+	curr = start;
+	while (curr && *curr) {
+		if (*curr == delim) {
+			*saveptr = curr+1;
+			*curr = '\0';
+
+			return start;
+		}
+		curr++;
+	}
+
+	return start;
+}
+
+static void __strip_nl(const char *src, char *dst, int maxlen) {
+	char *tmp;
+	int len=strlen(src);
+
+
+	if (!src || !dst) {
+		return;
+	}
+
+	dst[0] = '\0';
+	if (!len) {
+		return;
+	}
+
+	if (len >= maxlen) {
+		// to accomodate null
+		printk(KERN_WARNING"stripping newline output buffer overflow.. src %d(%s), dst %d\n",
+				len, src, maxlen);
+		len = maxlen - 1;
+	}
+
+	// leading space
+	while (src && *src) {
+		if (!isspace(*src) && !iscntrl(*src)) {
+			memcpy(dst,src,len);
+			dst[len]='\0';
+			break;
+		}
+		src++;
+		len--;
+	}
+
+	// trailing space
+	tmp = dst + len - 1;
+	while (len && *tmp) {
+		if (isspace(*tmp) || iscntrl(*tmp)) {
+			*tmp='\0';
+			tmp--;
+			len--;
+			continue;
+		}
+		break;
+	}
+
+	printk(KERN_INFO"stripping newline src=(%s), dst=(%s), len=%d\n",
+			src, dst, len);
+}
+
+static ssize_t pxd_fastpath_update(struct device *dev, struct device_attribute *attr,
+		               const char *buf, size_t count)
+{
+	// format: path,path,path
+	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
+	struct pxd_update_path_out update_out;
+	const char delim = ',';
+	char *token;
+	char *saveptr = NULL;
+	int i;
+	char trimtoken[256];
+
+	char *tmp = kzalloc(count, GFP_KERNEL);
+	if (!tmp) {
+		printk("No memory to process %lu bytes", count);
+		return count;
+	}
+	memcpy(tmp, buf, count);
+
+	i=0;
+	token = __strtok_r(tmp, delim, &saveptr);
+	for (i=0; i<MAX_PXD_BACKING_DEVS && token; i++) {
+		// strip the token of any newline/whitespace
+		__strip_nl(token, trimtoken, sizeof(trimtoken));
+		strncpy(update_out.devpath[i], trimtoken, MAX_PXD_DEVPATH_LEN);
+		update_out.devpath[i][MAX_PXD_DEVPATH_LEN] = '\0';
+
+		token = __strtok_r(0, delim, &saveptr);
+	}
+	update_out.size = i;
+	update_out.dev_id = pxd_dev->dev_id;
+
+	__pxd_update_path(pxd_dev, &update_out);
+	kfree(tmp);
+
 	return count;
 }
 
@@ -1116,8 +1331,10 @@ static DEVICE_ATTR(minor, S_IRUGO, pxd_minor_show, NULL);
 static DEVICE_ATTR(timeout, S_IRUGO|S_IWUSR, pxd_timeout_show, pxd_timeout_store);
 static DEVICE_ATTR(active, S_IRUGO, pxd_active_show, NULL);
 static DEVICE_ATTR(sync, S_IRUGO|S_IWUSR, pxd_sync_show, pxd_sync_store);
-static DEVICE_ATTR(congested, S_IRUGO|S_IWUSR, pxd_congestion_show, pxd_congestion_clear);
+static DEVICE_ATTR(congested, S_IRUGO|S_IWUSR, pxd_congestion_show, pxd_congestion_set);
 static DEVICE_ATTR(writesegment, S_IRUGO|S_IWUSR, pxd_wrsegment_show, pxd_wrsegment_store);
+static DEVICE_ATTR(fastpath, S_IRUGO|S_IWUSR, pxd_fastpath_state, pxd_fastpath_update);
+static DEVICE_ATTR(mode, S_IRUGO, pxd_mode_show, NULL);
 
 static struct attribute *pxd_attrs[] = {
 	&dev_attr_size.attr,
@@ -1128,6 +1345,8 @@ static struct attribute *pxd_attrs[] = {
 	&dev_attr_sync.attr,
 	&dev_attr_congested.attr,
 	&dev_attr_writesegment.attr,
+	&dev_attr_fastpath.attr,
+	&dev_attr_mode.attr,
 	NULL
 };
 
@@ -1196,130 +1415,8 @@ static void pxd_sysfs_exit(void)
 	device_unregister(&pxd_root_dev);
 }
 
-static void pxd_fill_init_desc(struct fuse_page_desc *desc, int num_ids)
-{
-	desc->length = num_ids * sizeof(struct pxd_dev_id);
-	desc->offset = 0;
-}
-
-static void pxd_fill_init(struct fuse_conn *fc, struct fuse_req *req,
-	struct pxd_init_in *in)
-{
-	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
-	int i = 0, j = 0;
-	int num_per_page = PAGE_SIZE / sizeof(struct pxd_dev_id);
-	struct pxd_device *pxd_dev;
-	struct pxd_dev_id *ids = NULL;
-
-	in->version = PXD_VERSION;
-
-	if (!req->num_pages)
-		return;
-
-	spin_lock(&ctx->lock);
-	list_for_each_entry(pxd_dev, &ctx->list, node) {
-		if (i == 0)
-			ids = kmap_atomic(req->pages[j]);
-		ids[i].dev_id = pxd_dev->dev_id;
-		ids[i].local_minor = pxd_dev->minor;
-		++i;
-		if (i == num_per_page) {
-			pxd_fill_init_desc(&req->page_descs[j], i);
-			kunmap_atomic(ids);
-			++j;
-			i = 0;
-		}
-	}
-	in->num_devices = ctx->num_devices;
-	spin_unlock(&ctx->lock);
-
-	if (i < num_per_page) {
-		pxd_fill_init_desc(&req->page_descs[j], i);
-		kunmap_atomic(ids);
-	}
-}
-
-static void pxd_process_init_reply(struct fuse_conn *fc,
-		struct fuse_req *req)
-{
-	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
-
-	printk(KERN_INFO "%s: pxd-control-%d:%llu init OK\n",
-		__func__, ctx->id, req->out.h.unique);
-	pxd_printk("%s: req %p err %d len %d un %lld\n",
-		__func__, req, req->out.h.error,
-		req->out.h.len, req->out.h.unique);
-
-	ctx->unique = req->out.h.unique;
-	if (req->out.h.error != 0)
-		fc->connected = 0;
-	fc->pend_open = 0;
-}
-
-static int pxd_send_init(struct fuse_conn *fc)
-{
-	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
-	int rc;
-	struct fuse_req *req;
-	struct pxd_init_in *arg;
-	void *outarg;
-	int i;
-	int num_per_page = PAGE_SIZE / sizeof(struct pxd_dev_id);
-	int num_pages = (sizeof(struct pxd_dev_id) * ctx->num_devices +
-				num_per_page - 1) / num_per_page;
-
-	req = fuse_get_req(fc, num_pages);
-	if (IS_ERR(req)) {
-		rc = PTR_ERR(req);
-		printk(KERN_ERR "%s: get req error %d\n", __func__, rc);
-		goto err;
-	}
-
-	req->num_pages = num_pages;
-
-	rc = -ENOMEM;
-	for (i = 0; i < req->num_pages; ++i) {
-		req->pages[i] = alloc_page(GFP_KERNEL | __GFP_ZERO);
-		if (!req->pages[i])
-			goto err_free_pages;
-	}
-
-	arg = &req->misc.pxd_init_in;
-	pxd_fill_init(fc, req, arg);
-
-	outarg = kzalloc(sizeof(struct pxd_init_out), GFP_KERNEL);
-	if (!outarg)
-		goto err_free_pages;
-
-	req->in.h.opcode = PXD_INIT;
-	req->in.numargs = 2;
-	req->in.args[0].size = sizeof(struct pxd_init_in);
-	req->in.args[0].value = arg;
-	req->in.args[1].size = sizeof(struct pxd_dev_id) * ctx->num_devices;
-	req->in.args[1].value = NULL;
-	req->in.argpages = 1;
-	req->end = pxd_process_init_reply;
-
-	fuse_request_send_oob(fc, req);
-
-	pxd_printk("%s: version %d num devices %ld(%d)\n", __func__, arg->version,
-		ctx->num_devices, arg->num_devices);
-	return 0;
-
-err_free_pages:
-	printk(KERN_ERR "%s: mem alloc\n", __func__);
-	for (i = 0; i < req->num_pages; ++i) {
-		if (req->pages[i])
-			put_page(req->pages[i]);
-	}
-	fuse_request_free(req);
-err:
-	return rc;
-}
-
 static int pxd_control_open(struct inode *inode, struct file *file)
 {
-	int rc;
 	struct pxd_context *ctx;
 	struct fuse_conn *fc;
 
@@ -1335,12 +1432,9 @@ static int pxd_control_open(struct inode *inode, struct file *file)
 	}
 
 	fc = &ctx->fc;
-	if (fc->pend_open == 1) {
-		printk(KERN_ERR "%s: too many outstanding opened\n", __func__);
-		return -EINVAL;
-	}
 	if (fc->connected == 1) {
-		printk(KERN_ERR "%s: pxd-control-%d already open\n", __func__, ctx->id);
+		printk(KERN_ERR "%s: pxd-control-%d(%lld) already open\n", __func__,
+			ctx->id, ctx->open_seq);
 		return -EINVAL;
 	}
 
@@ -1350,19 +1444,17 @@ static int pxd_control_open(struct inode *inode, struct file *file)
 	fc->connected = 1;
 	spin_unlock(&ctx->lock);
 
-	fc->pend_open = 1;
-	fc->initialized = 1;
 	fc->allow_disconnected = 1;
 	file->private_data = fc;
 
 	pxdctx_set_connected(ctx, true);
 	fuse_restart_requests(fc);
 
-	rc = pxd_send_init(fc);
-	if (rc)
-		return rc;
+	++ctx->open_seq;
 
-	printk(KERN_INFO "%s: pxd-control-%d open OK\n", __func__, ctx->id);
+	printk(KERN_INFO "%s: pxd-control-%d(%lld) open OK\n", __func__, ctx->id,
+		ctx->open_seq);
+
 	return 0;
 }
 
@@ -1380,12 +1472,11 @@ static int pxd_control_release(struct inode *inode, struct file *file)
 		pxd_printk("%s: not opened\n", __func__);
 	else
 		ctx->fc.connected = 0;
-	ctx->fc.pend_open = 0;
 	mod_timer(&ctx->timer, jiffies + (pxd_timeout_secs * HZ));
 	spin_unlock(&ctx->lock);
 
-	printk(KERN_INFO "%s: pxd-control-%d:%llu close OK\n", __func__,
-		ctx->id, ctx->unique);
+	printk(KERN_INFO "%s: pxd-control-%d(%lld) close OK\n", __func__, ctx->id,
+		ctx->open_seq);
 	return 0;
 }
 
@@ -1419,27 +1510,29 @@ static void pxd_timeout(unsigned long args)
 	fc->allow_disconnected = 0;
 	pxdctx_set_connected(ctx, false);
 	fuse_abort_conn(fc);
-	printk(KERN_INFO "PXD_TIMEOUT (%s:%llu): Aborting all requests...",
-		ctx->name, ctx->unique);
+	printk(KERN_INFO "PXD_TIMEOUT (%s:%u): Aborting all requests...",
+		ctx->name, ctx->id);
 }
 
 int pxd_context_init(struct pxd_context *ctx, int i)
 {
 	int err;
+
 	spin_lock_init(&ctx->lock);
 	ctx->id = i;
+	ctx->open_seq = 0;
 	ctx->fops = fuse_dev_operations;
 	ctx->fops.owner = THIS_MODULE;
 	ctx->fops.open = pxd_control_open;
 	ctx->fops.release = pxd_control_release;
+	ctx->fops.unlocked_ioctl = pxd_control_ioctl;
 
 	if (ctx->id < pxd_num_contexts_exported) {
 		err = fuse_conn_init(&ctx->fc);
 		if (err)
 			return err;
-	} else {
-		ctx->fops.unlocked_ioctl = pxd_control_ioctl;
 	}
+
 	ctx->fc.release = pxd_fuse_conn_release;
 	ctx->fc.allow_disconnected = 1;
 	INIT_LIST_HEAD(&ctx->list);
@@ -1506,18 +1599,11 @@ int pxd_init(void)
 			pxd_miscdev.name, err);
 		goto out_fuse;
 	}
-#ifdef __PX_BLKMQ__
-        pxd_wq = alloc_workqueue("pxd", WQ_MEM_RECLAIM, 0);
-        if (!pxd_wq) {
-                err = -ENOMEM;
-                goto out_misc;
-        }
-#endif
 	pxd_major = register_blkdev(0, "pxd");
 	if (pxd_major < 0) {
 		err = pxd_major;
 		printk(KERN_ERR "pxd: failed to register dev pxd: %d\n", err);
-		goto out_wq;
+		goto out_misc;
 	}
 
 	err = pxd_sysfs_init();
@@ -1541,11 +1627,7 @@ int pxd_init(void)
 
 out_blkdev:
 	unregister_blkdev(0, "pxd");
-out_wq:
-#ifdef __PX_BLKMQ__
-        destroy_workqueue(pxd_wq);
 out_misc:
-#endif
 	misc_deregister(&pxd_miscdev);
 out_fuse:
 	for (j = 0; j < i; ++j) {
@@ -1565,9 +1647,6 @@ void pxd_exit(void)
 	fastpath_cleanup();
 	pxd_sysfs_exit();
 	unregister_blkdev(pxd_major, "pxd");
-#ifdef __PX_BLKMQ__
-        destroy_workqueue(pxd_wq);
-#endif
 	misc_deregister(&pxd_miscdev);
 
 	for (i = 0; i < pxd_num_contexts; ++i) {

--- a/pxd.h
+++ b/pxd.h
@@ -27,10 +27,16 @@
 #define PXD_IOCTL_MAGIC			(('P' << 8) | 'X')
 #define PXD_IOC_DUMP_FC_INFO	_IO(PXD_IOCTL_MAGIC, 1)		/* 0x505801 */
 #define PXD_IOC_GET_VERSION		_IO(PXD_IOCTL_MAGIC, 2)		/* 0x505802 */
+#define PXD_IOC_INIT		_IO(PXD_IOCTL_MAGIC, 3)		/* 0x505803 */
 
 #define PXD_MAX_DEVICES	512			/**< maximum number of devices supported */
 #define PXD_MAX_IO		(1024*1024)	/**< maximum io size in bytes */
 #define PXD_MAX_QDEPTH  256			/**< maximum device queue depth */
+
+// use by fastpath for congestion control
+#define DEFAULT_CONGESTION_THRESHOLD (PXD_MAX_QDEPTH)
+// NOTE: nvme devices can go upto 1023 queue depth
+#define MAX_CONGESTION_THRESHOLD (1024)
 
 #define MAX_PXD_BACKING_DEVS (3)  /**< maximum number of replica targets for each user vol */
 #define MAX_PXD_DEVPATH_LEN (127) /**< device path length */
@@ -46,7 +52,10 @@ enum pxd_opcode {
 	PXD_READ_DATA,		/**< read data from kernel */
 	PXD_UPDATE_SIZE,	/**< update device size */
 	PXD_WRITE_SAME,		/**< write_same operation */
-	PXD_UPDATE_PATH,        /**< update backing file/device path for a volume */
+	PXD_ADD_EXT,		/**< add device with extended info to kernel */
+	PXD_UPDATE_PATH,    /**< update backing file/device path for a volume */
+	PXD_SET_FASTPATH,   /**< enable/disable fastpath */
+	PXD_GET_FEATURES,   /**< get features */
 	PXD_LAST,
 };
 
@@ -86,6 +95,15 @@ struct pxd_init_out {
 };
 
 /**
+ * PXD_UPDATE_PATH request from user space
+ */
+struct pxd_update_path_out {
+	uint64_t dev_id;
+	size_t size; // count of paths below.
+	char devpath[MAX_PXD_BACKING_DEVS][MAX_PXD_DEVPATH_LEN+1];
+};
+
+/**
  * PXD_ADD request from user space
  */
 struct pxd_add_out {
@@ -93,8 +111,21 @@ struct pxd_add_out {
 	size_t size;		/**< block device size in bytes */
 	int32_t queue_depth;	/**< use queue depth 0 to bypass queueing */
 	int32_t discard_size;	/**< block device discard size in bytes */
-	mode_t  open_mode; /**< backing file open mode O_RDONLY|O_SYNC|O_DIRECT etc */
 };
+
+/**
+ * PXD_ADD_EXT request from user space
+ */
+struct pxd_add_ext_out {
+	uint64_t dev_id;	/**< device global id */
+	size_t size;		/**< block device size in bytes */
+	int32_t queue_depth;	/**< use queue depth 0 to bypass queueing */
+	int32_t discard_size;	/**< block device discard size in bytes */
+	mode_t  open_mode; /**< backing file open mode O_RDONLY|O_SYNC|O_DIRECT etc */
+	int     enable_fp; /**< enable fast path */
+	struct pxd_update_path_out paths; /**< backing device paths */
+};
+
 
 /**
  * PXD_REMOVE request from user space
@@ -123,13 +154,21 @@ struct pxd_update_size_out {
 };
 
 /**
- * PXD_UPDATE_PATH request from user space
+ * PXD_SET_FASTPATH request from user space
  */
-struct pxd_update_path_out {
+struct pxd_fastpath_out {
 	uint64_t dev_id;
-	size_t size; // count of paths below.
-	char devpath[MAX_PXD_BACKING_DEVS][MAX_PXD_DEVPATH_LEN+1];
+	int enable;
+	int cleanup; // only meaningful while disabling
 };
+
+/**
+ * PXD_GET_FEATURES request from user space
+ * response contains feature set
+ */
+// No arguments necessary other than opcode
+#define PXD_FEATURE_FASTPATH (0x1)
+
 
 /**
  * PXD_READ/PXD_WRITE kernel request structure
@@ -204,6 +243,13 @@ static inline uint64_t pxd_rd_blocks(const struct rdwr_in *rdwr)
 struct pxd_ioctl_version_args {
 	int piv_len;
 	char piv_data[64];
+};
+
+struct pxd_ioctl_init_args {
+	struct pxd_init_in hdr;
+
+	/** list of devices */
+	struct pxd_dev_id devices[PXD_MAX_DEVICES];
 };
 
 #endif /* PXD_H_ */

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -41,7 +41,7 @@
 #define SUBMIT_BIO(bio) submit_bio(bio)
 #else
 // only supports read or write
-#define BIO_OP(bio)   (bio->bi_rw & 1)
+#define BIO_OP(bio)   ((bio)->bi_rw & 1)
 #define SUBMIT_BIO(bio)  submit_bio(BIO_OP(bio), bio)
 #endif
 

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1,55 +1,224 @@
 #include <linux/types.h>
+#include <linux/delay.h>
 
 #include "pxd.h"
 #include "pxd_core.h"
 #include "pxd_compat.h"
 
+// cached info at px loadtime, to gracefully handle hot plugging cpus
+static int __px_ncpus;
+
+// A private global bio mempool for punting requests bypassing vfs
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0)
 static struct bio_set pxd_bio_set;
 #endif
 #define PXD_MIN_POOL_PAGES (128)
 static struct bio_set* ppxd_bio_set;
 
-// A one-time built, static lookup table to distribute requests to cpu
-// within same numa node
-// A private global bio mempool for punting requests bypassing vfs
-static struct node_cpu_map *node_cpu_map;
+// global thread contexts
+static struct thread_context *g_tc;
 
 // forward decl
-static void disableFastPath(struct pxd_device *pxd_dev);
+static int pxd_io_writer(void *data);
+static int pxd_io_reader(void *data);
+static void __pxd_cleanup_block_io(struct pxd_io_tracker *head);
+static struct pxd_io_tracker* pxd_get_io(struct thread_context *tc, int rw);
+#define pxd_get_writeio(tc)  pxd_get_io(tc, WRITE)
+#define pxd_get_readio(tc)   pxd_get_io(tc, READ)
 
-static inline
-int getnextcpu(int node, int pos)
+// congestion callback from kernel writeback module
+int pxd_device_congested(void *data, int bits)
 {
-	const struct node_cpu_map *map = &node_cpu_map[node];
-	if (map->ncpu == 0) {
-		return 0;
+	struct pxd_device *pxd_dev = data;
+	int ncount = atomic_read(&pxd_dev->fp.ncount);
+
+	// notify congested if device is suspended as well.
+	// modified under lock, read outside lock.
+	if (pxd_dev->fp.suspend) {
+		return 1;
 	}
 
-	return map->cpu[(pos) % map->ncpu];
+	// does not care about async or sync request.
+	if (ncount > pxd_dev->fp.qdepth) {
+		spin_lock_irq(&pxd_dev->lock);
+		if (!pxd_dev->fp.congested) {
+			pxd_dev->fp.congested = true;
+			pxd_dev->fp.nr_congestion_on++;
+		}
+		spin_unlock_irq(&pxd_dev->lock);
+		return 1;
+	}
+
+	if (pxd_dev->fp.congested) {
+		if (ncount < (3*pxd_dev->fp.qdepth)/4) {
+			spin_lock_irq(&pxd_dev->lock);
+			if (pxd_dev->fp.congested) {
+				pxd_dev->fp.congested = false;
+				pxd_dev->fp.nr_congestion_off++;
+			}
+			spin_unlock_irq(&pxd_dev->lock);
+			return 0;
+		}
+		return 1;
+	}
+
+	return 0;
+}
+
+static inline
+int pxd_io_empty(struct thread_context *tc, int rw)
+{
+	int empty;
+
+	if (rw == WRITE) {
+		spin_lock_irq(&tc->write_lock);
+		empty = list_empty(&tc->iot_writers);
+		spin_unlock_irq(&tc->write_lock);
+	} else {
+		spin_lock_irq(&tc->read_lock);
+		empty = list_empty(&tc->iot_readers);
+		spin_unlock_irq(&tc->read_lock);
+	}
+
+	return empty;
+}
+
+static inline
+void pxd_wait_io(struct thread_context *tc, int rw)
+{
+	if (rw == READ) {
+		wait_event_interruptible(tc->read_event,
+                            !pxd_io_empty(tc, rw) || kthread_should_stop());
+	} else {
+		wait_event_interruptible(tc->write_event,
+                            !pxd_io_empty(tc, rw) || kthread_should_stop());
+	}
+}
+
+static int fastpath_global_threadctx_init(struct thread_context *tc, int cpuid)
+{
+	int i;
+	int err;
+	int node = cpu_to_node(cpuid);
+
+	spin_lock_init(&tc->read_lock);
+	init_waitqueue_head(&tc->read_event);
+	INIT_LIST_HEAD(&tc->iot_readers);
+
+	spin_lock_init(&tc->write_lock);
+	init_waitqueue_head(&tc->write_event);
+	INIT_LIST_HEAD(&tc->iot_writers);
+
+	// setup readers
+	for (i = 0; i < PXD_MAX_THREAD_PER_CPU; i++) {
+		// set dedicated thread function
+		tc->reader[i] = kthread_create_on_node(pxd_io_reader, tc,
+				node, "pxwr%d:%d:%d", node, cpuid, i);
+		if (IS_ERR(tc->reader[i])) {
+			pxd_printk("Init global reader kthread for cpu %d failed %lu\n",
+				cpuid, PTR_ERR(tc->reader[i]));
+			err = -EINVAL;
+			goto fail_rd;
+		}
+
+		//  bind readers on any cpu but on same numa node
+		set_cpus_allowed_ptr(tc->reader[i], cpumask_of_node(node));
+		set_user_nice(tc->reader[i], MIN_NICE);
+		wake_up_process(tc->reader[i]);
+	}
+
+	// setup writers
+	for (i = 0; i < PXD_MAX_THREAD_PER_CPU; i++) {
+		// set dedicated thread function
+		tc->writer[i] = kthread_create_on_node(pxd_io_writer, tc,
+				node, "pxrd%d:%d:%d", node, cpuid, i);
+		if (IS_ERR(tc->writer[i])) {
+			pxd_printk("Init global writer kthread for cpu %d failed %lu\n",
+				cpuid, PTR_ERR(tc->writer[i]));
+			err = -EINVAL;
+			goto fail_wr;
+		}
+
+		//  bind all writers on the same cpu
+		kthread_bind(tc->writer[i], cpuid);
+		set_user_nice(tc->writer[i], MIN_NICE);
+		wake_up_process(tc->writer[i]);
+	}
+
+	return 0;
+
+fail_wr:
+	for(;i >= 0; i--) {
+		if (tc->writer[i]) kthread_stop(tc->writer[i]);
+	}
+	i = PXD_MAX_THREAD_PER_CPU;
+fail_rd:
+	for(;i >= 0; i--) {
+		if (tc->reader[i]) kthread_stop(tc->reader[i]);
+	}
+	return err;
+}
+
+static void fastpath_global_threadctx_cleanup(void)
+{
+	int i,t;
+	struct pxd_io_tracker *head;
+	struct thread_context *tc;
+
+	if (!g_tc) return;
+
+	for (i = 0; i < __px_ncpus; i++) {
+		tc = &g_tc[i];
+		for (t=0;t<PXD_MAX_THREAD_PER_CPU; t++) {
+			if (tc->writer[t]) kthread_stop(tc->writer[t]);
+			if (tc->reader[t]) kthread_stop(tc->reader[t]);
+		}
+
+		// fail all enqueue'd IOs
+		while ((head = pxd_get_readio(tc)) != NULL) {
+			if (head->orig) BIO_ENDIO(head->orig, -ENXIO);
+			__pxd_cleanup_block_io(head);
+		}
+
+		while ((head = pxd_get_writeio(tc)) != NULL) {
+			if (head->orig) BIO_ENDIO(head->orig, -ENXIO);
+			__pxd_cleanup_block_io(head);
+		}
+	}
 }
 
 int fastpath_init(void)
 {
-	int i;
+	int i, err;
 
-	printk(KERN_INFO"CPU %d/%d, NUMA nodes %d/%d\n", nr_cpu_ids, NR_CPUS, nr_node_ids, MAX_NUMNODES);
-	node_cpu_map = kzalloc(sizeof(struct node_cpu_map) * nr_node_ids, GFP_KERNEL);
-	if (!node_cpu_map) {
-		printk(KERN_ERR "pxd: failed to initialize node_cpu_map: -ENOMEM\n");
+	// cache the count of cpu information at module load time.
+	// if there is any subsequent hot plugging of cpus, will still handle gracefully.
+	__px_ncpus = nr_cpu_ids;
+
+	printk(KERN_INFO"CPU %d/%d, NUMA nodes %d/%d\n", __px_ncpus, NR_CPUS, nr_node_ids, MAX_NUMNODES);
+	g_tc = kzalloc(sizeof(struct thread_context) * __px_ncpus, GFP_KERNEL);
+	if (!g_tc) {
+		printk(KERN_ERR "pxd: failed to initialize global thread context: -ENOMEM\n");
 		return -ENOMEM;
 	}
 
-	for (i = 0; i < nr_cpu_ids; i++) {
-		struct node_cpu_map *map=&node_cpu_map[cpu_to_node(i)];
-		map->cpu[map->ncpu++] = i;
+	// capturing all the cpu's on a given numa node during run-time
+	for (i = 0; i < __px_ncpus; i++) {
+		// initialize global thread context
+		err = fastpath_global_threadctx_init(&g_tc[i], i);
+		if (err) {
+			fastpath_global_threadctx_cleanup();
+			kfree(g_tc);
+			return err;
+		}
 	}
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0)
 	if (bioset_init(&pxd_bio_set, PXD_MIN_POOL_PAGES,
 			offsetof(struct pxd_io_tracker, clone), 0)) {
 		printk(KERN_ERR "pxd: failed to initialize bioset_init: -ENOMEM\n");
-		kfree(node_cpu_map);
+		fastpath_global_threadctx_cleanup();
+		kfree(g_tc);
 		return -ENOMEM;
 	}
 	ppxd_bio_set = &pxd_bio_set;
@@ -59,7 +228,8 @@ int fastpath_init(void)
 
 	if (!ppxd_bio_set) {
 		printk(KERN_ERR "pxd: bioset init failed");
-		kfree(node_cpu_map);
+		fastpath_global_threadctx_cleanup();
+		kfree(g_tc);
 		return -ENOMEM;
 	}
 
@@ -68,6 +238,8 @@ int fastpath_init(void)
 
 void fastpath_cleanup(void)
 {
+	fastpath_global_threadctx_cleanup();
+
 	if (ppxd_bio_set) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0)
 		bioset_exit(ppxd_bio_set);
@@ -76,26 +248,14 @@ void fastpath_cleanup(void)
 #endif
 	}
 
-	if (node_cpu_map) kfree(node_cpu_map);
+	if (g_tc) kfree(g_tc);
 	ppxd_bio_set = NULL;
-	node_cpu_map = NULL;
+	g_tc = NULL;
 }
 
-static inline
-struct file* getFile(struct pxd_device *pxd_dev, int index)
-{
-	if (index < pxd_dev->fp.nfd) {
-		return pxd_dev->fp.file[index];
-	}
-
-	return NULL;
-}
-
-static int _pxd_flush(struct pxd_device *pxd_dev)
+static int _pxd_flush(struct pxd_device *pxd_dev, struct file *file)
 {
 	int ret = 0;
-	int index;
-	struct file *file;
 
 	// pxd_dev is opened in o_sync mode. all writes are complete with implicit sync.
 	// explicit sync can be treated nop
@@ -104,12 +264,9 @@ static int _pxd_flush(struct pxd_device *pxd_dev)
 		return 0;
 	}
 
-	for (index=0; index<pxd_dev->fp.nfd; index++) {
-		file = getFile(pxd_dev, index);
-		ret = vfs_fsync(file, 0);
-		if (unlikely(ret && ret != -EINVAL && ret != -EIO)) {
-			ret = -EIO;
-		}
+	ret = vfs_fsync(file, 0);
+	if (unlikely(ret && ret != -EINVAL && ret != -EIO)) {
+		ret = -EIO;
 	}
 	atomic_inc(&pxd_dev->fp.nio_flush);
 	atomic_set(&pxd_dev->fp.nwrite_counter, 0);
@@ -128,18 +285,17 @@ static int pxd_should_flush(struct pxd_device *pxd_dev, int *active)
 	return 0;
 }
 
-static void pxd_issue_sync(struct pxd_device *pxd_dev)
+static void pxd_issue_sync(struct pxd_device *pxd_dev, struct file *file)
 {
-	int i;
 	struct block_device *bdev = bdget_disk(pxd_dev->disk, 0);
+	int ret;
+
 	if (!bdev) return;
 
-	for (i = 0; i < pxd_dev->fp.nfd; i++) {
-		int ret = vfs_fsync(getFile(pxd_dev, i), 0);
-		if (unlikely(ret && ret != -EINVAL && ret != -EIO)) {
-			printk(KERN_WARNING"device %llu fsync failed with %d\n",
-					pxd_dev->dev_id, ret);
-		}
+	ret = vfs_fsync(file, 0);
+	if (unlikely(ret && ret != -EINVAL && ret != -EIO)) {
+		printk(KERN_WARNING"device %llu fsync failed with %d\n",
+				pxd_dev->dev_id, ret);
 	}
 
 	spin_lock_irq(&pxd_dev->fp.sync_lock);
@@ -151,7 +307,7 @@ static void pxd_issue_sync(struct pxd_device *pxd_dev)
 	wake_up(&pxd_dev->fp.sync_event);
 }
 
-static void pxd_check_write_cache_flush(struct pxd_device *pxd_dev)
+static void pxd_check_write_cache_flush(struct pxd_device *pxd_dev, struct file *file)
 {
 	int sync_wait, sync_now;
 	spin_lock_irq(&pxd_dev->fp.sync_lock);
@@ -164,33 +320,26 @@ static void pxd_check_write_cache_flush(struct pxd_device *pxd_dev)
 	}
 	spin_unlock_irq(&pxd_dev->fp.sync_lock);
 
-	if (sync_now) pxd_issue_sync(pxd_dev);
+	if (sync_now) pxd_issue_sync(pxd_dev, file);
 }
 
-static int _pxd_bio_discard(struct pxd_device *pxd_dev, struct bio *bio, loff_t pos)
+static int _pxd_bio_discard(struct pxd_device *pxd_dev, struct file *file, struct bio *bio, loff_t pos)
 {
-	struct file *file;
 	int mode = FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE;
 	int ret;
-	int i;
 
 	atomic_inc(&pxd_dev->fp.nio_discard);
 
-	for (i = 0; i < pxd_dev->fp.nfd; i++) {
-		pxd_printk("device %llu calling discard [%s] (REQ_DISCARD)...\n",
-				pxd_dev->dev_id, pxd_dev->fp.device_path[i]);
-		file = getFile(pxd_dev, i);
-		if ((!file->f_op->fallocate)) {
-			return -EOPNOTSUPP;
-		}
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
-		ret = file->f_op->fallocate(file, mode, pos, bio->bi_iter.bi_size);
-#else
-		ret = file->f_op->fallocate(file, mode, pos, bio->bi_size);
-#endif
-		if (unlikely(ret && ret != -EINVAL && ret != -EOPNOTSUPP))
-			return -EIO;
+	if ((!file->f_op->fallocate)) {
+		return -EOPNOTSUPP;
 	}
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
+	ret = file->f_op->fallocate(file, mode, pos, bio->bi_iter.bi_size);
+#else
+	ret = file->f_op->fallocate(file, mode, pos, bio->bi_size);
+#endif
+	if (unlikely(ret && ret != -EINVAL && ret != -EOPNOTSUPP))
+		return -EIO;
 
 	return 0;
 }
@@ -243,7 +392,7 @@ static int _pxd_write(uint64_t dev_id, struct file *file, struct bio_vec *bvec, 
 	return bw;
 }
 
-static int do_pxd_send(struct pxd_device *pxd_dev, struct bio *bio, loff_t pos)
+static int pxd_send(struct pxd_device *pxd_dev, struct file *file, struct bio *bio, loff_t pos)
 {
 	int ret = 0;
 	int nsegs = 0;
@@ -254,37 +403,29 @@ static int do_pxd_send(struct pxd_device *pxd_dev, struct bio *bio, loff_t pos)
 	struct bio_vec *bvec;
 	int i;
 #endif
-	int fileindex;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
 	bio_for_each_segment(bvec, bio, i) {
 		nsegs++;
-
-		for (fileindex = 0; fileindex < pxd_dev->fp.nfd; fileindex++) {
-			struct file *file = getFile(pxd_dev, fileindex);
-			loff_t tpos = pos;
-			ret = _pxd_write(pxd_dev->dev_id, file, &bvec, &tpos);
-			if (ret < 0) {
-				return ret;
-			}
+		ret = _pxd_write(pxd_dev->dev_id, file, &bvec, &pos);
+		if (ret < 0) {
+			printk(KERN_ERR"do_pxd_write pos %lld page %p, off %u for len %d FAILED %d\n",
+				pos, bvec.bv_page, bvec.bv_offset, bvec.bv_len, ret);
+			return ret;
 		}
 
-		pos += bvec.bv_len;
 		cond_resched();
 	}
 #else
 	bio_for_each_segment(bvec, bio, i) {
 		nsegs++;
-		for (fileindex = 0; fileindex < pxd_dev->fp.nfd; fileindex++) {
-			struct file *file = getFile(pxd_dev, fileindex);
-			loff_t tpos = pos;
-			ret = _pxd_write(pxd_dev->dev_id, file, bvec, &tpos);
-			if (ret < 0) {
-				return ret;
-			}
+		ret = _pxd_write(pxd_dev->dev_id, file, bvec, &pos);
+		if (ret < 0) {
+			pxd_printk("device %llu: do_pxd_write pos %lld page %p, off %u for len %d FAILED %d\n",
+				pxd_dev->dev_id, pos, bvec->bv_page, bvec->bv_offset, bvec->bv_len, ret);
+			return ret;
 		}
 
-		pos += bvec->bv_len;
 		cond_resched();
 	}
 #endif
@@ -294,7 +435,7 @@ static int do_pxd_send(struct pxd_device *pxd_dev, struct bio *bio, loff_t pos)
 }
 
 static
-ssize_t _pxd_read(struct file *file, struct bio_vec *bvec, loff_t *pos)
+ssize_t _pxd_read(uint64_t dev_id, struct file *file, struct bio_vec *bvec, loff_t *pos)
 {
 	int result = 0;
 
@@ -303,6 +444,7 @@ ssize_t _pxd_read(struct file *file, struct bio_vec *bvec, loff_t *pos)
 	struct iov_iter i;
 
 	iov_iter_bvec(&i, READ, bvec, 1, bvec->bv_len);
+	result = vfs_iter_read(file, &i, pos, 0);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
 	struct iov_iter i;
 
@@ -322,16 +464,12 @@ ssize_t _pxd_read(struct file *file, struct bio_vec *bvec, loff_t *pos)
 	set_fs(old_fs);
 	kunmap(bvec->bv_page);
 #endif
-	if (result < 0) printk(KERN_ERR "__vfs_read return %d\n", result);
+	if (result < 0)
+		printk(KERN_ERR "device %llu: __vfs_read return %d\n", dev_id, result);
 	return result;
 }
 
-static ssize_t do_pxd_receive(struct pxd_device *pxd_dev, struct bio_vec *bvec, loff_t pos)
-{
-        return _pxd_read(getFile(pxd_dev, 0), bvec, &pos);
-}
-
-static ssize_t pxd_receive(struct pxd_device *pxd_dev, struct bio *bio, loff_t pos)
+static ssize_t pxd_receive(struct pxd_device *pxd_dev, struct file *file, struct bio *bio, loff_t *pos)
 {
 	ssize_t s;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
@@ -344,32 +482,74 @@ static ssize_t pxd_receive(struct pxd_device *pxd_dev, struct bio *bio, loff_t p
 
 	bio_for_each_segment(bvec, bio, i) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
-		s = do_pxd_receive(pxd_dev, &bvec, pos);
+		s = _pxd_read(pxd_dev->dev_id, file, &bvec, pos);
 		if (s < 0) return s;
 
 		if (s != bvec.bv_len) {
 			zero_fill_bio(bio);
 			break;
 		}
-		pos += bvec.bv_len;
 #else
-		s = do_pxd_receive(pxd_dev, bvec, pos);
+		s = _pxd_read(pxd_dev->dev_id, file, bvec, pos);
 		if (s < 0) return s;
 
 		if (s != bvec->bv_len) {
 			zero_fill_bio(bio);
 			break;
 		}
-		pos += bvec->bv_len;
 #endif
 	}
 	return 0;
+}
+
+static void __pxd_cleanup_block_io(struct pxd_io_tracker *head)
+{
+	while (!list_empty(&head->replicas)) {
+		struct pxd_io_tracker *repl = list_first_entry(&head->replicas, struct pxd_io_tracker, item);
+		pxd_printk("__pxd_cleanup_block_io for head %p, repl %p\n", head, repl);
+		list_del(&repl->item);
+		bio_put(&repl->clone);
+	}
+
+	pxd_printk("__pxd_cleanup_block_io freeing head %p\n", head);
+	bio_put(&head->clone);
 }
 
 static void pxd_complete_io(struct bio* bio)
 {
 	struct pxd_io_tracker *iot = container_of(bio, struct pxd_io_tracker, clone);
 	struct pxd_device *pxd_dev = bio->bi_private;
+	struct pxd_io_tracker *head = iot->head;
+
+	pxd_io_printk("%s: dev m %d g %lld %s at %ld len %d bytes %d pages "
+			"flags 0x%x op %#x op_flags 0x%x\n", __func__,
+			pxd_dev->minor, pxd_dev->dev_id,
+			bio_data_dir(bio) == WRITE ? "wr" : "rd",
+			BIO_SECTOR(bio) * SECTOR_SIZE, BIO_SIZE(bio),
+			bio->bi_vcnt, bio->bi_flags,
+			(bio->bi_opf & REQ_OP_MASK),
+			((bio->bi_opf & ~REQ_OP_MASK) >> REQ_OP_BITS));
+
+	pxd_printk("pxd_complete_io for bio %p (pxd %p) with head %p active %d\n",
+			bio, pxd_dev, head, atomic_read(&head->active));
+
+	if (!atomic_dec_and_test(&head->active)) {
+		// not all responses have come back
+		// but update head status if this is a failure
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
+		if (bio->bi_status) {
+			atomic_inc(&head->fails);
+		}
+#else
+		if (bio->bi_error) {
+			atomic_inc(&head->fails);
+		}
+#endif
+		pxd_printk("pxd_complete_io for bio %p (pxd %p) with head %p active %d error %d early return\n",
+			bio, pxd_dev, head, atomic_read(&head->active), atomic_read(&head->fails));
+
+		return;
+	}
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
 	generic_end_io_acct(pxd_dev->disk->queue, bio_op(bio), &pxd_dev->disk->part0, iot->start);
@@ -377,14 +557,23 @@ static void pxd_complete_io(struct bio* bio)
 	generic_end_io_acct(bio_data_dir(bio), &pxd_dev->disk->part0, iot->start);
 #endif
 
+	pxd_printk("pxd_complete_io for bio %p (pxd %p) with head %p active %d - completing orig %p\n",
+			bio, pxd_dev, head, atomic_read(&head->active), iot->orig);
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
 {
 	iot->orig->bi_status = bio->bi_status;
+	if (atomic_read(&head->fails)) {
+		iot->orig->bi_status = -EIO; // mark failure
+	}
 	bio_endio(iot->orig);
 }
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
 {
 	int status = bio->bi_error;
+	if (atomic_read(&head->fails)) {
+		status = -EIO; // mark failure
+	}
 	if (status) {
 		bio_io_error(iot->orig);
 	} else {
@@ -392,52 +581,107 @@ static void pxd_complete_io(struct bio* bio)
 	}
 }
 #else
-    bio_endio(iot->orig, bio->bi_error);
+{
+	int status = bio->bi_error;
+	if (atomic_read(&head->fails)) {
+		status = -EIO; // mark failure
+	}
+	bio_endio(iot->orig, status);
+}
 #endif
 
-	atomic_inc(&pxd_dev->fp.ncomplete);
+	__pxd_cleanup_block_io(head);
+
 	atomic_dec(&pxd_dev->fp.ncount);
-
-	bio_put(bio);
-
-	/* free up from any prior congestion wait */
-	spin_lock_irq(&pxd_dev->lock);
-	if (atomic_read(&pxd_dev->fp.ncount) < pxd_dev->disk->queue->nr_congestion_off) {
-		wake_up(&pxd_dev->fp.congestion_wait);
-	}
-	spin_unlock_irq(&pxd_dev->lock);
+	atomic_inc(&pxd_dev->fp.ncomplete);
 }
 
-static int pxd_switch_bio(struct pxd_device *pxd_dev, struct bio* bio) {
-	struct address_space *mapping = pxd_dev->fp.file[0]->f_mapping;
+static struct pxd_io_tracker* __pxd_init_block_replica(struct pxd_device *pxd_dev,
+		struct bio *bio, struct file *fileh) {
+	struct bio* clone_bio;
+	struct pxd_io_tracker* iot;
+	struct address_space *mapping = fileh->f_mapping;
 	struct inode *inode = mapping->host;
 	struct block_device *bdi = I_BDEV(inode);
-	struct bio* clone_bio = bio_clone_fast(bio, GFP_KERNEL, ppxd_bio_set);
-	struct pxd_io_tracker* iot = container_of(clone_bio, struct pxd_io_tracker, clone);
 
+	pxd_printk("pxd %p:__pxd_init_block_replica entering with bio %p, fileh %p with blkg %p\n",
+			pxd_dev, bio, fileh, bio->bi_blkg);
+
+	clone_bio = bio_clone_fast(bio, GFP_KERNEL, ppxd_bio_set);
 	if (!clone_bio) {
-		return -ENOMEM;
+		pxd_printk(KERN_ERR"No memory for io context");
+		return NULL;
 	}
 
+	iot = container_of(clone_bio, struct pxd_io_tracker, clone);
+
+	iot->pxd_dev = pxd_dev;
+	iot->head = iot;
+	INIT_LIST_HEAD(&iot->replicas);
+	INIT_LIST_HEAD(&iot->item);
 	iot->orig = bio;
 	iot->start = jiffies;
-	BIO_SET_DEV(clone_bio, bdi);
-	clone_bio->bi_private = pxd_dev;
-	clone_bio->bi_end_io = pxd_complete_io;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
-	generic_start_io_acct(pxd_dev->disk->queue, bio_op(bio), REQUEST_GET_SECTORS(bio), &pxd_dev->disk->part0);
+	atomic_set(&iot->active, 0);
+	atomic_set(&iot->fails, 0);
+	iot->file = fileh;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)
+	iot->read = (bio_op(bio) == REQ_OP_READ);
 #else
-	generic_start_io_acct(bio_data_dir(bio), REQUEST_GET_SECTORS(bio), &pxd_dev->disk->part0);
+	iot->read = (bio_data_dir(bio) == READ);
 #endif
 
-	SUBMIT_BIO(clone_bio);
-	atomic_inc(&pxd_dev->fp.ncount);
-	atomic_inc(&pxd_dev->fp.nswitch);
+	pxd_printk("pxd %p:__pxd_init_block_replica clone bio %p (blkg %p), resetting backing block dev to %p\n",
+			pxd_dev, clone_bio, clone_bio->bi_blkg, bdi);
 
-	return 0;
+	if (S_ISBLK(inode->i_mode)) {
+		BIO_SET_DEV(clone_bio, bdi);
+	}
+	clone_bio->bi_private = pxd_dev;
+	clone_bio->bi_end_io = pxd_complete_io;
+
+	pxd_printk("pxd %p:__pxd_init_block_replica allocated repl %p for orig bio %p\n",
+			pxd_dev, iot, bio);
+
+	return iot;
 }
 
-static void _pxd_setup(struct pxd_device *pxd_dev, bool enable) {
+static
+struct pxd_io_tracker* __pxd_init_block_head(struct pxd_device *pxd_dev, struct bio* bio) {
+	struct pxd_io_tracker* head;
+	struct pxd_io_tracker *repl;
+	int index;
+
+	pxd_printk("pxd %p:__pxd_init_block_replica to allocate iotracker for bio %p\n",
+			pxd_dev, bio);
+
+	head = __pxd_init_block_replica(pxd_dev, bio, pxd_dev->fp.file[0]);
+	if (!head) {
+		return NULL;
+	}
+	// initialize the replicas only if the request is non-read
+	if (!head->read) {
+		for (index=1; index<pxd_dev->fp.nfd; index++) {
+			repl = __pxd_init_block_replica(pxd_dev, bio, pxd_dev->fp.file[index]);
+			if (!repl) {
+				goto repl_cleanup;
+			}
+
+			repl->head = head;
+			list_add(&repl->item, &head->replicas);
+		}
+	}
+
+	pxd_printk("pxd %p:__pxd_init_block_head allocated head %p for orig bio %p nfd %d\n",
+			pxd_dev, head, bio, pxd_dev->fp.nfd);
+	return head;
+
+repl_cleanup:
+	__pxd_cleanup_block_io(head);
+	return NULL;
+}
+
+static void _pxd_setup(struct pxd_device *pxd_dev, bool enable)
+{
 	if (!enable) {
 		printk(KERN_NOTICE "device %llu called to disable IO\n", pxd_dev->dev_id);
 		pxd_dev->connected = false;
@@ -454,7 +698,8 @@ static void _pxd_setup(struct pxd_device *pxd_dev, bool enable) {
 	if (enable) pxd_dev->connected = true;
 }
 
-void pxdctx_set_connected(struct pxd_context *ctx, bool enable) {
+void pxdctx_set_connected(struct pxd_context *ctx, bool enable)
+{
 	struct list_head *cur;
 	spin_lock(&ctx->lock);
 	list_for_each(cur, &ctx->list) {
@@ -466,19 +711,13 @@ void pxdctx_set_connected(struct pxd_context *ctx, bool enable) {
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)
-static int __do_bio_filebacked(struct pxd_device *pxd_dev, struct bio *bio)
+static int __do_bio_filebacked(struct pxd_device *pxd_dev, struct pxd_io_tracker *iot)
 {
+	struct bio *bio = &iot->clone;
 	loff_t pos;
 	unsigned int op = bio_op(bio);
 	int ret;
-	unsigned long startTime = jiffies;
 
-	// NOTE NOTE NOTE accessing out of lock
-	if (!pxd_dev->connected) {
-		printk(KERN_ERR"px is disconnected, failing IO.\n");
-		bio_io_error(bio);
-		return -EIO;
-	}
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
 	generic_start_io_acct(pxd_dev->disk->queue, bio_op(bio), REQUEST_GET_SECTORS(bio), &pxd_dev->disk->part0);
 #else
@@ -491,36 +730,36 @@ static int __do_bio_filebacked(struct pxd_device *pxd_dev, struct bio *bio)
 
 	switch (op) {
 	case REQ_OP_READ:
-		ret = pxd_receive(pxd_dev, bio, pos);
+		ret = pxd_receive(pxd_dev, iot->file, bio, &pos);
 		goto out;
 	case REQ_OP_WRITE:
 
 		if (bio->bi_opf & REQ_PREFLUSH) {
 			atomic_inc(&pxd_dev->fp.nio_preflush);
-			ret = _pxd_flush(pxd_dev);
+			ret = _pxd_flush(pxd_dev, iot->file);
 			if (ret < 0) goto out;
 		}
 
 		/* Before any newer writes happen, make sure previous write/sync complete */
-		pxd_check_write_cache_flush(pxd_dev);
+		pxd_check_write_cache_flush(pxd_dev, iot->file);
 
-		ret = do_pxd_send(pxd_dev, bio, pos);
+		ret = pxd_send(pxd_dev, iot->file, bio, pos);
 		if (ret < 0) goto out;
 
 		if (bio->bi_opf & REQ_FUA) {
 			atomic_inc(&pxd_dev->fp.nio_fua);
-			ret = _pxd_flush(pxd_dev);
+			ret = _pxd_flush(pxd_dev, iot->file);
 			if (ret < 0) goto out;
 		}
 
 		ret = 0; goto out;
 
 	case REQ_OP_FLUSH:
-		ret = _pxd_flush(pxd_dev);
+		ret = _pxd_flush(pxd_dev, iot->file);
 		goto out;
 	case REQ_OP_DISCARD:
 	case REQ_OP_WRITE_ZEROES:
-		ret = _pxd_bio_discard(pxd_dev, bio, pos);
+		ret = _pxd_bio_discard(pxd_dev, iot->file, bio, pos);
 		goto out;
 	default:
 		WARN_ON_ONCE(1);
@@ -529,38 +768,97 @@ static int __do_bio_filebacked(struct pxd_device *pxd_dev, struct bio *bio)
 	}
 
 out:
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
-	generic_end_io_acct(pxd_dev->disk->queue, bio_op(bio), &pxd_dev->disk->part0, startTime);
-#else
-	generic_end_io_acct(bio_data_dir(bio), &pxd_dev->disk->part0, startTime);
-#endif
-	atomic_inc(&pxd_dev->fp.ncomplete);
-	pxd_printk("Completed a request direction %p/%d\n", bio, bio_data_dir(bio));
-
 	if (ret < 0) {
-		bio_io_error(bio);
-		return ret;
-	}
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
-	bio_endio(bio);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
+		bio->bi_status = ret;
 #else
-	bio_endio(bio, ret);
+		bio->bi_error = ret;
 #endif
-    return ret;
+	}
+	pxd_complete_io(bio);
+
+	return ret;
 }
 
 #else
-static int __do_bio_filebacked(struct pxd_device *pxd_dev, struct bio *bio)
+static int __do_bio_filebacked(struct pxd_device *pxd_dev, struct pxd_io_tracker *iot)
 {
 	loff_t pos;
 	int ret;
-	unsigned long startTime = jiffies;
+	struct bio *bio = &iot->clone;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
+	pos = ((loff_t) bio->bi_iter.bi_sector << 9);
+#else
+	pos = ((loff_t) bio->bi_sector << 9);
+#endif
+
+	// mark status all good to begin with!
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
+	bio->bi_status = 0;
+#else
+	bio->bi_error = 0;
+#endif
+	if (bio_data_dir(bio) == WRITE) {
+		pxd_printk("bio bi_rw %#lx, flush %#llx, fua %#llx, discard %#llx\n",
+				bio->bi_rw, REQ_FLUSH, REQ_FUA, REQ_DISCARD);
+
+		if (bio->bi_rw & REQ_DISCARD) {
+			ret = _pxd_bio_discard(pxd_dev, iot->file, bio, pos);
+			goto out;
+		}
+		/* Before any newer writes happen, make sure previous write/sync complete */
+		pxd_check_write_cache_flush(pxd_dev, iot->file);
+		ret = pxd_send(pxd_dev, iot->file, bio, pos);
+
+		if (!ret) {
+			if ((bio->bi_rw & REQ_FUA)) {
+				atomic_inc(&pxd_dev->fp.nio_fua);
+				ret = _pxd_flush(pxd_dev, iot->file);
+				if (ret < 0) goto out;
+			} else if ((bio->bi_rw & REQ_FLUSH)) {
+				ret = _pxd_flush(pxd_dev, iot->file);
+				if (ret < 0) goto out;
+			}
+		}
+
+	} else {
+		ret = pxd_receive(pxd_dev, iot->file, bio, &pos);
+	}
+
+out:
+	if (ret < 0) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
+		bio->bi_status = ret;
+#else
+		bio->bi_error = ret;
+#endif
+	}
+	pxd_complete_io(bio);
+
+	return ret;
+}
+
+#endif
+
+static inline int pxd_handle_io(struct thread_context *tc, struct pxd_io_tracker *head)
+{
+	struct pxd_device *pxd_dev = head->pxd_dev;
+	struct bio *bio = head->orig;
+
+	//
+	// Based on the nfd mapped on pxd_dev, that many cloned bios shall be
+	// setup, then each replica takes its own processing path, which could be
+	// either file backup or block device backup.
+	//
+	struct pxd_io_tracker *curr;
 
 	// NOTE NOTE NOTE accessing out of lock
 	if (!pxd_dev->connected) {
 		printk(KERN_ERR"px is disconnected, failing IO.\n");
-		bio_io_error(bio);
-		return -EIO;
+		__pxd_cleanup_block_io(head);
+		BIO_ENDIO(bio, -ENXIO);
+		return -ENXIO;
 	}
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
@@ -569,119 +867,144 @@ static int __do_bio_filebacked(struct pxd_device *pxd_dev, struct bio *bio)
 	generic_start_io_acct(bio_data_dir(bio), REQUEST_GET_SECTORS(bio), &pxd_dev->disk->part0);
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
-	pos = ((loff_t) bio->bi_iter.bi_sector << 9);
-#else
-	pos = ((loff_t) bio->bi_sector << 9);
-#endif
-
-	if (bio_data_dir(bio) == WRITE) {
-		pxd_printk("bio bi_rw %#lx, flush %#llx, fua %#llx, discard %#llx\n",
-				bio->bi_rw, REQ_FLUSH, REQ_FUA, REQ_DISCARD);
-
-		if (bio->bi_rw & REQ_DISCARD) {
-			ret = _pxd_bio_discard(pxd_dev, bio, pos);
-			goto out;
-		}
-		/* Before any newer writes happen, make sure previous write/sync complete */
-		pxd_check_write_cache_flush(pxd_dev);
-		ret = do_pxd_send(pxd_dev, bio, pos);
-
-		if (!ret) {
-			if ((bio->bi_rw & REQ_FUA)) {
-				atomic_inc(&pxd_dev->fp.nio_fua);
-				ret = _pxd_flush(pxd_dev);
-				if (ret < 0) goto out;
-			} else if ((bio->bi_rw & REQ_FLUSH)) {
-				ret = _pxd_flush(pxd_dev);
-				if (ret < 0) goto out;
+	// initialize active io to configured replicas
+	if (!head->read) {
+		atomic_set(&head->active, pxd_dev->fp.nfd);
+		// submit all replicas linked from head, if not read
+		list_for_each_entry(curr, &head->replicas, item) {
+			if (S_ISBLK(curr->file->f_inode->i_mode)) {
+				SUBMIT_BIO(&curr->clone);
+				atomic_inc(&pxd_dev->fp.nswitch);
+			} else {
+				__do_bio_filebacked(pxd_dev, curr);
 			}
 		}
-
 	} else {
-		ret = pxd_receive(pxd_dev, bio, pos);
+		atomic_set(&head->active, 1);
 	}
 
-out:
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
-	generic_end_io_acct(pxd_dev->disk->queue, bio_op(bio), &pxd_dev->disk->part0, startTime);
-#else
-	generic_end_io_acct(bio_data_dir(bio), &pxd_dev->disk->part0, startTime);
-#endif
-	atomic_inc(&pxd_dev->fp.ncomplete);
-	pxd_printk("Completed a request direction %p/%lu\n", bio, bio_data_dir(bio));
-
-	if (ret < 0) {
-		bio_io_error(bio);
-		return ret;
+	// submit head bio the last
+	if (S_ISBLK(head->file->f_inode->i_mode)) {
+		SUBMIT_BIO(&head->clone);
+		atomic_inc(&pxd_dev->fp.nswitch);
+	} else {
+		__do_bio_filebacked(pxd_dev, head);
 	}
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
-	bio_endio(bio);
-#else
-	bio_endio(bio, ret);
-#endif
-    return ret;
+
+	return 0; // all good
 }
 
-#endif
-
-static inline void pxd_handle_bio(struct thread_context *tc, struct bio *bio)
+static void pxd_add_io(struct thread_context *tc, struct pxd_io_tracker *head, int rw)
 {
-	struct pxd_device *pxd_dev = tc->pxd_dev;
+	if (rw != READ) {
+		spin_lock_irq(&tc->write_lock);
+		list_add(&head->item, &tc->iot_writers);
+		spin_unlock_irq(&tc->write_lock);
+		wake_up(&tc->write_event);
+	} else {
+		spin_lock_irq(&tc->read_lock);
+		list_add(&head->item, &tc->iot_readers);
+		spin_unlock_irq(&tc->read_lock);
 
-	// calling version dependent handling code
-	__do_bio_filebacked(pxd_dev, bio);
+		wake_up(&tc->read_event);
+	}
 }
 
-static void pxd_add_bio(struct thread_context *tc, struct bio *bio)
+static struct pxd_io_tracker* pxd_get_io(struct thread_context *tc, int rw)
 {
-	atomic_inc(&tc->pxd_dev->fp.ncount);
+	struct pxd_io_tracker* head = NULL;
 
-	spin_lock_irq(&tc->lock);
-	bio_list_add(&tc->bio_list, bio);
-	spin_unlock_irq(&tc->lock);
+	if (rw != READ) {
+		spin_lock_irq(&tc->write_lock);
+		if (!list_empty(&tc->iot_writers)) {
+			head = list_first_entry(&tc->iot_writers, struct pxd_io_tracker, item);
+			list_del(&head->item);
+		}
+		spin_unlock_irq(&tc->write_lock);
+	} else {
+		spin_lock_irq(&tc->read_lock);
+		if (!list_empty(&tc->iot_readers)) {
+			head = list_first_entry(&tc->iot_readers, struct pxd_io_tracker, item);
+			list_del(&head->item);
+		}
+		spin_unlock_irq(&tc->read_lock);
+	}
+
+	return head;
 }
 
-static struct bio* pxd_get_bio(struct thread_context *tc)
-{
-	struct bio* bio;
-	atomic_dec(&tc->pxd_dev->fp.ncount);
-
-	spin_lock_irq(&tc->lock);
-	bio=bio_list_pop(&tc->bio_list);
-	spin_unlock_irq(&tc->lock);
-
-	return bio;
-}
-
-static int pxd_io_thread(void *data)
+static int pxd_io_thread(void *data, int rw)
 {
 	struct thread_context *tc = data;
-	struct bio *bio;
+	struct pxd_io_tracker *head;
 
-	while (!kthread_should_stop() || !bio_list_empty(&tc->bio_list)) {
-		wait_event_interruptible(tc->pxd_event,
-                             !bio_list_empty(&tc->bio_list) ||
-                             kthread_should_stop());
+	while (!kthread_should_stop()) {
+		pxd_wait_io(tc, rw);
 
-		if (bio_list_empty(&tc->bio_list))
+		head = pxd_get_io(tc, rw);
+		if (!head) {
 			continue;
-
-		pxd_printk("pxd_io_thread new bio for device %llu, pending %u\n",
-				tc->pxd_dev->dev_id, atomic_read(&tc->pxd_dev->fp.ncount));
-
-		bio = pxd_get_bio(tc);
-		BUG_ON(!bio);
-
-		spin_lock_irq(&tc->pxd_dev->lock);
-		if (atomic_read(&tc->pxd_dev->fp.ncount) < tc->pxd_dev->disk->queue->nr_congestion_off) {
-			wake_up(&tc->pxd_dev->fp.congestion_wait);
 		}
-		spin_unlock_irq(&tc->pxd_dev->lock);
 
-		pxd_handle_bio(tc, bio);
+		if (unlikely(pxd_handle_io(tc, head) != 0)) {
+			/* if early fail, then force wakeup */
+
+			struct pxd_device *pxd_dev = head->pxd_dev;
+			BUG_ON(!pxd_dev);
+
+			atomic_dec(&pxd_dev->fp.ncount);
+			atomic_inc(&pxd_dev->fp.ncomplete);
+		}
 	}
 	return 0;
+}
+
+static int pxd_io_reader(void *data)
+{
+	return pxd_io_thread(data, READ);
+}
+
+static int pxd_io_writer(void *data)
+{
+	return pxd_io_thread(data, WRITE);
+}
+
+static void pxd_suspend_io(struct pxd_device *pxd_dev)
+{
+	int need_flush = 0;
+	spin_lock_irq(&pxd_dev->fp.suspend_lock);
+	if (!pxd_dev->fp.suspend++) {
+		printk("For pxd device %llu IO suspended\n", pxd_dev->dev_id);
+		need_flush = 1;
+	} else {
+		printk("For pxd device %llu IO already suspended\n", pxd_dev->dev_id);
+	}
+	spin_unlock_irq(&pxd_dev->fp.suspend_lock);
+
+	// need to wait for inflight IOs to complete
+	if (need_flush) {
+		do {
+			int nactive = atomic_read(&pxd_dev->fp.ncount);
+			if (!nactive) break;
+			printk(KERN_WARNING"pxd device %llu still has %d active IO, waiting completion to suspend",
+					pxd_dev->dev_id, nactive);
+			msleep_interruptible(100);
+		} while (1);
+	}
+}
+
+static void pxd_resume_io(struct pxd_device *pxd_dev)
+{
+	spin_lock_irq(&pxd_dev->fp.suspend_lock);
+	pxd_dev->fp.suspend--;
+	if (!pxd_dev->fp.suspend) {
+		printk("For pxd device %llu IO resumed\n", pxd_dev->dev_id);
+		wake_up(&pxd_dev->fp.suspend_wait);
+	} else {
+		printk("For pxd device %llu IO still suspended(%d)\n",
+				pxd_dev->dev_id, pxd_dev->fp.suspend);
+	}
+	spin_unlock_irq(&pxd_dev->fp.suspend_lock);
 }
 
 /*
@@ -696,7 +1019,12 @@ void enableFastPath(struct pxd_device *pxd_dev, bool force)
 	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
 	int nfd = fp->nfd;
 	mode_t mode = open_mode(pxd_dev->mode);
+	char modestr[32];
 
+	pxd_suspend_io(pxd_dev);
+
+	decode_mode(mode, modestr);
+	printk("device %llu mode %s\n", pxd_dev->dev_id, modestr);
 	for (i = 0; i < nfd; i++) {
 		if (fp->file[i] > 0) { /* valid fd exists already */
 			if (force) {
@@ -724,18 +1052,18 @@ void enableFastPath(struct pxd_device *pxd_dev, bool force)
 		inode = f->f_inode;
 		printk(KERN_INFO"device %lld:%d, inode %lu mode %#x\n", pxd_dev->dev_id, i, inode->i_ino, mode);
 		if (S_ISREG(inode->i_mode)) {
-			fp->block_device = false; /* override config to use file io */
 			printk(KERN_INFO"device[%lld:%d] is a regular file - inode %lu\n",
 					pxd_dev->dev_id, i, inode->i_ino);
 		} else if (S_ISBLK(inode->i_mode)) {
 			printk(KERN_INFO"device[%lld:%d] is a block device - inode %lu\n",
 				pxd_dev->dev_id, i, inode->i_ino);
 		} else {
-			fp->block_device = false; /* override config to use file io */
 			printk(KERN_INFO"device[%lld:%d] inode %lu unknown device %#x\n",
 				pxd_dev->dev_id, i, inode->i_ino, inode->i_mode);
 		}
 	}
+
+	pxd_resume_io(pxd_dev);
 
 	printk(KERN_INFO"pxd_dev %llu mode %#x setting up with %d backing volumes, [%p,%p,%p]\n",
 		pxd_dev->dev_id, mode, fp->nfd,
@@ -745,54 +1073,68 @@ void enableFastPath(struct pxd_device *pxd_dev, bool force)
 
 out_file_failed:
 	fp->nfd = 0;
-	for (i=0; i<nfd; i++) {
+	for (i = 0; i < nfd; i++) {
 		if (fp->file[i] > 0) filp_close(fp->file[i], NULL);
 	}
 	memset(fp->file, 0, sizeof(fp->file));
 	memset(fp->device_path, 0, sizeof(fp->device_path));
+
+	pxd_resume_io(pxd_dev);
 	printk(KERN_INFO"Device %llu no backing volume setup, will take slow path\n",
 		pxd_dev->dev_id);
 }
 
-static void disableFastPath(struct pxd_device *pxd_dev)
+void disableFastPath(struct pxd_device *pxd_dev)
 {
-	int i;
 	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
+	int nfd = fp->nfd;
+	int i;
 
-	for (i=0; i<fp->nfd; i++) {
+	pxd_suspend_io(pxd_dev);
+
+	for (i = 0; i < nfd; i++) {
 		filp_close(fp->file[i], NULL);
 	}
 	fp->nfd=0;
 
-	if (fp->tc) {
-		for (i=0; i<MAX_THREADS; i++) {
-			struct thread_context *tc = &fp->tc[i];
-			if (tc->pxd_thread) kthread_stop(tc->pxd_thread);
-		}
-		if (fp->tc) kfree(fp->tc);
-	}
-	fp->tc = NULL;
+	pxd_resume_io(pxd_dev);
 }
 
 int pxd_fastpath_init(struct pxd_device *pxd_dev)
 {
-	int err = -EINVAL;
 	int i;
 	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
 
-	fp->block_device = true; // always default to considering as block device
 	fp->nfd = 0; // will take slow path, if additional info not provided.
 
-	pxd_printk("Number of cpu ids %d\n", MAX_THREADS);
+	pxd_printk("Number of cpu ids %d\n", __px_ncpus);
+#if 0
+	// configure bg flush based on passed mode of operation
 	if (pxd_dev->mode & O_DIRECT) {
-		fp->bg_flush_enabled = false; // introduces high latency
+		fp->bg_flush_enabled = false; // avoids high latency
+		printk("For pxd device %llu background flush disabled\n", pxd_dev->dev_id);
 	} else {
 		fp->bg_flush_enabled = true; // introduces high latency
+		printk("For pxd device %llu background flush enabled\n", pxd_dev->dev_id);
 	}
+#else
+	fp->bg_flush_enabled = false; // avoids high latency
+#endif
+
 	fp->n_flush_wrsegs = MAX_WRITESEGS_FOR_FLUSH;
 
+	// device temporary IO suspend
+	init_waitqueue_head(&fp->suspend_wait);
+	spin_lock_init(&fp->suspend_lock);
+	fp->suspend = 0;
+
 	// congestion init
-	init_waitqueue_head(&fp->congestion_wait);
+	// hard coded congestion limits within driver
+	fp->congested = false;
+	fp->qdepth = DEFAULT_CONGESTION_THRESHOLD;
+	fp->nr_congestion_on = 0;
+	fp->nr_congestion_off = 0;
+
 	init_waitqueue_head(&fp->sync_event);
 	spin_lock_init(&fp->sync_lock);
 
@@ -810,55 +1152,65 @@ int pxd_fastpath_init(struct pxd_device *pxd_dev)
 	atomic_set(&fp->ncomplete,0);
 	atomic_set(&fp->nwrite_counter,0);
 
-	fp->tc = kzalloc(MAX_THREADS * sizeof(struct thread_context), GFP_NOIO);
-	if (!fp->tc) {
-		printk(KERN_ERR"Initializing backing volumes for pxd failed %d\n", err);
-		return -ENOMEM;
-	}
-
 	for (i = 0; i < nr_node_ids; i++) {
 		atomic_set(&fp->index[i], 0);
-	}
-
-	for (i = 0; i < MAX_THREADS; i++) {
-		struct thread_context *tc = &fp->tc[i];
-		int node = cpu_to_node(i);
-		tc->pxd_dev = pxd_dev;
-		spin_lock_init(&tc->lock);
-		init_waitqueue_head(&tc->pxd_event);
-		tc->pxd_thread = kthread_create_on_node(pxd_io_thread, tc,
-				node, "pxd%d:%llu", i, pxd_dev->dev_id);
-		if (IS_ERR(tc->pxd_thread)) {
-			pxd_printk("Init kthread for device %llu failed %lu\n",
-				pxd_dev->dev_id, PTR_ERR(tc->pxd_thread));
-			err = -EINVAL;
-			goto fail;
-		}
-
-		//
-		// Each px volume, creates a 'cpu' number of threads, that
-		// are bound to the numa node mask.
-		//
-		set_cpus_allowed_ptr(tc->pxd_thread, cpumask_of_node(node));
-		set_user_nice(tc->pxd_thread, MIN_NICE);
-		wake_up_process(tc->pxd_thread);
 	}
 
 	enableFastPath(pxd_dev, true);
 
 	return 0;
-fail:
-	for (i = 0; i < MAX_THREADS; i++) {
-		struct thread_context *tc = &fp->tc[i];
-		if (tc->pxd_thread) kthread_stop(tc->pxd_thread);
-	}
-
-	if (fp->tc) kfree(fp->tc);
-	return err;
 }
 
-void pxd_fastpath_cleanup(struct pxd_device *pxd_dev) {
+void pxd_fastpath_cleanup(struct pxd_device *pxd_dev)
+{
 	disableFastPath(pxd_dev);
+}
+
+int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path)
+{
+	mode_t mode = 0;
+	int err = 0;
+	int i;
+	struct file* f;
+
+	mode = open_mode(pxd_dev->mode);
+	for (i = 0; i < update_path->size; i++) {
+		if (!strcmp(pxd_dev->fp.device_path[i], update_path->devpath[i])) {
+			// if previous paths are same.. then skip anymore config
+			printk(KERN_INFO"pxd%llu already configured for path %s\n",
+				pxd_dev->dev_id, pxd_dev->fp.device_path[i]);
+			continue;
+		}
+
+		if (pxd_dev->fp.file[i] > 0) filp_close(pxd_dev->fp.file[i], NULL);
+		f = filp_open(update_path->devpath[i], mode, 0600);
+		if (IS_ERR_OR_NULL(f)) {
+			printk(KERN_ERR"Failed attaching path: device %llu, path %s, err %ld\n",
+				pxd_dev->dev_id, update_path->devpath[i], PTR_ERR(f));
+			err = PTR_ERR(f);
+			goto out_file_failed;
+		}
+		pxd_dev->fp.file[i] = f;
+		strncpy(pxd_dev->fp.device_path[i], update_path->devpath[i],MAX_PXD_DEVPATH_LEN);
+		pxd_dev->fp.device_path[i][MAX_PXD_DEVPATH_LEN] = '\0';
+	}
+	pxd_dev->fp.nfd = update_path->size;
+
+	/* setup whether access is block or file access */
+	enableFastPath(pxd_dev, false);
+
+	return 0;
+out_file_failed:
+	for (i = 0; i < pxd_dev->fp.nfd; i++) {
+		if (pxd_dev->fp.file[i] > 0) filp_close(pxd_dev->fp.file[i], NULL);
+	}
+	pxd_dev->fp.nfd = 0;
+	memset(pxd_dev->fp.file, 0, sizeof(pxd_dev->fp.file));
+	memset(pxd_dev->fp.device_path, 0, sizeof(pxd_dev->fp.device_path));
+
+	// even if there are errors setting up fastpath, initialize to take slow path,
+	// do not report failure outside
+	return 0;
 }
 
 /* fast path make request function, io entry point */
@@ -875,8 +1227,9 @@ void pxd_make_request_fastpath(struct request_queue *q, struct bio *bio)
 	unsigned int rw = bio_rw(bio);
 #endif
 	int cpu = smp_processor_id();
-	int thread = cpu % MAX_THREADS;
+	int thread = cpu % __px_ncpus;
 
+	struct pxd_io_tracker *head;
 	struct thread_context *tc;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
@@ -897,45 +1250,60 @@ void pxd_make_request_fastpath(struct request_queue *q, struct bio *bio)
 		return BLK_QC_RETVAL;
 	}
 
+	// If IO suspended, then hang IO onto the suspend wait queue
+	{
+		spin_lock_irq(&pxd_dev->fp.suspend_lock);
+		if (pxd_dev->fp.suspend) {
+			printk("pxd device %llu is suspended, IO blocked until device activated[bio %p, wr %d]\n",
+				pxd_dev->dev_id, bio, (bio_data_dir(bio) == WRITE));
+			wait_event_lock_irq(pxd_dev->fp.suspend_wait, !pxd_dev->fp.suspend, pxd_dev->fp.suspend_lock);
+			printk("pxd device %llu re-activated, IO resumed[bio %p, wr %d]\n",
+				pxd_dev->dev_id, bio, (bio_data_dir(bio) == WRITE));
+		}
+		spin_unlock_irq(&pxd_dev->fp.suspend_lock);
+	}
+
 	if (!pxd_dev->fp.nfd) {
 		pxd_printk("px has no backing path yet, should take slow path IO.\n");
 		atomic_inc(&pxd_dev->fp.nslowPath);
 		return pxd_make_request_slowpath(q, bio);
 	}
 
-	pxd_printk("pxd_make_request for device %llu queueing with thread %d\n", pxd_dev->dev_id, thread);
+	pxd_printk("pxd_make_fastpath_request for device %llu queueing with thread %d\n", pxd_dev->dev_id, thread);
 
-	{ /* add congestion handling */
-		spin_lock_irq(&pxd_dev->lock);
-		if (atomic_read(&pxd_dev->fp.ncount) >= q->nr_congestion_on) {
-			pxd_printk("Hit congestion... wait until clear\n");
-			atomic_inc(&pxd_dev->fp.ncongested);
-			wait_event_lock_irq(pxd_dev->fp.congestion_wait,
-				atomic_read(&pxd_dev->fp.ncount) < q->nr_congestion_off,
-				pxd_dev->lock);
-			pxd_printk("congestion cleared\n");
-		}
+	pxd_io_printk("%s: dev m %d g %lld %s at %ld len %d bytes %d pages "
+			"flags 0x%x op %#x op_flags 0x%x\n", __func__,
+			pxd_dev->minor, pxd_dev->dev_id,
+			bio_data_dir(bio) == WRITE ? "wr" : "rd",
+			BIO_SECTOR(bio) * SECTOR_SIZE, BIO_SIZE(bio),
+			bio->bi_vcnt, bio->bi_flags,
+			(bio->bi_opf & REQ_OP_MASK),
+			((bio->bi_opf & ~REQ_OP_MASK) >> REQ_OP_BITS));
 
-		spin_unlock_irq(&pxd_dev->lock);
-
-	}
-
-	if (pxd_dev->fp.block_device) { /* switch bio to target device bypassing vfs */
-		if (pxd_switch_bio(pxd_dev, bio)) {
-			BIO_ENDIO(bio, -ENOMEM);
-		}
-		return BLK_QC_RETVAL;
-	}
-
+#if 0
 	/* keep writes on same cpu, but allow reads to spread but within same numa node */
 	if (rw == READ) {
 		int node = cpu_to_node(cpu);
 		thread = getnextcpu(node, atomic_add_return(1, &pxd_dev->fp.index[node]));
 	}
-	tc = &pxd_dev->fp.tc[thread];
+#endif
 
-	pxd_add_bio(tc, bio);
-	wake_up(&tc->pxd_event);
+	head = __pxd_init_block_head(pxd_dev, bio);
+	if (!head) {
+		BIO_ENDIO(bio, -ENOMEM);
+
+		// non-trivial high memory pressure failing IO
+		spin_lock_irq(&pxd_dev->lock);
+		atomic_dec(&pxd_dev->fp.ncount);
+		spin_unlock_irq(&pxd_dev->lock);
+
+		return BLK_QC_RETVAL;
+	}
+
+	tc = &g_tc[thread];
+	BUG_ON(!tc);
+	pxd_add_io(tc, head, rw);
+
 	pxd_printk("pxd_make_request for device %llu done\n", pxd_dev->dev_id);
 	return BLK_QC_RETVAL;
 }

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -328,7 +328,7 @@ static ssize_t pxd_receive(struct pxd_device *pxd_dev, struct bio *bio, loff_t p
 	int i;
 #endif
 
-	pxd_printk("pxd_receive[%llu] with bio=%p, pos=%llu, nsects=%lu\n",
+	pxd_printk("pxd_receive[%llu] with bio=%p, pos=%llu, nsects=%u\n",
 				pxd_dev->dev_id, bio, pos, REQUEST_GET_SECTORS(bio));
 	bio_for_each_segment(bvec, bio, i) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -13,7 +13,11 @@
 #include <linux/falloc.h>
 #include <linux/bio.h>
 
-#define MAX_THREADS (nr_cpu_ids)
+// atleast 2 per cpu
+// create two pool of PXD_MAX_THREAD_PER_CPU threads on each cpu, dedicated for writes and reads
+// writer threads are pinned on the same cpu.
+// reader threads are pinned on the same numa node
+#define PXD_MAX_THREAD_PER_CPU (4)
 
 struct pxd_device;
 struct pxd_context;
@@ -27,23 +31,37 @@ struct node_cpu_map {
 
 // Added metadata for each bio
 struct pxd_io_tracker {
-	unsigned long start; // start time
-	struct bio *orig;    // original request bio
-	struct bio clone;    // cloned bio
+	struct pxd_device *pxd_dev; // back pointer to pxd device
+	struct pxd_io_tracker *head; // back pointer to head copy [ALL]
+	struct list_head replicas; // only replica needs this
+	struct list_head item; // only HEAD needs this
+	atomic_t active; // only HEAD has refs to all active IO
+	atomic_t fails; // should be zero, non-zero indicates atleast one path failed
+	struct file* file;
+	int read; // if read is from the first target only
+
+	unsigned long start; // start time [HEAD]
+	struct bio *orig;    // original request bio [HEAD]
+
+	// THIS SHOULD BE LAST ITEM
+	struct bio clone;    // cloned bio [ALL]
 };
 
 struct pxd_device;
 struct thread_context {
-	struct pxd_device  *pxd_dev;
-	struct task_struct *pxd_thread;
-	wait_queue_head_t   pxd_event;
-	spinlock_t  		lock;
-	struct bio_list  bio_list;
+	spinlock_t  	    read_lock;
+	wait_queue_head_t   read_event;
+	struct list_head iot_readers;
+	struct task_struct *reader[PXD_MAX_THREAD_PER_CPU];
+
+	spinlock_t  	    write_lock;
+	wait_queue_head_t   write_event;
+	struct list_head iot_writers;
+	struct task_struct *writer[PXD_MAX_THREAD_PER_CPU];
 };
 
 struct pxd_fastpath_extension {
 	// Extended information
-	bool   block_device;
 	int bg_flush_enabled; // dynamically enable bg flush from driver
 	int n_flush_wrsegs; // num of PXD_LBS write segments to force flush
 
@@ -53,7 +71,16 @@ struct pxd_fastpath_extension {
 	char device_path[MAX_PXD_BACKING_DEVS][MAX_PXD_DEVPATH_LEN+1];
 
 	struct thread_context *tc;
-	wait_queue_head_t   congestion_wait;
+	unsigned int qdepth;
+	bool congested;
+	unsigned int nr_congestion_on;
+	unsigned int nr_congestion_off;
+
+	// if set, then newer IOs shall block, until reactivated.
+	int suspend;
+	wait_queue_head_t  suspend_wait;
+	spinlock_t suspend_lock;
+
 	wait_queue_head_t   sync_event;
 	spinlock_t   	sync_lock;
 	atomic_t nsync_active; // [global] currently active?
@@ -64,20 +91,20 @@ struct pxd_fastpath_extension {
 	atomic_t nio_flush_nop;
 	atomic_t nio_fua;
 	atomic_t nio_write;
-	atomic_t ncount; // [global] total active requests
+	atomic_t ncount; // [global] total active requests, always modify with pxd_dev.lock
 	atomic_t nswitch; // [global] total number of requests through bio switch path
 	atomic_t nslowPath; // [global] total requests through slow path
 	atomic_t ncomplete; // [global] total completed requests
-	atomic_t ncongested; // [global] total number of times queue congested
 	atomic_t nwrite_counter; // [global] completed writes, gets cleared on a threshold
-	atomic_t index[MAX_NUMNODES];
+	atomic_t index[MAX_NUMNODES]; // [global] read path IO optimization - last cpu
 };
-
-// helpers
 
 // global initialization during module init for fastpath
 int fastpath_init(void);
 void fastpath_cleanup(void);
+
+struct pxd_update_path_out;
+int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path);
 
 // per device initialization for fastpath
 int pxd_fastpath_init(struct pxd_device *pxd_dev);
@@ -95,5 +122,9 @@ void pxd_make_request_fastpath(struct request_queue *q, struct bio *bio);
 #endif
 
 void enableFastPath(struct pxd_device *pxd_dev, bool force);
+void disableFastPath(struct pxd_device *pxd_dev);
+
+// congestion
+int pxd_device_congested(void *, int);
 
 #endif /* _PXD_FASTPATH_H_ */

--- a/pxd_fastpath_stub.c
+++ b/pxd_fastpath_stub.c
@@ -5,6 +5,7 @@
 #include "pxd_core.h"
 #include "pxd_fastpath.h"
 
+int pxd_device_congested(void *data, int cond) { return 0; }
 int fastpath_init(void) { return 0; }
 void fastpath_cleanup(void) {}
 
@@ -15,4 +16,12 @@ void pxd_fastpath_cleanup(struct pxd_device *pxd_dev) {}
 void pxdctx_set_connected(struct pxd_context *ctx, bool enable) {}
 
 void enableFastPath(struct pxd_device *pxd_dev, bool force) {}
+void disableFastPath(struct pxd_device *pxd_dev) {}
+int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path)
+{
+	// unsupported
+	printk(KERN_WARNING"px driver does not support fastpath - kernel version not supported\n");
+	return 0; // cannot fail
+}
+
 #endif


### PR DESCRIPTION
when px comes along and opens the px control file, an implicit fuse init message is pushed to the userspace. This has no associated bio and parsing some debug states failed with null pointer exception.
