### PR TITLE
fastpath driver cleanup

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -340,7 +340,7 @@ static void __fuse_convert_zero_writes_fastpath(struct fuse_req *req)
 
 void fuse_convert_zero_writes(struct fuse_req *req)
 {
-	if (req->fastpath) {
+	if (!req->using_blkque) {
 		__fuse_convert_zero_writes_fastpath(req);
 	} else {
 		__fuse_convert_zero_writes_slowpath(req);
@@ -679,7 +679,7 @@ static int fuse_notify_read_data(struct fuse_conn *conn, unsigned int size,
 		return -EINVAL;
 	}
 
-	if (req->fastpath) {
+	if (!req->using_blkque) {
 		return __fuse_notify_read_data_fastpath(conn, req, &read_data, iter);
 	}
 
@@ -879,7 +879,7 @@ static ssize_t fuse_dev_do_write(struct fuse_conn *fc, struct iov_iter *iter)
 		return -ENOENT;
 	}
 
-	if (req->fastpath) {
+	if (!req->using_blkque) {
 		err = __fuse_dev_do_write_fastpath(fc, req, iter);
 	} else {
 		err = __fuse_dev_do_write_slowpath(fc, req, iter);
@@ -969,7 +969,7 @@ void fuse_process_user_request(struct fuse_conn *fc, struct fuse_user_request *u
 		iov_iter_init(&iter, READ, data_iov, ureq->len,
 			iov_length(data_iov, ureq->len));
 
-		ret = req->fastpath ?
+		ret = !req->using_blkque ?
 		      __fuse_dev_do_write_fastpath(fc, req, &iter) :
 		      __fuse_dev_do_write_slowpath(fc, req, &iter);
 

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -44,8 +44,8 @@ struct fuse_conn;
  * A request to the client
  */
 struct fuse_req {
-	/** Request to use fastpath */
-	unsigned fastpath:1;
+	/** Block IO requests are processed through blk request queue */
+	unsigned using_blkque:1;
 
 	/** The request input header */
 	struct fuse_in_header in;

--- a/pxd.c
+++ b/pxd.c
@@ -967,7 +967,6 @@ copy_error:
 
 static int __pxd_update_path(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path)
 {
-	int err = 0;
 	/// This seems risky to update paths on the fly while the px device is active
 	/// Need to confirm behavior while IOs are active and handle it right!!!!
 	if (pxd_dev->using_blkque) {

--- a/pxd.c
+++ b/pxd.c
@@ -691,7 +691,6 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 
 	/* adjust queue limits to be compatible with backing device */
 	if (!pxd_dev->using_blkque) {
-		enableFastPath(pxd_dev, true);
 		pxd_fastpath_adjust_limits(pxd_dev, q);
 	}
 
@@ -975,10 +974,7 @@ static int __pxd_update_path(struct pxd_device *pxd_dev, struct pxd_update_path_
 		printk(KERN_WARNING"%llu: block device registered for native path - cannot update for fastpath\n", pxd_dev->dev_id);
 		return -EINVAL;
 	}
-	disableFastPath(pxd_dev);
-	err = pxd_init_fastpath_target(pxd_dev, update_path);
-	enableFastPath(pxd_dev, true);
-	return err;
+	return pxd_init_fastpath_target(pxd_dev, update_path);
 
 }
 

--- a/pxd.c
+++ b/pxd.c
@@ -611,7 +611,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 #ifndef __PX_FASTPATH__
 	if (!pxd_dev->using_blkque) {
 		printk(KERN_NOTICE"PX driver does not support fastpath, disabling it.");
-		pxd_dev->fastpath = true;
+		pxd_dev->using_blkque = true;
 	}
 #else
 	if (!pxd_dev->using_blkque) {

--- a/pxd.c
+++ b/pxd.c
@@ -458,7 +458,7 @@ void pxd_make_request_slowpath(struct request_queue *q, struct bio *bio)
 
 	flags = bio->bi_flags;
 
-	pxd_printk("%s: dev m %d g %lld %s at %lld len %d bytes %d pages "
+	pxd_printk("%s: dev m %d g %lld %s at %ld len %d bytes %d pages "
 			"flags 0x%x op_flags 0x%x\n", __func__,
 			pxd_dev->minor, pxd_dev->dev_id,
 			bio_data_dir(bio) == WRITE ? "wr" : "rd",
@@ -557,7 +557,7 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 	if (BLK_RQ_IS_PASSTHROUGH(rq))
 		return BLK_STS_IOERR;
 
-	pxd_printk("%s: dev m %d g %lld %s at %lld len %d bytes %d pages "
+	pxd_printk("%s: dev m %d g %lld %s at %ld len %d bytes %d pages "
 		   "flags  %x\n", __func__,
 		pxd_dev->minor, pxd_dev->dev_id,
 		rq_data_dir(rq) == WRITE ? "wr" : "rd",
@@ -691,6 +691,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 
 	/* adjust queue limits to be compatible with backing device */
 	if (!pxd_dev->using_blkque) {
+		enableFastPath(pxd_dev, true);
 		pxd_fastpath_adjust_limits(pxd_dev, q);
 	}
 

--- a/pxd.c
+++ b/pxd.c
@@ -1123,8 +1123,9 @@ static ssize_t pxd_active_show(struct device *dev,
 	int available = PAGE_SIZE - 1;
 	int i;
 
-	ncount = snprintf(cp, available, "active/complete: %u/%u, [write: %u, flush: %u(nop: %u), fua: %u, discard: %u, preflush: %u], switched: %u, slowpath: %u\n",
+	ncount = snprintf(cp, available, "active/complete: %u/%u, failed: %u, [write: %u, flush: %u(nop: %u), fua: %u, discard: %u, preflush: %u], switched: %u, slowpath: %u\n",
                 atomic_read(&pxd_dev->fp.ncount), atomic_read(&pxd_dev->fp.ncomplete),
+		atomic_read(&pxd_dev->fp.nerror),
 		atomic_read(&pxd_dev->fp.nio_write),
 		atomic_read(&pxd_dev->fp.nio_flush), atomic_read(&pxd_dev->fp.nio_flush_nop),
 		atomic_read(&pxd_dev->fp.nio_fua), atomic_read(&pxd_dev->fp.nio_discard),

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -46,7 +46,7 @@ struct pxd_device {
 	struct pxd_context *ctx;
 	bool connected;
 	mode_t mode;
-	bool fastpath;
+	bool using_blkque; // this is persistent, how the block device registered with kernel
 	bool strict;
 #ifdef __PX_BLKMQ__
         struct blk_mq_tag_set tag_set;

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1396,7 +1396,7 @@ int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_
 			pxd_dev->dev_id, mode, modestr, update_path->count);
 
 	// fastpath cannot be active while updating paths
-	BUG_ON(pxd_dev->fp.fastpath);
+	disableFastPath(pxd_dev);
 	for (i = 0; i < update_path->count; i++) {
 		pxd_printk("Fastpath %d(%d): %s, current %s, %px\n", i, pxd_dev->fp.nfd,
 			update_path->devpath[i], pxd_dev->fp.device_path[i], pxd_dev->fp.file[i]);
@@ -1408,12 +1408,14 @@ int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_
 			pxd_dev->dev_id, pxd_dev->fp.device_path[i]);
 	}
 	pxd_dev->fp.nfd = update_path->count;
+	enableFastPath(pxd_dev, true);
 
-	if (!update_path->count && pxd_dev->strict) goto out_file_failed;
+	if (!pxd_dev->fp.nfd && pxd_dev->strict) goto out_file_failed;
 
 	printk("dev%llu completed setting up %d paths\n", pxd_dev->dev_id, pxd_dev->fp.nfd);
 	return 0;
 out_file_failed:
+	disableFastPath(pxd_dev);
 	for (i = 0; i < pxd_dev->fp.nfd; i++) {
 		if (pxd_dev->fp.file[i] > 0) filp_close(pxd_dev->fp.file[i], NULL);
 	}

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1231,7 +1231,7 @@ void enableFastPath(struct pxd_device *pxd_dev, bool force)
 	mode_t mode = open_mode(pxd_dev->mode);
 	char modestr[32];
 
-	if (!pxd_dev->fastpath || !pxd_dev->fp.nfd) return;
+	if (pxd_dev->using_blkque || !pxd_dev->fp.nfd) return;
 
 	pxd_suspend_io(pxd_dev);
 
@@ -1304,7 +1304,7 @@ void disableFastPath(struct pxd_device *pxd_dev)
 	int nfd = fp->nfd;
 	int i;
 
-	if (!pxd_dev->fastpath || !pxd_dev->fp.nfd) return;
+	if (pxd_dev->using_blkque || !pxd_dev->fp.nfd) return;
 
 	pxd_suspend_io(pxd_dev);
 

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -740,6 +740,7 @@ static void pxd_complete_io(struct bio* bio, int error)
 	if (atomic_read(&head->fails)) {
 		iot->orig->bi_status = -EIO; // mark failure
 	}
+	if (iot->orig->bi_status) atomic_inc(&pxd_dev->fp.nerror);
 	bio_endio(iot->orig);
 }
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -748,11 +748,8 @@ static void pxd_complete_io(struct bio* bio, int error)
 	if (atomic_read(&head->fails)) {
 		status = -EIO; // mark failure
 	}
-	if (status) {
-		bio_io_error(iot->orig);
-	} else {
-		bio_endio(iot->orig);
-	}
+	if (status) atomic_inc(&pxd_dev->fp.nerror);
+	bio_endio(iot->orig, status);
 }
 #else
 {
@@ -760,6 +757,7 @@ static void pxd_complete_io(struct bio* bio, int error)
 	if (atomic_read(&head->fails)) {
 		status = -EIO; // mark failure
 	}
+	if (status) atomic_inc(&pxd_dev->fp.nerror);
 	bio_endio(iot->orig, status);
 }
 #endif
@@ -1370,6 +1368,7 @@ int pxd_fastpath_init(struct pxd_device *pxd_dev)
 	atomic_set(&fp->nwrite_counter,0);
 	atomic_set(&pxd_dev->fp.ncount, 0);
 	atomic_set(&pxd_dev->fp.ncomplete, 0);
+	atomic_set(&pxd_dev->fp.nerror, 0);
 
 	for (i = 0; i < MAX_NUMNODES; i++) {
 		atomic_set(&fp->index[i], 0);

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -94,6 +94,7 @@ struct pxd_fastpath_extension {
 	atomic_t nswitch; // [global] total number of requests through bio switch path
 	atomic_t nslowPath; // [global] total requests through slow path
 	atomic_t ncomplete; // [global] total completed requests
+	atomic_t nerror; // [global] total IO error
 	atomic_t ncount; // [global] total active requests, always modify with pxd_dev.lock
 	atomic_t nwrite_counter; // [global] completed writes, gets cleared on a threshold
 	atomic_t index[MAX_NUMNODES]; // [global] read path IO optimization - last cpu

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -66,6 +66,7 @@ struct pxd_fastpath_extension {
 	int n_flush_wrsegs; // num of PXD_LBS write segments to force flush
 
 	// Below information has to be set through new PXD_UPDATE_PATH ioctl
+	bool fastpath;
 	int nfd;
 	struct file *file[MAX_PXD_BACKING_DEVS];
 	char device_path[MAX_PXD_BACKING_DEVS][MAX_PXD_DEVPATH_LEN+1];


### PR DESCRIPTION
Minor code cleanup and reorg as below.
1) for a device attached, fastpath state could switch to native path dynamically, hence this flag cannot be treated as  state as to how the block device is registered. Separated this condition to be part of fastpath context.

2) the io completion path only relies on whether request queue is used or not, it is better a state within fuse request and further simplifies code. Introduced  a new flag that is part of fuse request, using_blkque that is always persistent and can decide code flow to complete block requests.

3) fixed compilation issues while enabling debug prints.

4) adjust queue limits is only needed if the backing device is a block device, if its a file, it can be left as is.

5) pxd_init_fastpath_target() revised to disable/enable fastpath internal to it, to enable updating fastpath status on the fly.


**TestLogs**
```
[root@PDC1-SM1 porx]# pxctl status
Status: PX is operational
License: Trial (expires in 31 days)
Node ID: bd2e7ce8-ef59-4e4c-89bc-36925f507594
        IP: 70.0.0.16
        Local Storage Pool: 1 pool
        POOL    IO_PRIORITY     RAID_LEVEL      USABLE  USED    STATUS  ZONE    REGION
        0       HIGH            raid0           745 GiB 129 GiB Online  default default
        Local Storage Devices: 1 device
        Device  Path            Media Type              Size            Last-Scan
        0:1     /dev/nvme0n1    STORAGE_MEDIUM_NVME     745 GiB         30 Apr 20 05:52 PDT
        total                   -                       745 GiB
        Cache Devices:
        No cache devices
        Metadata Device:
        1       /dev/sdb        STORAGE_MEDIUM_MAGNETIC
Cluster Summary
        Cluster ID: pxfp-12345
        Cluster UUID: 51ad74f1-0e5b-4c3d-bdc3-35dfbf801304
        Scheduler: none
        Nodes: 1 node(s) with storage (1 online)
        IP              ID                                      SchedulerNodeName       StorageNode     Used Capacity Status  StorageStatus   Version         Kernel                          OS
        70.0.0.16       bd2e7ce8-ef59-4e4c-89bc-36925f507594    N/A                     Yes             129 GiB       745 GiB         Online  Up (This node)  3.0.0.0-9af1573 3.10.0-1062.18.1.el7.x86_64     CentOS Linux 7 (Core)
        Warnings:
                 WARNING: Persistent journald logging is not enabled on this node.
Global Storage Pool
        Total Used      :  129 GiB
        Total Capacity  :  745 GiB
[root@PDC1-SM1 porx]# pxctl v l
ID                      NAME    SIZE    HA      SHARED  ENCRYPTED       IO_PRIORITY     STATUS          SNAP-ENABLED  PUBLIC
759928311017618491      fpv1    100 GiB 1       no      no              HIGH            up - detached   no   true
[root@PDC1-SM1 porx]# pxctl host attach --fastpath=true fpv1
Volume successfully attached at: /dev/pxd/pxd759928311017618491
[root@PDC1-SM1 porx]# pxctl v i -j fpv1 | jq .[].fpConfig
{
  "setup_on": 0,
  "promote": true,
  "status": "FASTPATH_ACTIVE",
  "replicas": [
    {
      "dev_id": "759928311017618491",
      "node_id": 0,
      "protocol": "FASTPATH_PROTO_ISCSI",
      "acl": true,
      "exported_device": "/var/.px/0/759928311017618491/pxdev",
      "block": false,
      "target": "/var/.px/0/759928311017618491/pxdev",
      "exported": true,
      "imported": true,
      "devpath": "/var/.px/0/759928311017618491/pxdev"
    }
  ]
}
[root@PDC1-SM1 porx]# pxctl v c --fastpath=true -s 100 fpv2
Volume successfully created: 517203549515567997
[root@PDC1-SM1 porx]# pxctl host attach fpv2
Volume successfully attached at: /dev/pxd/pxd517203549515567997
[root@PDC1-SM1 porx]# pxctl v i -j fpv2 | jq .[].fpConfig
{
  "setup_on": 0,
  "promote": false,
  "status": "FASTPATH_ACTIVE",
  "replicas": [
    {
      "dev_id": "517203549515567997",
      "node_id": 0,
      "protocol": "FASTPATH_PROTO_ISCSI",
      "acl": true,
      "exported_device": "/var/.px/0/517203549515567997/pxdev",
      "block": false,
      "target": "/var/.px/0/517203549515567997/pxdev",
      "exported": true,
      "imported": true,
      "devpath": "/var/.px/0/517203549515567997/pxdev"
    }
  ]
}
[root@PDC1-SM1 porx]#
```