### PR TITLE
adjust pxd device queue limits wrt backing device

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -686,6 +686,11 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 	/* Enable flush support. */
 	BLK_QUEUE_FLUSH(q);
 
+	/* adjust queue limits to be compatible with backing device */
+	if (pxd_dev->fastpath) {
+		pxd_fastpath_adjust_limits(pxd_dev, q);
+	}
+
 	disk->queue = q;
 	q->queuedata = pxd_dev;
 	pxd_dev->disk = disk;
@@ -710,7 +715,7 @@ static void pxd_free_disk(struct pxd_device *pxd_dev)
 		if (disk->queue)
 			blk_cleanup_queue(disk->queue);
 #ifdef __PX_BLKMQ__
-		blk_mq_free_tag_set(&pxd_dev->tag_set);
+		if (!pxd_dev->fastpath) blk_mq_free_tag_set(&pxd_dev->tag_set);
 #endif
 	}
 	put_disk(disk);

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -779,7 +779,7 @@ static struct pxd_io_tracker* __pxd_init_block_replica(struct pxd_device *pxd_de
 	struct pxd_io_tracker* iot;
 	struct address_space *mapping = fileh->f_mapping;
 	struct inode *inode = mapping->host;
-	struct block_device *bdi = I_BDEV(inode);
+	struct block_device *bdev = I_BDEV(inode);
 
 	pxd_printk("pxd %px:__pxd_init_block_replica entering with bio %px, fileh %px with blkg %px\n",
 			pxd_dev, bio, fileh, bio->bi_blkg);
@@ -810,7 +810,7 @@ static struct pxd_io_tracker* __pxd_init_block_replica(struct pxd_device *pxd_de
 
 	clone_bio->bi_private = pxd_dev;
 	if (S_ISBLK(inode->i_mode)) {
-		BIO_SET_DEV(clone_bio, bdi);
+		BIO_SET_DEV(clone_bio, bdev);
 		clone_bio->bi_end_io = pxd_complete_io;
 	} else {
 		clone_bio->bi_end_io = pxd_complete_io_dummy;
@@ -1549,7 +1549,7 @@ void pxd_fastpath_adjust_limits(struct pxd_device *pxd_dev, struct request_queue
 
 	printk(KERN_INFO"pxd device %llu: adjusting queue limits nfd %d\n", pxd_dev->dev_id, pxd_dev->fp.nfd);
 
-	for (i=0; i<pxd_dev->fp.nfd; i++) {
+	for (i = 0; i < pxd_dev->fp.nfd; i++) {
 		file = pxd_dev->fp.file[i];
 		BUG_ON(!file);
 		inode = file_inode(file);

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -134,4 +134,5 @@ int pxd_device_congested(void *, int);
 // return the io count processed by a thread
 int get_thread_count(int id);
 
+void pxd_fastpath_adjust_limits(struct pxd_device *pxd_dev, struct request_queue *topque);
 #endif /* _PXD_FASTPATH_H_ */

--- a/pxd_fastpath_stub.c
+++ b/pxd_fastpath_stub.c
@@ -27,4 +27,5 @@ int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_
 // return the io count processed by a thread
 int get_thread_count(int id) { return -1; }
 
+void pxd_fastpath_adjust_limits(struct pxd_device *pxd_dev, struct request_queue *topque) {}
 #endif


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

If the queue limits are not properly set, then it may be possible to submit an incompatible block IO directly with the backing devices.
This shall results in bio too large error messages.

```
[root@PDC1-SM1 px-fuse]# cat /sys/block/pxd\!pxd831186063849924602/queue/max_sectors_kb
128
[root@PDC1-SM1 px-fuse]# cat /sys/block/pxd\!pxd831186063849924602/queue/max_segments
33
[root@PDC1-SM1 px-fuse]# cat /sys/block/pxd\!pxd831186063849924602/queue/logical_block_size
4096
[root@PDC1-SM1 px-fuse]# cat /sys/block/pxd\!pxd831186063849924602/queue/max_segment_size
65536
[root@PDC1-SM1 px-fuse]# cat /sys/block/pxd\!pxd831186063849924602/queue/max_discard_segments
1
[root@PDC1-SM1 px-fuse]# cat /sys/block/pxd\!pxd831186063849924602/queue/discard_max_bytes
1048576
[root@PDC1-SM1 px-fuse]# cat /sys/block/pxd\!pxd831186063849924602/queue/discard_max_hw_bytes
2199023255040
[root@PDC1-SM1 px-fuse]# cat /sys/block/pxd\!pxd831186063849924602/queue/discard_zeroes_data
0
[root@PDC1-SM1 px-fuse]# cat /sys/block/pxd\!pxd831186063849924602/queue/discard_granularity
1048576
[root@PDC1-SM1 px-fuse]# pxctl v i -j fpvol1 | jq .[].fpConfig
{
  "setup_on": 0,
  "promote": false,
  "status": "FASTPATH_ACTIVE",
  "replicas": [
    {
      "dev_id": "831186063849924602",
      "node_id": 0,
      "protocol": "FASTPATH_PROTO_LOCAL",
      "acl": true,
      "exported_device": "/dev/pwx0/831186063849924602",
      "block": true,
      "target": "/dev/pwx0/831186063849924602",
      "exported": true,
      "imported": true,
      "devpath": "/dev/pwx0/831186063849924602"
    }
  ]
}
[root@PDC1-SM1 px-fuse]# ls -al /dev/pwx0/831186063849924602
lrwxrwxrwx 1 root root 7 Apr  6 02:46 /dev/pwx0/831186063849924602 -> ../dm-8
[root@PDC1-SM1 px-fuse]# cat /sys/block/dm-8/queue/max_sectors_kb
128
[root@PDC1-SM1 px-fuse]# cat /sys/block/dm-8/queue/max_hw_sectors_kb
128
[root@PDC1-SM1 px-fuse]# cat /sys/block/dm-8/queue/max_segments
33
[root@PDC1-SM1 px-fuse]# cat /sys/block/dm-8/queue/max_segment_size
65536
[root@PDC1-SM1 px-fuse]# cat /sys/block/dm-8/queue/max_discard_segments
256
[root@PDC1-SM1 px-fuse]# cat /sys/block/dm-8/queue/discard_granularity
1048576
[root@PDC1-SM1 px-fuse]# cat /sys/block/dm-8/queue/discard_zeroes_data
0
[root@PDC1-SM1 px-fuse]# cat /sys/block/dm-8/queue/discard_max_hw_bytes
2199023255040
[root@PDC1-SM1 px-fuse]# cat /sys/block/dm-8/queue/discard_max_bytes
17179869184
[root@PDC1-SM1 px-fuse]#
```