### PR TITLE
use array to lookup request by id

### DIFF
--- a/fuse_i.h
+++ b/fuse_i.h
@@ -275,8 +275,6 @@ struct ____cacheline_aligned fuse_per_cpu_ids {
 
 	/** followed by list of free ids */
 	u64 free_ids[FUSE_MAX_PER_CPU_IDS];
-
-	u64 pad[7];
 };
 
 /**

--- a/pxd.c
+++ b/pxd.c
@@ -220,13 +220,6 @@ static void pxd_update_stats(struct fuse_req *req, int rw, unsigned int count)
  * copy of fuse_i.h that uses the older layout.
  */
 #define	REQCTR(fc) (fc)->reqctr
-#if 0
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,2,0)
-#define	REQCTR(fc) (fc)->iq.reqctr
-#else
-#define	REQCTR(fc) (fc)->reqctr
-#endif
-#endif
 
 static void pxd_request_complete(struct fuse_conn *fc, struct fuse_req *req)
 {


### PR DESCRIPTION
this does not require locks while hash does
per cpu id allocators