### PR TITLE
use ioctl instead of request for init call

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -330,9 +330,6 @@ static ssize_t fuse_dev_do_read(struct fuse_conn *fc, struct file *file,
 	ssize_t copied = 0, copied_this_time;
 	ssize_t remain = iter->count;
 
-	if (unlikely(fc->pend_open))
-		return pxd_read_init(fc, iter);
-
 	INIT_LIST_HEAD(&tmp);
 
 	spin_lock(&fc->lock);
@@ -684,9 +681,6 @@ static ssize_t fuse_dev_do_write(struct fuse_conn *fc, struct iov_iter *iter)
 		err = fuse_notify(fc, oh.error, nbytes - sizeof(oh), iter);
 		return err ? err : nbytes;
 	}
-
-	if (unlikely(oh.unique == (u64)-1))
-		return pxd_process_init_reply(fc, &oh);
 
 	if (oh.error <= -1000 || oh.error > 0)
 		return -EINVAL;

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -595,7 +595,6 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_out *add);
 ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove);
 ssize_t pxd_update_size(struct fuse_conn *fc, struct pxd_update_size_out *update_size);
 ssize_t pxd_read_init(struct fuse_conn *fc, struct iov_iter *iter);
-ssize_t pxd_process_init_reply(struct fuse_conn *fc, struct fuse_out_header *hdr);
 
 void fuse_request_init(struct fuse_req *req);
 void fuse_req_init_context(struct fuse_req *req);

--- a/pxd.c
+++ b/pxd.c
@@ -131,8 +131,18 @@ static void pxd_release(struct gendisk *disk, fmode_t mode)
 	put_device(&pxd_dev->dev);
 }
 
-static long pxd_control_ioctl(
-	struct file *file, unsigned int cmd, unsigned long arg)
+static long pxd_ioctl_init(struct file *file, void __user *argp)
+{
+	struct pxd_context *ctx = container_of(file->f_op, struct pxd_context, fops);
+	struct iov_iter iter;
+	struct iovec iov = {argp, sizeof(struct pxd_ioctl_init_args)};
+
+	iov_iter_init(&iter, WRITE, &iov, 1, sizeof(struct pxd_ioctl_init_args));
+
+	return pxd_read_init(&ctx->fc, &iter);
+}
+
+static long pxd_control_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 {
 	void __user *argp = (void __user *)arg;
 	struct pxd_context *ctx = NULL;
@@ -171,6 +181,9 @@ static long pxd_control_ioctl(
 		}
 		printk(KERN_INFO "pxd driver at version: %s\n", gitversion);
 		status = 0;
+		break;
+	case PXD_IOC_INIT:
+		status = pxd_ioctl_init(file, argp);
 		break;
 	default:
 		break;
@@ -842,27 +855,12 @@ out:
 
 ssize_t pxd_read_init(struct fuse_conn *fc, struct iov_iter *iter)
 {
-	size_t copied;
+	size_t copied = 0;
 	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
 	struct pxd_device *pxd_dev;
-
-	struct fuse_in in;
 	struct pxd_init_in pxd_init;
 
-	memset(&in, 0, sizeof(in));
-
 	spin_lock(&fc->lock);
-
-	in.h.opcode = PXD_INIT;
-	in.h.len = sizeof(in.h) + sizeof(struct pxd_init_in) +
-		sizeof(struct pxd_dev_id) * ctx->num_devices;
-	in.h.unique = (u64)-1;
-
-	copied = sizeof(in.h);
-	if (copy_to_iter(&in.h, copied, iter) != copied) {
-		printk(KERN_ERR "%s: copy header error\n", __func__);
-		goto copy_error;
-	}
 
 	pxd_init.num_devices = ctx->num_devices;
 	pxd_init.version = PXD_VERSION;
@@ -887,8 +885,10 @@ ssize_t pxd_read_init(struct fuse_conn *fc, struct iov_iter *iter)
 
 	spin_unlock(&fc->lock);
 
-	printk(KERN_INFO "%s: ctx %d %ld devs total %ld", __func__, ctx->id,
-		ctx->num_devices, copied);
+	printk(KERN_INFO "%s: pxd-control-%d init OK %d devs version %d\n", __func__,
+		ctx->id, pxd_init.num_devices, pxd_init.version);
+
+	fc->pend_open = 0;
 
 	return copied;
 
@@ -1052,20 +1052,6 @@ static void pxd_sysfs_exit(void)
 	device_unregister(&pxd_root_dev);
 }
 
-ssize_t pxd_process_init_reply(struct fuse_conn *fc, struct fuse_out_header *hdr)
-{
-	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
-
-	printk(KERN_INFO "%s: pxd-control-%d(%lld) init status %d\n",
-		__func__, ctx->id, ctx->open_seq, hdr->error);
-
-	if (hdr->error != 0)
-		fc->connected = 0;
-	fc->pend_open = 0;
-
-	return sizeof(*hdr);
-}
-
 static int pxd_control_open(struct inode *inode, struct file *file)
 {
 	struct pxd_context *ctx;
@@ -1172,6 +1158,7 @@ static void pxd_timeout(unsigned long args)
 int pxd_context_init(struct pxd_context *ctx, int i)
 {
 	int err;
+
 	spin_lock_init(&ctx->lock);
 	ctx->id = i;
 	ctx->open_seq = 0;
@@ -1179,14 +1166,14 @@ int pxd_context_init(struct pxd_context *ctx, int i)
 	ctx->fops.owner = THIS_MODULE;
 	ctx->fops.open = pxd_control_open;
 	ctx->fops.release = pxd_control_release;
+	ctx->fops.unlocked_ioctl = pxd_control_ioctl;
 
 	if (ctx->id < pxd_num_contexts_exported) {
 		err = fuse_conn_init(&ctx->fc);
 		if (err)
 			return err;
-	} else {
-		ctx->fops.unlocked_ioctl = pxd_control_ioctl;
 	}
+
 	ctx->fc.release = pxd_fuse_conn_release;
 	ctx->fc.allow_disconnected = 1;
 	INIT_LIST_HEAD(&ctx->list);

--- a/pxd.h
+++ b/pxd.h
@@ -18,7 +18,7 @@
 #define PXD_DEV  	"pxd/pxd"		/**< block device prefix */
 #define PXD_DEV_PATH	"/dev/" PXD_DEV		/**< block device path prefix */
 
-#define PXD_VERSION 8				/**< driver version */
+#define PXD_VERSION 9				/**< driver version */
 
 #define PXD_NUM_CONTEXTS			11	/**< Total available control devices */
 #define PXD_NUM_CONTEXT_EXPORTED	1	/**< Available for external use */
@@ -26,6 +26,7 @@
 #define PXD_IOCTL_MAGIC			(('P' << 8) | 'X')
 #define PXD_IOC_DUMP_FC_INFO	_IO(PXD_IOCTL_MAGIC, 1)		/* 0x505801 */
 #define PXD_IOC_GET_VERSION		_IO(PXD_IOCTL_MAGIC, 2)		/* 0x505802 */
+#define PXD_IOC_INIT		_IO(PXD_IOCTL_MAGIC, 3)		/* 0x505803 */
 
 #define PXD_MAX_DEVICES	512			/**< maximum number of devices supported */
 #define PXD_MAX_IO		(1024*1024)	/**< maximum io size in bytes */
@@ -189,6 +190,13 @@ static inline uint64_t pxd_rd_blocks(const struct rdwr_in *rdwr)
 struct pxd_ioctl_version_args {
 	int piv_len;
 	char piv_data[64];
+};
+
+struct pxd_ioctl_init_args {
+	struct pxd_init_in hdr;
+
+	/** list of devices */
+	struct pxd_dev_id devices[PXD_MAX_DEVICES];
 };
 
 #endif /* PXD_H_ */


### PR DESCRIPTION
remove init handling from data path
bump module version 

https://github.com/portworx/porx/pull/4856 for corresponding user space changes