### PR TITLE
fix compile issue

### DIFF
--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -100,17 +100,4 @@
 			__SETUP_CONGESTION_HOOK(__ptr_or_null(&bdev), cfn, cdata))
 
 
-#define __COMPAT_CALL_LOOKUP_BDEV_0(fn, path) ({ struct block_device* (*f)(const char*) = fn; struct block_device *p = NULL; if (f) { p = f(path);}  p; })
-#define __COMPAT_CALL_LOOKUP_BDEV_1(fn, path) ({ struct block_device* (*f)(const char*, int) = fn; struct block_device *p = NULL; if (f) { p = f(path, 0);}  p; })
-
-#define __lookup_bdev_singlearg(fn) __builtin_types_compatible_p(typeof(fn), struct block_device* (*)(const char*))
-#define __lookup_bdev_twoarg(fn) __builtin_types_compatible_p(typeof(fn), struct block_device* (*)(const char*, int))
-#define __singlearg_method_or_null(fn) __builtin_choose_expr(__lookup_bdev_singlearg(fn), fn, NULL)
-#define __doublearg_method_or_null(fn) __builtin_choose_expr(__lookup_bdev_twoarg(fn), fn, NULL)
-#define COMPAT_CALL_LOOKUP_BDEV(path) \
-	__builtin_choose_expr(__lookup_bdev_singlearg(lookup_bdev), \
-			__COMPAT_CALL_LOOKUP_BDEV_0(__singlearg_method_or_null(lookup_bdev), path), \
-			__COMPAT_CALL_LOOKUP_BDEV_1(__doublearg_method_or_null(lookup_bdev), path))
-
-
 #endif //GDFS_PXD_COMPAT_H


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

1/ fix for blk_endio() signature change for 4.3+ kernel.
2/ fix for adjust queue depth which calls lookup_dev whose signature change across distribution by avoiding it.

**TestLogs**
a) compiles on 4.20
```
[lns@PDC1-SM1 px-fuse]$ uname -r
4.20.13-1.el7.elrepo.x86_64
[lns@PDC1-SM1 px-fuse]$ make
Kernel version 4.20 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.20.13-1.el7.elrepo.x86_64 need minimum 3.10
make -C /usr/src/kernels/4.20.13-1.el7.elrepo.x86_64  M=/home/lns/srcs/src/github.com/portworx/px-fuse modules
make[1]: Entering directory `/usr/src/kernels/4.20.13-1.el7.elrepo.x86_64'
Kernel version 4.20 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.20.13-1.el7.elrepo.x86_64 need minimum 3.10
  Building modules, stage 2.
Kernel version 4.20 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.20.13-1.el7.elrepo.x86_64 need minimum 3.10
  MODPOST 1 modules
make[1]: Leaving directory `/usr/src/kernels/4.20.13-1.el7.elrepo.x86_64'
[lns@PDC1-SM1 px-fuse]$ git branch
  ln/fixcompile
* ln/fixcomple
  ln/master
  ln/master-fpwip
  ln/optimize
  ln/perf-aio
  ln/pxfp_perf1
  ln/pxfp_perf2
  ln/pxfp_switch
  ln/queadjust
  ln/test
  master
[lns@PDC1-SM1 px-fuse]$ git log | head
commit d3815c55f7b0b4eb5391d93be9cf38f40f90a197
Author: Lakshmi Narasimhan Sundararajan <lns@portworx.com>
Date:   Sun May 10 17:27:21 2020 -0700

    fix compile issue

    Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

commit 266a4f734285950ea64db7c23b1134a5ede05ff8
Author: Lakshmi Narasimhan Sundararajan <sulakshm@users.noreply.github.com>
[lns@PDC1-SM1 px-fuse]$
```

b) compiles on 3.10
```
[lns@PDC1-SM1 px-fuse]$ uname -r
3.10.0-1062.18.1.el7.x86_64
[lns@PDC1-SM1 px-fuse]$ git branch
  ln/fixcompile
* ln/fixcomple
  ln/master
  ln/master-fpwip
  ln/optimize
  ln/perf-aio
  ln/pxfp_perf1
  ln/pxfp_perf2
  ln/pxfp_switch
  ln/queadjust
  ln/test
  master
[lns@PDC1-SM1 px-fuse]$ make clean
Kernel fast path enabled, current kernel version 3.10.0-1062.18.1.el7.x86_64 need minimum 3.10
make -C /usr/src/kernels/3.10.0-1062.18.1.el7.x86_64  M=/home/lns/srcs/src/github.com/portworx/px-fuse clean
make[1]: Entering directory `/usr/src/kernels/3.10.0-1062.18.1.el7.x86_64'
Kernel fast path enabled, current kernel version 3.10.0-1062.18.1.el7.x86_64 need minimum 3.10
  CLEAN   /home/lns/srcs/src/github.com/portworx/px-fuse/.tmp_versions
  CLEAN   /home/lns/srcs/src/github.com/portworx/px-fuse/Module.symvers
make[1]: Leaving directory `/usr/src/kernels/3.10.0-1062.18.1.el7.x86_64'
[lns@PDC1-SM1 px-fuse]$ make
Kernel fast path enabled, current kernel version 3.10.0-1062.18.1.el7.x86_64 need minimum 3.10
make -C /usr/src/kernels/3.10.0-1062.18.1.el7.x86_64  M=/home/lns/srcs/src/github.com/portworx/px-fuse modules
make[1]: Entering directory `/usr/src/kernels/3.10.0-1062.18.1.el7.x86_64'
Kernel fast path enabled, current kernel version 3.10.0-1062.18.1.el7.x86_64 need minimum 3.10
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/pxd.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/dev.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/iov_iter.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/px_version.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/io.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/pxd_fastpath.o
  LD [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/px.o
  Building modules, stage 2.
Kernel fast path enabled, current kernel version 3.10.0-1062.18.1.el7.x86_64 need minimum 3.10
  MODPOST 1 modules
  CC      /home/lns/srcs/src/github.com/portworx/px-fuse/px.mod.o
  LD [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/px.ko
make[1]: Leaving directory `/usr/src/kernels/3.10.0-1062.18.1.el7.x86_64'
[lns@PDC1-SM1 px-fuse]$ sudo su
[root@PDC1-SM1 px-fuse]# insmod ./px.ko
[root@PDC1-SM1 px-fuse]# rmmod px
[root@PDC1-SM1 px-fuse]#
```