### PR TITLE
remove unused fields

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -414,8 +414,8 @@ retry:
 
 		/* Check if a write request is writing zeroes */
 		if (pxd_detect_zero_writes && (req->in.h.opcode == PXD_WRITE) &&
-			req->misc.pxd_rdwr_in.size &&
-			!(req->misc.pxd_rdwr_in.flags & PXD_FLAGS_SYNC)) {
+		    req->pxd_rdwr_in.size &&
+		    !(req->pxd_rdwr_in.flags & PXD_FLAGS_SYNC)) {
 			fuse_convert_zero_writes(req);
 		}
 		next = entry->next;
@@ -595,9 +595,9 @@ static int fuse_notify_read_data(struct fuse_conn *conn, unsigned int size,
 		return ret;
 
 	/* advance the iterator if data is unaligned */
-	if (unlikely(req->misc.pxd_rdwr_in.offset & PXD_LBS_MASK))
+	if (unlikely(req->pxd_rdwr_in.offset & PXD_LBS_MASK))
 		iov_iter_advance(&data_iter,
-				 req->misc.pxd_rdwr_in.offset & PXD_LBS_MASK);
+				 req->pxd_rdwr_in.offset & PXD_LBS_MASK);
 
 	rq_for_each_segment(bvec, req->rq, breq_iter) {
 		copied = 0;

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -245,12 +245,7 @@ struct fuse_req {
 	/** The request output */
 	struct fuse_out out;
 
-	/** Data for asynchronous requests */
-	union {
-		struct pxd_init_in pxd_init_in;
-		struct pxd_init_out pxd_init_out;
-		struct pxd_rdwr_in pxd_rdwr_in;
-	} misc;
+	struct pxd_rdwr_in pxd_rdwr_in;
 
 	union {
 		/** Associated request structrure. */

--- a/pxd.c
+++ b/pxd.c
@@ -301,13 +301,13 @@ static void pxd_req_misc(struct fuse_req *req, uint32_t size, uint64_t off,
 {
 	req->in.numargs = 1;
 	req->in.args[0].size = sizeof(struct pxd_rdwr_in);
-	req->in.args[0].value = &req->misc.pxd_rdwr_in;
+	req->in.args[0].value = &req->pxd_rdwr_in;
 	req->in.h.pid = current->pid;
-	req->misc.pxd_rdwr_in.minor = minor;
-	req->misc.pxd_rdwr_in.offset = off;
-	req->misc.pxd_rdwr_in.size = size;
+	req->pxd_rdwr_in.minor = minor;
+	req->pxd_rdwr_in.offset = off;
+	req->pxd_rdwr_in.size = size;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) || defined(REQ_PREFLUSH)
-	req->misc.pxd_rdwr_in.flags =
+	req->pxd_rdwr_in.flags =
 		((flags & REQ_FUA) ? PXD_FLAGS_FLUSH : 0) |
 		((flags & REQ_META) ? PXD_FLAGS_META : 0);
 #else
@@ -547,8 +547,8 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 		pxd_dev->minor, req_op(rq), rq->cmd_flags, true,
 		REQCTR(&pxd_dev->ctx->fc));
 
-	req->misc.pxd_rdwr_in.chksum = 0;
-	req->misc.pxd_rdwr_in.pad = 0;
+	req->pxd_rdwr_in.chksum = 0;
+	req->pxd_rdwr_in.pad = 0;
 	req->rq = rq;
 	fuse_request_send_nowait(&pxd_dev->ctx->fc, req);
 


### PR DESCRIPTION
don't need union anymore since init is handled by ioctl