### PR TITLE
fix the race where we would reset fc->connected in abort which 

### DIFF
--- a/fuse_i.h
+++ b/fuse_i.h
@@ -208,9 +208,19 @@ void fuse_abort_conn(struct fuse_conn *fc);
 int fuse_conn_init(struct fuse_conn *fc);
 
 /**
+ * Abort pending requests
+ */
+void fuse_end_queued_requests(struct fuse_conn *fc);
+
+/**
  * Release reference to fuse_conn
  */
 void fuse_conn_put(struct fuse_conn *fc);
+
+/**
+ * Acquire reference to fuse_conn
+ */
+struct fuse_conn *fuse_conn_get(struct fuse_conn *fc);
 
 void fuse_restart_requests(struct fuse_conn *fc);
 

--- a/pxd.c
+++ b/pxd.c
@@ -1127,10 +1127,14 @@ static void pxd_abort_context(struct work_struct *work)
 	printk(KERN_INFO "PXD_TIMEOUT (%s:%u): Aborting all requests...",
 		ctx->name, ctx->id);
 
-	fc->connected = true;
 	fc->allow_disconnected = 0;
 
-	fuse_abort_conn(fc);
+	/* Let other threads see the value of allow_disconnected. */
+	synchronize_rcu();
+
+	spin_lock(&fc->lock);
+	fuse_end_queued_requests(fc);
+	spin_unlock(&fc->lock);
 
 	fuse_conn_put(fc);
 


### PR DESCRIPTION
allows user to submit new requests after abort and deadlock.

use syncrhonize_rcu() to make sure changes are seen by all threads
don't need to lock around checking connected status anymore