### PR TITLE
remove duplicate checks for connected, check once in send_nowait()

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -88,11 +88,6 @@ static struct fuse_req *__fuse_get_req(struct fuse_conn *fc)
 	struct fuse_req *req;
 	int err;
 
-	if (!fc->connected && !fc->allow_disconnected) {
-		 err = -ENOTCONN;
-		goto out;
-	}
-
 	req = fuse_request_alloc();
 	if (!req) {
 		err = -ENOMEM;
@@ -254,20 +249,16 @@ static int request_pending(struct fuse_conn *fc)
 
 /* Wait until a request is available on the pending list */
 static void request_wait(struct fuse_conn *fc)
-__releases(fc->lock)
-__acquires(fc->lock)
 {
 	DECLARE_WAITQUEUE(wait, current);
 
 	add_wait_queue_exclusive(&fc->waitq, &wait);
-	while (fc->connected && !request_pending(fc)) {
+	while (!request_pending(fc)) {
 		set_current_state(TASK_INTERRUPTIBLE);
 		if (signal_pending(current))
 			break;
 
-		spin_unlock(&fc->lock);
 		schedule();
-		spin_lock(&fc->lock);
 	}
 	set_current_state(TASK_RUNNING);
 	remove_wait_queue(&fc->waitq, &wait);
@@ -381,24 +372,17 @@ static void fuse_convert_zero_writes(struct fuse_req *req)
 static ssize_t fuse_dev_do_read(struct fuse_conn *fc, struct file *file,
 	struct iov_iter *iter)
 {
-	int err;
 	struct fuse_req *req;
 	ssize_t copied = 0, copied_this_time;
 	ssize_t remain = iter->count;
 	u32 read, write;
 
 	if (!request_pending(fc)) {
-		if ((file->f_flags & O_NONBLOCK) && fc->connected)
+		if ((file->f_flags & O_NONBLOCK))
 			return -EAGAIN;
-		spin_lock(&fc->lock);
 		request_wait(fc);
-		err = -ENODEV;
-		if (!fc->connected)
-			goto err_unlock;
-		err = -ERESTARTSYS;
 		if (!request_pending(fc))
-			goto err_unlock;
-		spin_unlock(&fc->lock);
+			return -ERESTARTSYS;
 	}
 
 retry:
@@ -437,10 +421,6 @@ retry:
 		goto retry;
 
 	return copied;
-
- err_unlock:
-	spin_unlock(&fc->lock);
-	return err;
 }
 
 
@@ -984,12 +964,8 @@ static unsigned fuse_dev_poll(struct file *file, poll_table *wait)
 
 	poll_wait(file, &fc->waitq, wait);
 
-	spin_lock(&fc->lock);
-	if (!fc->connected)
-		mask = POLLERR;
-	else if (request_pending(fc))
+	if (request_pending(fc))
 		mask |= POLLIN | POLLRDNORM;
-	spin_unlock(&fc->lock);
 
 	return mask;
 }

--- a/pxd.c
+++ b/pxd.c
@@ -527,9 +527,6 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 	if (BLK_RQ_IS_PASSTHROUGH(rq))
 		return BLK_STS_IOERR;
 
-	if (!fc->connected && !fc->allow_disconnected)
-		return BLK_STS_IOERR;
-
 	pxd_printk("%s: dev m %d g %lld %s at %ld len %d bytes %d pages "
 		   "flags  %llx\n", __func__,
 		pxd_dev->minor, pxd_dev->dev_id,


### PR DESCRIPTION
remove unnecessary locks in waits
remove unnecessary checks for connected in read and poll,
since connected set on open, !connected is impossible