### PR TITLE
since io context is allocated dynamically

### DIFF
--- a/io.c
+++ b/io.c
@@ -2356,16 +2356,19 @@ struct file_operations io_ring_fops = {
 	.mmap = io_uring_mmap,
 };
 
-int io_ring_register_device(struct io_dev *ctx, int context_id)
+static struct miscdevice miscdev;
+
+int io_ring_register_device()
 {
-	struct miscdevice *dev = &ctx->miscdev;
-
-	ctx->context_id = context_id;
-
-	sprintf(ctx->name, "pxd/pxd-io-%d", context_id);
-	dev->minor = MISC_DYNAMIC_MINOR;
-	dev->name = ctx->name;
-	dev->fops = &io_ring_fops;
-	return misc_register(dev);
+	miscdev.minor = MISC_DYNAMIC_MINOR;
+	miscdev.name = "pxd/pxd-io";
+	miscdev.fops = &io_ring_fops;
+	return misc_register(&miscdev);
 }
+
+void io_ring_unregister_device()
+{
+	misc_deregister(&miscdev);
+}
+
 #endif

--- a/io.h
+++ b/io.h
@@ -189,8 +189,8 @@ struct io_kiocb {
 extern struct kmem_cache *req_cachep;
 
 struct io_uring_params;
-struct io_dev;
 
-int io_ring_register_device(struct io_dev *ctx, int context_id);
+int io_ring_register_device(void);
+void io_ring_unregister_device(void);
 
 #endif //PXFUSE_IO_H

--- a/pxd.c
+++ b/pxd.c
@@ -1667,9 +1667,6 @@ int pxd_context_init(struct pxd_context *ctx, int i)
 static void pxd_context_destroy(struct pxd_context *ctx)
 {
 	misc_deregister(&ctx->miscdev);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
-	misc_deregister(&ctx->io_dev.miscdev);
-#endif
 	cancel_delayed_work_sync(&ctx->abort_work);
 	if (ctx->id < pxd_num_contexts_exported) {
 		fuse_abort_conn(&ctx->fc);
@@ -1686,6 +1683,12 @@ int pxd_init(void)
 	req_cachep = KMEM_CACHE(io_kiocb, SLAB_HWCACHE_ALIGN);
 	if (req_cachep == NULL) {
 		printk(KERN_ERR "pxd: failed to initialize request cache");
+		goto out;
+	}
+
+	err = io_ring_register_device();
+	if (err) {
+		printk(KERN_ERR "pxd: failed to register io dev: %d\n", err);
 		goto out;
 	}
 #endif
@@ -1718,15 +1721,6 @@ int pxd_init(void)
 				ctx->miscdev.name, i, err);
 			goto out_fuse;
 		}
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
-		err = io_ring_register_device(&ctx->io_dev, i);
-		if (err) {
-			printk(KERN_ERR "pxd: failed to register io dev %s %d: %d\n",
-				ctx->io_dev.name, i, err);
-			goto out_fuse;
-		}
-#endif
 	}
 
 	pxd_miscdev.fops = &pxd_contexts[0].fops;
@@ -1782,6 +1776,10 @@ out:
 void pxd_exit(void)
 {
 	int i;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+	io_ring_unregister_device();
+#endif
 
 	fastpath_cleanup();
 	pxd_sysfs_exit();

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -24,13 +24,6 @@ struct pxd_context {
 	char name[256];
 	int id;
 	struct miscdevice miscdev;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
-	struct io_dev {
-		char name[256];
-		struct miscdevice miscdev;
-		uint32_t context_id;
-	} io_dev;
-#endif
 	struct delayed_work abort_work;
 	uint64_t open_seq;
 };


### PR DESCRIPTION
it is enough to create just one device