### PR TITLE
can't call fuse_conn_abort() from timer since connection locks

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -60,6 +60,7 @@ struct pxd_context {
 	struct miscdevice miscdev;
 	struct list_head pending_requests;
 	struct timer_list timer;
+	struct work_struct abort_work;
 	uint64_t open_seq;
 };
 
@@ -1116,6 +1117,26 @@ static void pxd_fuse_conn_release(struct fuse_conn *conn)
 {
 }
 
+static void pxd_abort_context(struct work_struct *work)
+{
+	struct pxd_context *ctx = container_of(work, struct pxd_context, abort_work);
+	struct fuse_conn *fc = &ctx->fc;
+
+	BUG_ON(fc->connected);
+
+	printk(KERN_INFO "PXD_TIMEOUT (%s:%u): Aborting all requests...",
+		ctx->name, ctx->id);
+
+	fc->connected = true;
+	fc->allow_disconnected = 0;
+
+	fuse_abort_conn(fc);
+
+	fuse_conn_put(fc);
+
+	module_put(THIS_MODULE);
+}
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
 static void pxd_timeout(struct timer_list *args)
 #else
@@ -1127,15 +1148,23 @@ static void pxd_timeout(unsigned long args)
 #else
 	struct pxd_context *ctx = (struct pxd_context *)args;
 #endif
-	struct fuse_conn *fc = &ctx->fc;
+	/* Prevent the connection structure to be deleted while work is scheduled. */
+	if (!try_module_get(THIS_MODULE)) {
+		printk(KERN_INFO "PXD_TIMEOUT: (%s:%u) timer triggered while unloading",
+			ctx->name, ctx->id);
+		return;
+	}
 
-	BUG_ON(fc->connected);
+	/*
+	 * Prevent any connection allocated structures to be freed while work is
+	 * scheduled.
+	 */
+	fuse_conn_get(&ctx->fc);
 
-	fc->connected = true;
-	fc->allow_disconnected = 0;
-	fuse_abort_conn(fc);
-	printk(KERN_INFO "PXD_TIMEOUT (%s:%u): Aborting all requests...",
-		ctx->name, ctx->id);
+	printk(KERN_INFO "PXD_TIMEOUT: (%s:%u) schedule abort work", ctx->name, ctx->id);
+
+	INIT_WORK(&ctx->abort_work, pxd_abort_context);
+	schedule_work(&ctx->abort_work);
 }
 
 int pxd_context_init(struct pxd_context *ctx, int i)


### PR DESCRIPTION
are not interrupt safe
schedule abort as a work_struct