### PR TITLE
Add define to denote el8 kernels so 5.x blq mq changes can be used fo…

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -50,7 +50,7 @@ export OUTPATH
 
 # EL8 Specific kernel checks
 ifeq ($(shell echo "$(CHK_KVER)" | grep -Eq '.*\.el8.*\.x86_64'; echo $$?),0)
-PXDEFINES += -D__PX_BLKMQ__
+PXDEFINES += -D__PX_BLKMQ__ -D__EL8__
 else
 # 5.x kernel checks
 ifeq ($(shell test "$(MAJOR)" = "5"; echo $$?),0)

--- a/pxd.c
+++ b/pxd.c
@@ -188,7 +188,7 @@ static void pxd_update_stats(struct fuse_req *req, int rw, unsigned int count)
 {
         struct pxd_device *pxd_dev = req->queue->queuedata;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0) || __EL8__
         part_stat_lock();
         part_stat_inc(&pxd_dev->disk->part0, ios[rw]);
         part_stat_add(&pxd_dev->disk->part0, sectors[rw], count);


### PR DESCRIPTION
…r el8.  This is just the start.  Will need to replace '__PX_BLKMQ__' with '#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0) || __EL8__' in other places of the code.

Signed-off-by: Jose Rivera <jose@portworx.com>