### PR TITLE
store request directly in the queue instead of pointer

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -1161,8 +1161,11 @@ int fuse_restart_requests(struct fuse_conn *fc)
 	spin_lock(&fc->queue.w.lock);
 	sequence = fc->queue.w.sequence;
 	write = fc->queue.w.write;
-	if (read != write)
-		sequence = fc->request_map[fc->queue.w.requests[read].in.unique]->sequence;
+	if (read != write) {
+		int index = fc->queue.w.requests[read].in.unique &
+			(FUSE_MAX_REQUEST_IDS - 1);
+		sequence = fc->request_map[index]->sequence;
+	}
 	spin_unlock(&fc->queue.w.lock);
 
 	printk(KERN_INFO "read %d write %d sequence %lld", read, write, sequence);

--- a/dev.c
+++ b/dev.c
@@ -387,10 +387,9 @@ retry:
 
 	while (read != write && remain >= sizeof(struct rdwr_in)) {
 		/* copy as many contiguous elements as possible */
-		copied_this_time = min((FUSE_REQUEST_QUEUE_SIZE - read) *
-			sizeof(struct rdwr_in),
-			min((write - read) * sizeof(struct rdwr_in),
-			remain / sizeof(struct rdwr_in) * sizeof(struct rdwr_in)));
+		copied_this_time = min(FUSE_REQUEST_QUEUE_SIZE - read,
+			min(write - read, (u32)(remain / sizeof(struct rdwr_in)))) *
+				   sizeof(struct rdwr_in);
 		if (copy_to_iter(&fc->queue.r.requests[read], copied_this_time, iter)
 		    != copied_this_time) {
 			printk(KERN_ERR "%s: copy error\n", __func__);

--- a/dev.c
+++ b/dev.c
@@ -386,8 +386,11 @@ retry:
 	write = smp_load_acquire(&fc->queue.r.write);
 
 	while (read != write && remain >= sizeof(struct rdwr_in)) {
-		copied_this_time = min((write - read) * sizeof(struct rdwr_in),
-			remain / sizeof(struct rdwr_in) * sizeof(struct rdwr_in));
+		/* copy as many contiguous elements as possible */
+		copied_this_time = min((FUSE_REQUEST_QUEUE_SIZE - read) *
+			sizeof(struct rdwr_in),
+			min((write - read) * sizeof(struct rdwr_in),
+			remain / sizeof(struct rdwr_in) * sizeof(struct rdwr_in)));
 		if (copy_to_iter(&fc->queue.r.requests[read], copied_this_time, iter)
 		    != copied_this_time) {
 			printk(KERN_ERR "%s: copy error\n", __func__);

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -91,14 +91,14 @@ struct ____cacheline_aligned fuse_req_queue {
 		spinlock_t lock;	/** writer lock */
 		uint32_t pad_0;
 		uint64_t sequence;        /** next request sequence number */
-		struct fuse_req **requests;	/** request ring buffer */
+		struct rdwr_in *requests;	/** request ring buffer */
 		uint64_t pad[4];
 	} w;
 
 	struct ____cacheline_aligned {
 		uint32_t read;          /** read index updated by reader */
 		uint32_t write;		/** write pointer updated by receive function */
-		struct fuse_req **requests;	/** request ring buffer */
+		struct rdwr_in *requests;	/** request ring buffer */
 		uint64_t pad_2[14];
 	} r;
 };
@@ -225,4 +225,7 @@ ssize_t pxd_update_path(struct fuse_conn *fc, struct pxd_update_path_out *update
 int pxd_set_fastpath(struct fuse_conn *fc, struct pxd_fastpath_out*);
 
 void fuse_request_init(struct fuse_req *req);
+
+void fuse_convert_zero_writes(struct fuse_req *req);
+
 #endif /* _FS_FUSE_I_H */

--- a/pxd.c
+++ b/pxd.c
@@ -299,6 +299,9 @@ static void pxd_write_request(struct fuse_req *req, uint32_t size, uint64_t off,
 	}
 
 	pxd_req_misc(req, size, off, minor, flags);
+
+	if (pxd_detect_zero_writes && req->pxd_rdwr_in.size != 0)
+		fuse_convert_zero_writes(req);
 }
 
 static void pxd_discard_request(struct fuse_req *req, uint32_t size, uint64_t off,


### PR DESCRIPTION
in preparation to map the queue into user space