### PR TITLE
minor changes to px-fuse based on testing fastpath

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -66,12 +66,12 @@ endif
 ## blkmq checks
 ifeq ($(call verlater,${kmajor},${blkmq_major}),0)
 PXDEFINES += -D__PX_BLKMQ__
-$(warning Kernel version ${KERNELVER} supports blkmq driver model.")
+$(info Kernel version ${KERNELVER} supports blkmq driver model.)
 else
 ifeq ($(call versame,${kmajor},${blkmq_major}),0)
 ifeq ($(call versameorlater,${kminor},${blkmq_minor}),0)
 PXDEFINES += -D__PX_BLKMQ__
-$(warning Kernel version ${KERNELVER} supports blkmq driver model.")
+$(info Kernel version ${KERNELVER} supports blkmq driver model.)
 endif
 endif
 endif
@@ -85,20 +85,20 @@ endif
 ifeq ($(call verlater,${kmajor},${fp_major}),0)
 PXDEFINES += -D__PX_FASTPATH__
 px-objs += pxd_fastpath.o
-$(warning kernel fast path enabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
+$(info kernel fast path enabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
 else
 ifeq ($(call versame,${kmajor},${fp_major}),0)
 ifeq ($(call versameorlater,${kminor},${fp_minor}),0)
 PXDEFINES += -D__PX_FASTPATH__
 px-objs += pxd_fastpath.o
-$(warning kernel fast path enabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
+$(info Kernel fast path enabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
 else
 px-objs += pxd_fastpath_stub.o
-$(warning kernel fast path disabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
+$(warning Kernel fast path disabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
 endif
 else
 px-objs += pxd_fastpath_stub.o
-$(warning kernel fast path disabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
+$(warning Kernel fast path disabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
 endif
 endif
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -85,7 +85,7 @@ endif
 ifeq ($(call verlater,${kmajor},${fp_major}),0)
 PXDEFINES += -D__PX_FASTPATH__
 px-objs += pxd_fastpath.o
-$(info kernel fast path enabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
+$(info Kernel fast path enabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
 else
 ifeq ($(call versame,${kmajor},${fp_major}),0)
 ifeq ($(call versameorlater,${kminor},${fp_minor}),0)

--- a/dev.c
+++ b/dev.c
@@ -821,13 +821,7 @@ static int fuse_notify_set_fastpath(struct fuse_conn *conn, unsigned int size,
 
 static int fuse_notify_get_features(struct fuse_conn *conn, unsigned int size,
 		struct iov_iter *iter) {
-	int features = 0;
-
-#ifdef __PX_FASTPATH__
-	features |= PXD_FEATURE_FASTPATH;
-#endif
-
-	return features;
+	return pxd_supported_features();
 }
 
 static int fuse_notify(struct fuse_conn *fc, enum fuse_notify_code code,

--- a/pxd.c
+++ b/pxd.c
@@ -735,9 +735,10 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 	pxd_dev->size = add->size;
 	pxd_dev->mode = add->open_mode;
 	pxd_dev->fastpath = add->enable_fp;
+	pxd_dev->strict = add->strict;
 
-	printk(KERN_INFO"Device %llu added with mode %#x fastpath %d npath %lu\n",
-			add->dev_id, add->open_mode, add->enable_fp, add->paths.size);
+	printk(KERN_INFO"Device %llu added with mode %#x fastpath %d(%d) npath %lu\n",
+			add->dev_id, add->open_mode, add->enable_fp, add->strict, add->paths.count);
 
 	// initializes fastpath context part of pxd_dev, enables it only
 	// if pxd_dev->fastpath is true, and backing dev paths are available.
@@ -1320,7 +1321,7 @@ static ssize_t pxd_fastpath_update(struct device *dev, struct device_attribute *
 
 		token = __strtok_r(0, delim, &saveptr);
 	}
-	update_out.size = i;
+	update_out.count = i;
 	update_out.dev_id = pxd_dev->dev_id;
 
 	__pxd_update_path(pxd_dev, &update_out);

--- a/pxd.h
+++ b/pxd.h
@@ -19,7 +19,7 @@
 #define PXD_DEV  	"pxd/pxd"		/**< block device prefix */
 #define PXD_DEV_PATH	"/dev/" PXD_DEV		/**< block device path prefix */
 
-#define PXD_VERSION 9				/**< driver version */
+#define PXD_VERSION 10				/**< driver version */
 
 #define PXD_NUM_CONTEXTS			11	/**< Total available control devices */
 #define PXD_NUM_CONTEXT_EXPORTED	1	/**< Available for external use */

--- a/pxd.h
+++ b/pxd.h
@@ -99,7 +99,7 @@ struct pxd_init_out {
  */
 struct pxd_update_path_out {
 	uint64_t dev_id;
-	size_t size; // count of paths below.
+	size_t count; // count of paths below.
 	char devpath[MAX_PXD_BACKING_DEVS][MAX_PXD_DEVPATH_LEN+1];
 };
 
@@ -123,6 +123,7 @@ struct pxd_add_ext_out {
 	int32_t discard_size;	/**< block device discard size in bytes */
 	mode_t  open_mode; /**< backing file open mode O_RDONLY|O_SYNC|O_DIRECT etc */
 	int     enable_fp; /**< enable fast path */
+	bool strict; /***< if strict, then fastpath attach fails if dependencies fail, if not, attach fallback to native path */
 	struct pxd_update_path_out paths; /**< backing device paths */
 };
 

--- a/pxd.h
+++ b/pxd.h
@@ -169,6 +169,17 @@ struct pxd_fastpath_out {
 // No arguments necessary other than opcode
 #define PXD_FEATURE_FASTPATH (0x1)
 
+static inline
+int pxd_supported_features(void)
+{
+	int features = 0;
+#ifdef __PX_FASTPATH__
+	features |= PXD_FEATURE_FASTPATH;
+#endif
+
+	return features;
+}
+
 
 /**
  * PXD_READ/PXD_WRITE kernel request structure

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -40,6 +40,7 @@ struct pxd_device {
 	bool connected;
 	mode_t mode;
 	bool fastpath;
+	bool strict;
 #ifdef __PX_BLKMQ__
         struct blk_mq_tag_set tag_set;
 #endif

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1224,9 +1224,10 @@ out_file_failed:
 	memset(pxd_dev->fp.file, 0, sizeof(pxd_dev->fp.file));
 	memset(pxd_dev->fp.device_path, 0, sizeof(pxd_dev->fp.device_path));
 
-	// even if there are errors setting up fastpath, initialize to take slow path,
-	// do not report failure outside
 	if (pxd_dev->strict) return -EINVAL;
+
+	// if not in strict mode, then even if there are errors setting up fastpath,
+	// initialize to take slow path, do not report failure outside.
 	return 0;
 }
 

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -360,7 +360,7 @@ static int _pxd_write(uint64_t dev_id, struct file *file, struct bio_vec *bvec, 
 	if (unlikely(bvec->bv_len != PXD_LBS)) {
 		printk(KERN_ERR"Unaligned block writes %d bytes\n", bvec->bv_len);
 	}
-	set_fs(get_ds());
+	set_fs(KERNEL_DS);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,20,0)
 	iov_iter_bvec(&i, WRITE, bvec, 1, bvec->bv_len);
 	file_start_write(file);
@@ -459,7 +459,7 @@ ssize_t _pxd_read(uint64_t dev_id, struct file *file, struct bio_vec *bvec, loff
 	mm_segment_t old_fs = get_fs();
 	void *kaddr = kmap(bvec->bv_page) + bvec->bv_offset;
 
-	set_fs(get_ds());
+	set_fs(KERNEL_DS);
 	result = vfs_read(file, kaddr, bvec->bv_len, pos);
 	set_fs(old_fs);
 	kunmap(bvec->bv_page);


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

Commit: https://github.com/torvalds/linux/commit/736706bee3298208343a76096370e4f6a5c55915
removed reference to get_ds(), hardcoded value to KERNEL_DS.

Without this change, px-fuse failing compilation in 5.1+ Linux kernels.

1/ fix log strings for capitalization
2/ fix fastpath counters
3/ fix fastpath init for extended device add with paths.
4/ bump version as pxd interface structs changed.