### PR TITLE
handle read only targets correctly

### DIFF
--- a/pxd_core.h
+++ b/pxd_core.h
@@ -1,6 +1,7 @@
 #ifndef _PXD_CORE_H_
 #define _PXD_CORE_H_
 
+#include <linux/types.h>
 #include <linux/miscdevice.h>
 #ifdef __PX_BLKMQ__
 #include <linux/blk-mq.h>
@@ -80,9 +81,7 @@ void pxd_make_request_slowpath(struct request_queue *q, struct bio *bio);
 static inline
 mode_t open_mode(mode_t mode) {
 	mode_t m = O_LARGEFILE | O_NOATIME; // default
-	if (mode & O_RDONLY) {
-		m |= O_RDONLY;
-	} else {
+	if (mode & O_RDWR) {
 		m |= O_RDWR;
 	}
 
@@ -97,11 +96,23 @@ void decode_mode(mode_t mode, char *out) {
 	if (mode & O_LARGEFILE) *out++ = 'L';
 	if (mode & O_NOATIME) *out++ = 'A';
 	if (mode & O_DIRECT) *out++='D';
-	if (mode & O_RDONLY) *out++='R';
-	if (mode & O_RDWR) *out++ = 'W';
+	if (mode & O_WRONLY) *out++ = 'W';
+	if (mode & O_RDWR) {
+		*out++ = 'R';
+		*out++ = 'W';
+	} else { // O_RDONLY is defined as zero
+		*out++ = 'R';
+	}
 	if (mode & O_SYNC) *out++ = 'S';
+	if (mode & O_TRUNC) *out++ = 'T';
+	if (mode & O_APPEND) *out++ = 'P';
 
 	*out = '\0';
+}
+
+static inline
+int write_allowed(mode_t curr) {
+	return ((curr & (O_RDWR | O_WRONLY)));
 }
 
 #endif /* _PXD_CORE_H_ */


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

The changes handle read only targets more gracefully very early at the request submission time with the px device. This also avoids btrfs kernel tracebacks for requests submitted to it, while read only.

**Test Logs**
```
root@ip-172-31-61-165:/home/ubuntu/srcs/src/github.com/portworx# pxctl v l
ID                      NAME            SIZE    HA      SHARED  ENCRYPTED       IO_PRIORITY     STATUS                          SNAP-ENABLED    PUBLIC
1013358237278815083     fpclone1        1 GiB   1       no      no              HIGH            up - detached                   no              true
751443242257173254      fpsnap1         1 GiB   1       no      no              HIGH            up - detached                   no              true
748633407233270884      fpsnap2         1 GiB   1       no      no              HIGH            up - attached on 172.31.61.165  no              true
487804370921860839      fpv1            1 GiB   1       no      no              HIGH            up - detached                   no              true
root@ip-172-31-61-165:/home/ubuntu/srcs/src/github.com/portworx# pxctl v snapshot create --name fpsnap3 fpv1
Volume snap successful: 15633552012327391
root@ip-172-31-61-165:/home/ubuntu/srcs/src/github.com/portworx# pxctl host attach fpv1
Volume successfully attached at: /dev/pxd/pxd487804370921860839
root@ip-172-31-61-165:/home/ubuntu/srcs/src/github.com/portworx# pxctl host attach fpsnap3
Volume successfully attached at: /dev/pxd/pxd15633552012327391
root@ip-172-31-61-165:/home/ubuntu/srcs/src/github.com/portworx# blkid /dev/pxd/pxd15633552012327391
/dev/pxd/pxd15633552012327391: UUID="496c2289-b9b6-46cc-a44e-0a5309b7533b" TYPE="ext4"
root@ip-172-31-61-165:/home/ubuntu/srcs/src/github.com/portworx# blkid /dev/pxd/pxd487804370921860839
/dev/pxd/pxd487804370921860839: UUID="496c2289-b9b6-46cc-a44e-0a5309b7533b" TYPE="ext4"
root@ip-172-31-61-165:/home/ubuntu/srcs/src/github.com/portworx# mkfs.xfs -f /dev/pxd/pxd15633552012327391
meta-data=/dev/pxd/pxd15633552012327391 isize=512    agcount=4, agsize=65536 blks
         =                       sectsz=4096  attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=0, rmapbt=0, reflink=0
data     =                       bsize=4096   blocks=262144, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0 ftype=1
log      =internal log           bsize=4096   blocks=2560, version=2
         =                       sectsz=4096  sunit=1 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
mkfs.xfs: pwrite failed: Input/output error
root@ip-172-31-61-165:/home/ubuntu/srcs/src/github.com/portworx# blkid /dev/pxd/pxd15633552012327391
/dev/pxd/pxd15633552012327391: UUID="496c2289-b9b6-46cc-a44e-0a5309b7533b" TYPE="ext4"
root@ip-172-31-61-165:/home/ubuntu/srcs/src/github.com/portworx# mkfs.xfs -f /dev/pxd/pxd487804370921860839
meta-data=/dev/pxd/pxd487804370921860839 isize=512    agcount=4, agsize=65536 blks
         =                       sectsz=4096  attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=0, rmapbt=0, reflink=0
data     =                       bsize=4096   blocks=262144, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0 ftype=1
log      =internal log           bsize=4096   blocks=2560, version=2
         =                       sectsz=4096  sunit=1 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
root@ip-172-31-61-165:/home/ubuntu/srcs/src/github.com/portworx# blkid /dev/pxd/pxd487804370921860839
/dev/pxd/pxd487804370921860839: UUID="136c041c-cb6d-44a6-899f-61ea6ab9a021" TYPE="xfs"
root@ip-172-31-61-165:/home/ubuntu/srcs/src/github.com/portworx# pxctl v l
ID                      NAME            SIZE    HA      SHARED  ENCRYPTED       IO_PRIORITY     STATUS                          SNAP-ENABLED    PUBLIC
1013358237278815083     fpclone1        1 GiB   1       no      no              HIGH            up - detached                   no              true
751443242257173254      fpsnap1         1 GiB   1       no      no              HIGH            up - detached                   no              true
748633407233270884      fpsnap2         1 GiB   1       no      no              HIGH            up - attached on 172.31.61.165  no              true
15633552012327391       fpsnap3         1 GiB   1       no      no              HIGH            up - attached on 172.31.61.165  no              true
487804370921860839      fpv1            1 GiB   1       no      no              HIGH            up - attached on 172.31.61.165  no              true
root@ip-172-31-61-165:/home/ubuntu/srcs/src/github.com/portworx# pxctl v restore -s fpsnap3 fpv1
restore: Failed to restore volume fpv1 to snapshot fpsnap3: Volume fpv1 (487804370921860839) is attached
root@ip-172-31-61-165:/home/ubuntu/srcs/src/github.com/portworx# pxctl host detach fpv1
Volume successfully detached
root@ip-172-31-61-165:/home/ubuntu/srcs/src/github.com/portworx# pxctl v restore -s fpsnap3 fpv1
Successfully started restoring volume fpv1 from fpsnap3.
root@ip-172-31-61-165:/home/ubuntu/srcs/src/github.com/portworx# pxctl v restore -s fpsnap3 fpv1 -j
{
 "cmd": "restore",
 "status": "Ok",
 "desc": "Successfully started restoring volume fpv1 from fpsnap3.",
 "uuid": [
  "fpv1"
 ]
}
root@ip-172-31-61-165:/home/ubuntu/srcs/src/github.com/portworx# pxctl host attach fpv1
Volume successfully attached at: /dev/pxd/pxd487804370921860839
root@ip-172-31-61-165:/home/ubuntu/srcs/src/github.com/portworx# blkid /dev/pxd/pxd487804370921860839
/dev/pxd/pxd487804370921860839: UUID="496c2289-b9b6-46cc-a44e-0a5309b7533b" TYPE="ext4"
root@ip-172-31-61-165:/home/ubuntu/srcs/src/github.com/portworx#
```