### PR TITLE
fix fastpath context uninitialized for nativepath crash

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -738,14 +738,11 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 	printk(KERN_INFO"Device %llu added with mode %#x fastpath %d npath %lu\n",
 			add->dev_id, add->open_mode, add->enable_fp, add->paths.size);
 
-	if (pxd_dev->fastpath) {
-		err = pxd_fastpath_init(pxd_dev);
-		if (err)
-			goto out_id;
-
-		printk(KERN_INFO"Device %llu enabling fastpath %d (paths: %lu)\n",
-				add->dev_id, add->enable_fp, add->paths.size);
-	}
+	// initializes fastpath context part of pxd_dev, enables it only
+	// if pxd_dev->fastpath is true, and backing dev paths are available.
+	err = pxd_fastpath_init(pxd_dev);
+	if (err)
+		goto out_id;
 
 	err = pxd_init_disk(pxd_dev, add);
 	if (err) {

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1021,6 +1021,8 @@ void enableFastPath(struct pxd_device *pxd_dev, bool force)
 	mode_t mode = open_mode(pxd_dev->mode);
 	char modestr[32];
 
+	if (!pxd_dev->fastpath || !pxd_dev->nfd) return;
+
 	pxd_suspend_io(pxd_dev);
 
 	decode_mode(mode, modestr);
@@ -1089,6 +1091,8 @@ void disableFastPath(struct pxd_device *pxd_dev)
 	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
 	int nfd = fp->nfd;
 	int i;
+
+	if (!pxd_dev->fastpath || !pxd_dev->nfd) return;
 
 	pxd_suspend_io(pxd_dev);
 


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

Backward compat issues fix.
1) using newer px/px-storage with older px-fuse results in device attach call fails.
This is because new px-storage uses PXD_ADD_EXT opcode which is unknown with older px-fuse driver.
Reverted attach to only use PXD_ADD for now.
This is part of porx PR: https://github.com/portworx/porx/pull/4987

2) during device removal, there is a kernel dump sometimes as below.
This is because fastpath contexts are not initialized during device add, but are cleaned up during device remove. Made context initialization mandatory, and operations to check and act only if enabled on fastpath.

BVT Pass: https://jenkins.portworx.co/job/DEV/job/Porx-08/66

Crash traceback
```
[Thu Dec 19 18:15:03 2019] For pxd device 1149187570116969707 IO suspended
[Thu Dec 19 18:15:03 2019] For pxd device 1149187570116969707 IO resumed
[Thu Dec 19 18:15:03 2019] BUG: unable to handle kernel NULL pointer dereference at           (null)
[Thu Dec 19 18:15:03 2019] IP: [<ffffffff810c79ce>] __wake_up_common+0x2e/0x90
[Thu Dec 19 18:15:03 2019] PGD 80000000d968e067 PUD da0a5067 PMD 0
[Thu Dec 19 18:15:03 2019] Oops: 0000 [#1] SMP
[Thu Dec 19 18:15:03 2019] Modules linked in: px(OE) ipt_MASQUERADE nf_nat_masquerade_ipv4 nf_conntrack_netlink nfnetlink xfrm_user xfrm_algo iptable_nat nf_conntrack_ipv4 nf_defrag_ipv4 nf_nat_ipv4 xt_addrtype iptable_filter ip
_tables xt_conntrack x_tables nf_nat nf_conntrack br_netfilter bridge stp llc overlay aufs binfmt_misc vboxvideo snd_intel8x0 ttm snd_ac97_codec ac97_bus drm_kms_helper snd_pcm snd_timer drm snd soundcore fb_sys_fops input_leds
joydev syscopyarea serio_raw i2c_piix4 sysfillrect sysimgblt mac_hid vboxguest nfsd auth_rpcgss nfs_acl lockd ib_iser grace rdma_cm iw_cm sunrpc ib_cm ib_sa ib_mad ib_core ib_addr iscsi_tcp libiscsi_tcp libiscsi scsi_transport_i
scsi autofs4 btrfs raid10 raid456 async_raid6_recov async_memcpy async_pq async_xor async_tx xor raid6_pq libcrc32c raid1 raid0 multipath
[Thu Dec 19 18:15:03 2019]  linear hid_generic usbhid hid crct10dif_pclmul crc32_pclmul ghash_clmulni_intel aesni_intel aes_x86_64 lrw gf128mul glue_helper ablk_helper cryptd psmouse ahci e1000 libahci pata_acpi video
[Thu Dec 19 18:15:03 2019] CPU: 0 PID: 2261 Comm: px-storage Tainted: G           OE   4.4.0-131-generic #157-Ubuntu
[Thu Dec 19 18:15:03 2019] Hardware name: innotek GmbH VirtualBox/VirtualBox, BIOS VirtualBox 12/01/2006
[Thu Dec 19 18:15:03 2019] task: ffff880035667000 ti: ffff8800356fc000 task.ti: ffff8800356fc000
[Thu Dec 19 18:15:03 2019] RIP: 0010:[<ffffffff810c79ce>]  [<ffffffff810c79ce>] __wake_up_common+0x2e/0x90
[Thu Dec 19 18:15:03 2019] RSP: 0018:ffff8800356ffbf8  EFLAGS: 00010086
[Thu Dec 19 18:15:03 2019] RAX: 0000000000000000 RBX: ffff88021296ace0 RCX: 0000000000000000
[Thu Dec 19 18:15:03 2019] RDX: 0000000000000001 RSI: 0000000000000003 RDI: ffff88021296ace0
[Thu Dec 19 18:15:03 2019] RBP: ffff8800356ffc30 R08: 0000000000000000 R09: 000000000000027e
[Thu Dec 19 18:15:03 2019] R10: 000000007ffff000 R11: 000000000000027e R12: ffff88021296ace8
[Thu Dec 19 18:15:03 2019] R13: 0000000000000003 R14: 0000000000000000 R15: 0000000000000000
[Thu Dec 19 18:15:03 2019] FS:  00007f978e7fc700(0000) GS:ffff88021fc00000(0000) knlGS:0000000000000000
[Thu Dec 19 18:15:03 2019] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[Thu Dec 19 18:15:03 2019] CR2: 0000000000000000 CR3: 00000000d9694000 CR4: 0000000000060670
[Thu Dec 19 18:15:03 2019] Stack:
[Thu Dec 19 18:15:03 2019]  00000001810dd349 0000000000000000 ffff88021296ace0 0000000000000046
[Thu Dec 19 18:15:03 2019]  0000000000000003 0000000000000001 0000000000000000 ffff8800356ffc68
[Thu Dec 19 18:15:03 2019]  ffffffff810c7a69 ffff88021296a800 ffff88021296acf8 0000000000000000
[Thu Dec 19 18:15:03 2019] Call Trace:
[Thu Dec 19 18:15:03 2019]  [<ffffffff810c7a69>] __wake_up+0x39/0x50
[Thu Dec 19 18:15:03 2019]  [<ffffffffc06dffca>] pxd_resume_io+0x7a/0x80 [px]
[Thu Dec 19 18:15:03 2019]  [<ffffffffc06e16c5>] disableFastPath+0x55/0x60 [px]
[Thu Dec 19 18:15:03 2019]  [<ffffffffc06e184e>] pxd_fastpath_cleanup+0xe/0x10 [px]
[Thu Dec 19 18:15:03 2019]  [<ffffffffc06dcce8>] pxd_remove+0xa8/0x1b0 [px]
[Thu Dec 19 18:15:03 2019]  [<ffffffffc06de846>] fuse_dev_write_iter+0x4b6/0x830 [px]
[Thu Dec 19 18:15:03 2019]  [<ffffffff810afcf9>] ? try_to_wake_up+0x49/0x400
[Thu Dec 19 18:15:03 2019]  [<ffffffff8139bb1e>] ? common_file_perm+0x6e/0x1a0
[Thu Dec 19 18:15:03 2019]  [<ffffffff81214eff>] do_iter_readv_writev+0x6f/0xa0
[Thu Dec 19 18:15:03 2019]  [<ffffffff81215aaf>] do_readv_writev+0x18f/0x230
[Thu Dec 19 18:15:03 2019]  [<ffffffff810c79f8>] ? __wake_up_common+0x58/0x90
[Thu Dec 19 18:15:03 2019]  [<ffffffff810b0140>] ? wake_up_q+0x70/0x70
[Thu Dec 19 18:15:03 2019]  [<ffffffff81215bd9>] vfs_writev+0x39/0x50
[Thu Dec 19 18:15:03 2019]  [<ffffffff81216909>] SyS_writev+0x59/0xf0
[Thu Dec 19 18:15:03 2019]  [<ffffffff8185328e>] entry_SYSCALL_64_fastpath+0x22/0xc1
```