### PR TITLE
handle different api signature for lookup_bdev

### DIFF
--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -100,4 +100,17 @@
 			__SETUP_CONGESTION_HOOK(__ptr_or_null(&bdev), cfn, cdata))
 
 
+#define __COMPAT_CALL_LOOKUP_BDEV_0(fn, path) ({ struct block_device* (*f)(const char*) = fn; struct block_device *p = NULL; if (f) { p = f(path);}  p; })
+#define __COMPAT_CALL_LOOKUP_BDEV_1(fn, path) ({ struct block_device* (*f)(const char*, int) = fn; struct block_device *p = NULL; if (f) { p = f(path, 0);}  p; })
+
+#define __lookup_bdev_singlearg(fn) __builtin_types_compatible_p(typeof(fn), struct block_device* (*)(const char*))
+#define __lookup_bdev_twoarg(fn) __builtin_types_compatible_p(typeof(fn), struct block_device* (*)(const char*, int))
+#define __singlearg_method_or_null(fn) __builtin_choose_expr(__lookup_bdev_singlearg(fn), fn, NULL)
+#define __doublearg_method_or_null(fn) __builtin_choose_expr(__lookup_bdev_twoarg(fn), fn, NULL)
+#define COMPAT_CALL_LOOKUP_BDEV(path) \
+	__builtin_choose_expr(__lookup_bdev_singlearg(lookup_bdev), \
+			__COMPAT_CALL_LOOKUP_BDEV_0(__singlearg_method_or_null(lookup_bdev), path), \
+			__COMPAT_CALL_LOOKUP_BDEV_1(__doublearg_method_or_null(lookup_bdev), path))
+
+
 #endif //GDFS_PXD_COMPAT_H

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1554,7 +1554,7 @@ void pxd_fastpath_adjust_limits(struct pxd_device *pxd_dev, struct request_queue
 		BUG_ON(!file);
 		inode = file_inode(file);
 		if (S_ISBLK(inode->i_mode)) {
-			bdev = lookup_bdev(pxd_dev->fp.device_path[i]);
+			bdev = COMPAT_CALL_LOOKUP_BDEV(pxd_dev->fp.device_path[i]);
 		} else {
 			bdev = inode->i_sb->s_bdev;
 		}

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1558,7 +1558,12 @@ void pxd_fastpath_adjust_limits(struct pxd_device *pxd_dev, struct request_queue
 		} else {
 			bdev = inode->i_sb->s_bdev;
 		}
-		if (!bdev) continue;
+
+		if (!bdev || IS_ERR(bdev)) {
+			printk(KERN_ERR"pxd device %llu: backing block device lookup for path %s failed %ld\n",
+				pxd_dev->dev_id, pxd_dev->fp.device_path[i], PTR_ERR(bdev));
+			continue;
+		}
 
 		disk = bdev->bd_disk;
 		if (disk) {


### PR DESCRIPTION
A compile time hack to find the proper signature for lookup_bdev.

Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

Failed compilation in ubuntu 18 distro as below. 
There doesn't exist any single compile time macro to check and decide on this.
```
/home/max/workspace/src/github.com/portworx/porx/src/gdfs/px_fuse/Makefile:97: kernel fast path enabled, current kernel version 4.15.0-96-generic need minimum 4.0
/home/max/workspace/src/github.com/portworx/porx/src/gdfs/px_fuse/pxd_fastpath.c: In function ‘pxd_fastpath_adjust_limits’:
/home/max/workspace/src/github.com/portworx/porx/src/gdfs/px_fuse/pxd_fastpath.c:1557:11: error: too few arguments to function ‘lookup_bdev’
    bdev = lookup_bdev(pxd_dev->fp.device_path[i]);
           ^~~~~~~~~~~
In file included from ./include/linux/seq_file.h:11:0,
                 from ./include/linux/pinctrl/consumer.h:17,
                 from ./include/linux/pinctrl/devinfo.h:21,
                 from ./include/linux/device.h:24,
                 from ./include/linux/genhd.h:65,
                 from /home/max/workspace/src/github.com/portworx/porx/src/gdfs/px_fuse/pxd_fastpath.c:4:
./include/linux/fs.h:2578:29: note: declared here
 extern struct block_device *lookup_bdev(const char *, int mask);
```