### PR TITLE
optimize IO scheduling path 

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -711,7 +711,6 @@ static void pxd_free_disk(struct pxd_device *pxd_dev)
 	if (!disk)
 		return;
 
-	pxd_fastpath_cleanup(pxd_dev);
 	pxd_dev->disk = NULL;
 	if (disk->flags & GENHD_FL_UP) {
 		del_gendisk(disk);
@@ -875,9 +874,9 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 	}
 
 	spin_unlock(&pxd_dev->lock);
-	pxd_fastpath_cleanup(pxd_dev);
 
 	device_unregister(&pxd_dev->dev);
+	pxd_fastpath_cleanup(pxd_dev);
 
 	module_put(THIS_MODULE);
 

--- a/pxd.c
+++ b/pxd.c
@@ -1144,24 +1144,6 @@ static ssize_t pxd_active_show(struct device *dev,
 	return ncount;
 }
 
-// show io distribution across thread context (useful in fastpath only)
-static ssize_t pxd_distrib_show(struct device *dev,
-                     struct device_attribute *attr, char *buf)
-{
-	char *cp = buf;
-	int ncount = 0;
-	int available = PAGE_SIZE - 1;
-	int i;
-
-	for (i = 0; i < num_online_cpus(); i++) {
-		size_t tmp = snprintf(cp, available, "[%d]=%d\n", i, get_thread_count(i));
-		cp += tmp;
-		available -= tmp;
-		ncount += tmp;
-	}
-
-	return ncount;
-}
 static ssize_t pxd_sync_show(struct device *dev,
                      struct device_attribute *attr, char *buf)
 {
@@ -1379,7 +1361,6 @@ static DEVICE_ATTR(major, S_IRUGO, pxd_major_show, NULL);
 static DEVICE_ATTR(minor, S_IRUGO, pxd_minor_show, NULL);
 static DEVICE_ATTR(timeout, S_IRUGO|S_IWUSR, pxd_timeout_show, pxd_timeout_store);
 static DEVICE_ATTR(active, S_IRUGO, pxd_active_show, NULL);
-static DEVICE_ATTR(distrib, S_IRUGO, pxd_distrib_show, NULL);
 static DEVICE_ATTR(sync, S_IRUGO|S_IWUSR, pxd_sync_show, pxd_sync_store);
 static DEVICE_ATTR(congested, S_IRUGO|S_IWUSR, pxd_congestion_show, pxd_congestion_set);
 static DEVICE_ATTR(writesegment, S_IRUGO|S_IWUSR, pxd_wrsegment_show, pxd_wrsegment_store);
@@ -1392,7 +1373,6 @@ static struct attribute *pxd_attrs[] = {
 	&dev_attr_minor.attr,
 	&dev_attr_timeout.attr,
 	&dev_attr_active.attr,
-	&dev_attr_distrib.attr,
 	&dev_attr_sync.attr,
 	&dev_attr_congested.attr,
 	&dev_attr_writesegment.attr,

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -99,18 +99,4 @@
 			__SETUP_CONGESTION_HOOK(__ptr_or_null(bdev), cfn, cdata), \
 			__SETUP_CONGESTION_HOOK(__ptr_or_null(&bdev), cfn, cdata))
 
-
-#define __COMPAT_CALL_LOOKUP_BDEV_0(fn, path) ({ struct block_device* (*f)(const char*) = fn; struct block_device *p = NULL; if (f) { p = f(path);}  p; })
-#define __COMPAT_CALL_LOOKUP_BDEV_1(fn, path) ({ struct block_device* (*f)(const char*, int) = fn; struct block_device *p = NULL; if (f) { p = f(path, 0);}  p; })
-
-#define __lookup_bdev_singlearg(fn) __builtin_types_compatible_p(typeof(fn), struct block_device* (*)(const char*))
-#define __lookup_bdev_twoarg(fn) __builtin_types_compatible_p(typeof(fn), struct block_device* (*)(const char*, int))
-#define __singlearg_method_or_null(fn) __builtin_choose_expr(__lookup_bdev_singlearg(fn), fn, NULL)
-#define __doublearg_method_or_null(fn) __builtin_choose_expr(__lookup_bdev_twoarg(fn), fn, NULL)
-#define COMPAT_CALL_LOOKUP_BDEV(path) \
-	__builtin_choose_expr(__lookup_bdev_singlearg(lookup_bdev), \
-			__COMPAT_CALL_LOOKUP_BDEV_0(__singlearg_method_or_null(lookup_bdev), path), \
-			__COMPAT_CALL_LOOKUP_BDEV_1(__doublearg_method_or_null(lookup_bdev), path))
-
-
 #endif //GDFS_PXD_COMPAT_H

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -532,8 +532,8 @@ static void pxd_complete_io(struct bio* bio, int error)
 	}
 	if (status) {
 		atomic_inc(&pxd_dev->fp.nerror);
-		iot->orig->bi_status = status;
 	}
+	iot->orig->bi_status = status;
 	bio_endio(iot->orig);
 }
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
@@ -544,8 +544,8 @@ static void pxd_complete_io(struct bio* bio, int error)
 	}
 	if (status) {
 		atomic_inc(&pxd_dev->fp.nerror);
-		iot->orig->bi_error = status;
 	}
+	iot->orig->bi_error = status;
 	bio_endio(iot->orig);
 }
 #else

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -8,8 +8,6 @@
 #include "pxd_core.h"
 #include "pxd_compat.h"
 
-#define STATIC
-
 #ifndef MIN_NICE
 #define MIN_NICE (-20)
 #endif

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -936,12 +936,12 @@ static void pxd_resume_io(struct pxd_device *pxd_dev)
 				printk_ratelimited(KERN_ERR"%s: pxd%llu: px is disconnected, failing IO.\n", __func__, pxd_dev->dev_id);
 				BIO_ENDIO(head->orig, -ENXIO);
 			} else if (pxd_dev->fp.fastpath) {
-				printk_ratelimited(KERN_ERR"%s: pxd%llu: resuming suspending IO in fastpath.\n", __func__, pxd_dev->dev_id);
+				printk_ratelimited(KERN_ERR"%s: pxd%llu: resuming IO in fastpath.\n", __func__, pxd_dev->dev_id);
 				freeme = false;
 				pxd_process_io(head);
 			} else {
 				// switch to native path
-				printk_ratelimited(KERN_ERR"%s: pxd%llu: resuming suspending IO in native path.\n", __func__, pxd_dev->dev_id);
+				printk_ratelimited(KERN_ERR"%s: pxd%llu: resuming IO in native path.\n", __func__, pxd_dev->dev_id);
 				atomic_inc(&pxd_dev->fp.nslowPath);
 				pxd_make_request_slowpath(pxd_dev->disk->queue, head->orig);
 			}

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -876,7 +876,7 @@ static void pxd_process_io(struct pxd_io_tracker *head)
 
 static void pxd_suspend_io(struct pxd_device *pxd_dev)
 {
-	int cpu, new, old;
+	int cpu, new = 0, old = 0;
 	int need_flush = 0;
 
 	for_each_online_cpu(cpu) {
@@ -917,7 +917,7 @@ static void pxd_resume_io(struct pxd_device *pxd_dev)
 {
 	LIST_HEAD(tmpQ);
 	bool wakeup;
-	int cpu, new, old;
+	int cpu, new = 0, old = 0;
 
 	for_each_online_cpu(cpu) {
 		struct pcpu_fpstate *statep = per_cpu_ptr(pxd_dev->fp.state, cpu);

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1337,8 +1337,6 @@ void pxd_fastpath_adjust_limits(struct pxd_device *pxd_dev, struct request_queue
 				blk_queue_stack_limits(topque, bque);
 			}
 		}
-
-		if (S_ISBLK(inode->i_mode)) bdput(bdev);
 	}
 	return;
 

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -682,13 +682,6 @@ static int __do_bio_filebacked(struct pxd_device *pxd_dev, struct pxd_io_tracker
 
 	BUG_ON(pxd_dev->magic != PXD_DEV_MAGIC);
 	BUG_ON(iot->magic != PXD_IOT_MAGIC);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
-	generic_start_io_acct(pxd_dev->disk->queue, bio_op(bio), REQUEST_GET_SECTORS(bio), &pxd_dev->disk->part0);
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3,19,0)
-	generic_start_io_acct(bio_data_dir(bio), REQUEST_GET_SECTORS(bio), &pxd_dev->disk->part0);
-#else
-	_generic_start_io_acct(pxd_dev->disk->queue, bio_data_dir(bio), REQUEST_GET_SECTORS(bio), &pxd_dev->disk->part0);
-#endif
 
 	pxd_printk("do_bio_filebacked for new bio (pending %u)\n", PXD_ACTIVE(pxd_dev));
 	pos = ((loff_t) bio->bi_iter.bi_sector << SECTOR_SHIFT);

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -41,6 +41,8 @@ struct pxd_io_tracker {
 	unsigned long start; // start time [HEAD]
 	struct bio *orig;    // original request bio [HEAD]
 
+	struct work_struct wi; // work item
+
 	// THIS SHOULD BE LAST ITEM
 	struct bio clone;    // cloned bio [ALL]
 };
@@ -71,15 +73,17 @@ struct pxd_fastpath_extension {
 	struct file *file[MAX_PXD_BACKING_DEVS];
 	char device_path[MAX_PXD_BACKING_DEVS][MAX_PXD_DEVPATH_LEN+1];
 
-	struct thread_context *tc;
+	struct thread_context *tc; // NOT NEEDED
 	unsigned int qdepth;
 	bool congested;
 	unsigned int nr_congestion_on;
 	unsigned int nr_congestion_off;
 
+	struct workqueue_struct *wq;
 	// if set, then newer IOs shall block, until reactivated.
 	int suspend;
 	wait_queue_head_t  suspend_wait;
+	struct list_head  suspend_queue;
 
 	wait_queue_head_t   sync_event;
 	atomic_t nsync_active; // [global] currently active?

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -40,6 +40,10 @@ struct pxd_io_tracker {
 	struct bio clone;    // cloned bio [ALL]
 };
 
+struct pcpu_fpstate {
+	int suspend;
+};
+
 struct pxd_fastpath_extension {
 	// Extended information
 	int bg_flush_enabled; // dynamically enable bg flush from driver
@@ -51,7 +55,6 @@ struct pxd_fastpath_extension {
 	struct file *file[MAX_PXD_BACKING_DEVS];
 	char device_path[MAX_PXD_BACKING_DEVS][MAX_PXD_DEVPATH_LEN+1];
 
-	struct thread_context *tc; // NOT NEEDED
 	unsigned int qdepth;
 	bool congested;
 	unsigned int nr_congestion_on;
@@ -59,8 +62,8 @@ struct pxd_fastpath_extension {
 
 	struct workqueue_struct *wq;
 	// if set, then newer IOs shall block, until reactivated.
-	int suspend;
-	wait_queue_head_t  suspend_wait;
+	struct pcpu_fpstate *state;
+	spinlock_t suspend_lock;
 	struct list_head  suspend_queue;
 
 	wait_queue_head_t   sync_event;

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -19,13 +19,6 @@
 struct pxd_device;
 struct pxd_context;
 
-// A one-time built, static lookup table to distribute requests to cpu within
-// same numa node
-struct node_cpu_map {
-	int cpu[NR_CPUS];
-	int ncpu;
-};
-
 // Added metadata for each bio
 struct pxd_io_tracker {
 #define PXD_IOT_MAGIC (0xbeefcafe)
@@ -45,21 +38,6 @@ struct pxd_io_tracker {
 
 	// THIS SHOULD BE LAST ITEM
 	struct bio clone;    // cloned bio [ALL]
-};
-
-struct pxd_device;
-struct thread_context {
-	spinlock_t  	    read_lock;
-	wait_queue_head_t   read_event;
-	struct list_head iot_readers;
-	struct task_struct *reader[PXD_MAX_THREAD_PER_CPU];
-
-	spinlock_t  	    write_lock;
-	wait_queue_head_t   write_event;
-	struct list_head iot_writers;
-	struct task_struct *writer[PXD_MAX_THREAD_PER_CPU];
-
-	atomic_t ncount;
 };
 
 struct pxd_fastpath_extension {

--- a/pxd_fastpath_stub.c
+++ b/pxd_fastpath_stub.c
@@ -24,8 +24,5 @@ int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_
 	return 0; // cannot fail
 }
 
-// return the io count processed by a thread
-int get_thread_count(int id) { return -1; }
-
 void pxd_fastpath_adjust_limits(struct pxd_device *pxd_dev, struct request_queue *topque) {}
 #endif


### PR DESCRIPTION
With the below changes addressed the high latency while in fastpath.
Results are tabulated here under optimized heading:
https://portworx.atlassian.net/wiki/spaces/PC/pages/899121235/Performance+study+on+fastpath+volumes
a) removed the queueing logic and if request if for block device requests can go through direct without any queueing.
b) for file based backing device, needs to be queued to avoid deadlocks.
c) optimize and remove all locks in the regular IO path.
d) use work queue instead for IO queueing and processing file IO.
