### PR TITLE
iouring provide a in kernel io switch path based on ctx, unique id

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -26,6 +26,7 @@
 #include <linux/sort.h>
 #include <linux/vmalloc.h>
 #include "pxd_compat.h"
+#include "pxd_core.h"
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)
 #define PAGE_CACHE_GET(page) get_page(page)
@@ -496,6 +497,15 @@ static struct fuse_req *request_find(struct fuse_conn *fc, u64 unique)
 		return NULL;
 	}
 	return req;
+}
+
+struct fuse_req* request_find_in_ctx(unsigned ctx, u64 unique)
+{
+	struct pxd_context *pctx = find_context(ctx);
+
+	if (!pctx) return NULL;
+
+	return request_find(&pctx->fc, unique);
 }
 
 #define IOV_BUF_SIZE 64

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -295,5 +295,6 @@ void fuse_process_user_request(struct fuse_conn *fc, struct fuse_user_request *u
 
 void fuse_queue_init_cb(struct fuse_queue_cb *cb);
 
+struct fuse_req* request_find_in_ctx(unsigned ctx, u64 unique);
 #endif
 #endif /* _FS_FUSE_I_H */

--- a/io.c
+++ b/io.c
@@ -862,6 +862,7 @@ static int build_bvec(struct fuse_req *req, int *rw, struct bio_vec **iovec, str
 		*bvec = tmp;
 		bvec++;
 	}
+	bio = rq->bio;
 	offset = 0;
 	bvec = alloc_bvec;
 	*rw = bio_data_dir(bio);
@@ -891,7 +892,7 @@ static int io_import_bvec(struct io_ring_ctx *ctx, int *rw,
                 return -ENOENT;
         }
 
-	if (!req->using_blkque) {
+	if (!req->pxd_dev->using_blkque) {
                 printk(KERN_ERR "%s: request %lld not support this io path\n", __func__, kidx);
 		return -EPERM;
 	}

--- a/io.c
+++ b/io.c
@@ -1445,7 +1445,7 @@ static int __io_submit_sqe(struct io_ring_ctx *ctx, struct io_kiocb *req,
 	case IORING_OP_POLL_REMOVE:
 		ret = io_poll_remove(req, s->sqe);
 		break;
-	case IORING_OP_DATA_SWITCH:
+	case IORING_OP_RWBIO:
 		ret = io_switch(req, s, force_nonblock);
 		break;
 	case IORING_OP_DISCARD_FIXED:

--- a/io.c
+++ b/io.c
@@ -788,15 +788,15 @@ out_free:
 
 // return nr_bytes in iovec if successful
 //   < 0 for failure
-#if 0
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,0)
 static int build_bvec(struct fuse_req *req, int *rw, struct bio_vec **iovec, struct iov_iter *iter)
 {
 	struct request *rq = req->rq;
 	int nr_bvec;
-        struct bio_vec *bvec = NULL;
+	struct bio_vec *bvec = NULL;
 	struct bio_vec *alloc_bvec = NULL;
 	struct bio *bio;
-        struct req_iterator rq_iter;
+	struct req_iterator rq_iter;
 	struct bio_vec tmp;
 	unsigned int offset;
 
@@ -837,10 +837,10 @@ static int build_bvec(struct fuse_req *req, int *rw, struct bio_vec **iovec, str
 {
 	struct request *rq = req->rq;
 	int nr_bvec;
-        struct bio_vec *bvec = NULL;
+	struct bio_vec *bvec = NULL;
 	struct bio_vec *alloc_bvec = NULL;
 	struct bio *bio;
-        struct req_iterator rq_iter;
+	struct req_iterator rq_iter;
 	struct bio_vec tmp;
 	unsigned int offset;
 

--- a/io.c
+++ b/io.c
@@ -883,7 +883,7 @@ static int build_bvec2(struct fuse_req *req, int *rw, size_t off, size_t len,
 
 	if (nr_bvec > UIO_FASTIOV) {
 		alloc_bvec = bvec = kmalloc_array(nr_bvec, sizeof(struct bio_vec),
-											GFP_NOIO);
+			     GFP_NOIO);
 	} else {
 		alloc_bvec = bvec = *iovec;
 	}
@@ -899,8 +899,8 @@ static int build_bvec2(struct fuse_req *req, int *rw, size_t off, size_t len,
 #endif
 		if (!bv.bv_len) continue;
 		if (skip >= bv.bv_len) {
-				skip -= bv.bv_len;
-				continue;
+			skip -= bv.bv_len;
+			continue;
 		} else if (!map_end) {
 			size_t bvlen = bv.bv_len - skip;
 			map_end = true;
@@ -933,7 +933,7 @@ static int build_bvec2(struct fuse_req *req, int *rw, size_t off, size_t len,
 
 	iov_iter_bvec(iter, bio_data_dir(bio), bvec, nr_bvec, len);
 	iter->iov_offset = offset;
-	return BIO_SIZE(bio);
+	return len;
 }
 
 static int io_import_bvec(struct io_kiocb *req, int *rw,

--- a/pxd.c
+++ b/pxd.c
@@ -57,6 +57,15 @@ module_param(pxd_detect_zero_writes, uint, 0644);
 
 static int pxd_bus_add_dev(struct pxd_device *pxd_dev);
 
+struct pxd_context* find_context(unsigned ctx)
+{
+	if (ctx >= pxd_num_contexts) {
+		return NULL;
+	}
+
+	return &pxd_contexts[ctx];
+}
+
 static int pxd_open(struct block_device *bdev, fmode_t mode)
 {
 	struct pxd_device *pxd_dev = bdev->bd_disk->private_data;

--- a/pxd.c
+++ b/pxd.c
@@ -1004,8 +1004,6 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 	int err;
 	struct pxd_device *pxd_dev;
 
-	printk(KERN_INFO"pxd_remove for device %llu\n", remove->dev_id);
-
 	spin_lock(&ctx->lock);
 	list_for_each_entry(pxd_dev, &ctx->list, node) {
 		if (pxd_dev->dev_id == remove->dev_id) {

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -28,6 +28,8 @@ struct pxd_context {
 	uint64_t open_seq;
 };
 
+struct pxd_context* find_context(unsigned ctx);
+
 struct pxd_device {
 #define PXD_DEV_MAGIC (0xcafec0de)
 	unsigned int magic;

--- a/pxd_io_uring.h
+++ b/pxd_io_uring.h
@@ -63,7 +63,8 @@ struct io_uring_sqe {
 #define IORING_OP_COPY_DATA	10
 #define IORING_OP_DISCARD_FIXED 11
 #define IORING_OP_SYNCFS_FIXED  12
-#define IORING_OP_RWBIO  13
+#define IORING_OP_READ_BIO  13
+#define IORING_OP_WRITE_BIO 14
 
 /*
  * sqe->fsync_flags

--- a/pxd_io_uring.h
+++ b/pxd_io_uring.h
@@ -61,7 +61,7 @@ struct io_uring_sqe {
 #define IORING_OP_SYNC_FILE_RANGE	8
 #define IORING_OP_REQ_DONE	9
 #define IORING_OP_COPY_DATA	10
-
+#define IORING_OP_DATA_SWITCH  13
 /*
  * sqe->fsync_flags
  */

--- a/pxd_io_uring.h
+++ b/pxd_io_uring.h
@@ -21,7 +21,7 @@ struct io_uring_sqe {
 	__u16	ioprio;		/* ioprio for the request */
 	__s32	fd;		/* file descriptor to do IO on */
 	__u64	off;		/* offset into file */
-	__u64	addr;		/* pointer to buffer or iovecs */
+	__u64	addr;		/* pointer to buffer or iovecs or kernel_id */
 	__u32	len;		/* buffer size or number of iovecs */
 	union {
 		int		rw_flags;
@@ -31,7 +31,7 @@ struct io_uring_sqe {
 	};
 	__u64	user_data;	/* data to be passed back at completion time */
 	union {
-		__u16	buf_index;	/* index into fixed buffers, if used */
+		__u16	buf_index;	/* index into fixed buffers, if used or context id */
 		__u64	__pad2[3];
 	};
 };
@@ -63,7 +63,7 @@ struct io_uring_sqe {
 #define IORING_OP_COPY_DATA	10
 #define IORING_OP_DISCARD_FIXED 11
 #define IORING_OP_SYNCFS_FIXED  12
-#define IORING_OP_DATA_SWITCH  13
+#define IORING_OP_RWBIO  13
 
 /*
  * sqe->fsync_flags


### PR DESCRIPTION
goes with porx change:
https://github.com/portworx/porx/pull/6098

**test logs**

kernel: 
```
lns@xenial:~/srcs/src/github.com/portworx/porx/src/gdfs$ uname -r
4.20.17-042017-generic
lns@xenial:~/srcs/src/github.com/portworx/porx/src/gdfs$
```

***ut logs***
```
root@xenial:/home/lns/srcs/src/github.com/portworx/porx/src/gdfs# ./t --gtest_filter=KernelQueueTest.switch_io*
Note: Google Test filter = KernelQueueTest.switch_io*
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from KernelQueueTest
[ RUN      ] KernelQueueTest.switch_io
[       OK ] KernelQueueTest.switch_io (12121 ms)
[ RUN      ] KernelQueueTest.switch_io2
[       OK ] KernelQueueTest.switch_io2 (12135 ms)
[----------] 2 tests from KernelQueueTest (24256 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (24256 ms total)
[  PASSED  ] 2 tests.
root@xenial:/home/lns/srcs/src/github.com/portworx/porx/src/gdfs#
```

***dmesg logs***
```
CPU 1/8192, NUMA nodes 1/1024
pxd: blk-mq driver loaded version remotes/origin/ln/ioswitch:6639ca76cd9278e2ed5ef2984cd78c4a94b61f75, features 0x1
BTRFS: device fsid efe2b93e-f01e-4b04-9df7-a5a1261af723 devid 1 transid 5 /dev/loop0
BTRFS info (device loop0): disk space caching is enabled
BTRFS info (device loop0): has skinny extents
BTRFS info (device loop0): flagging fs with big metadata feature
BTRFS info (device loop0): creating UUID tree
pxd_vm_open off 0 start 140710722981888 end 140710743957504
pxd_vm_open off 0 start 140710722981888 end 140710743957504
io_uring_vm_close
read 0 write 0 sequence 1
read 0 write 0 sequence 1
pxd_control_open: pxd-control-0(1) open OK
Device 1 added ffff8ca037bf0000 with mode 0x0 fastpath 0 npath 0
pxd_remove for device 1
pxd_control_release: pxd-control-0(1) close OK
io_uring_vm_close
pxd: driver unloaded
CPU 1/8192, NUMA nodes 1/1024
pxd: blk-mq driver loaded version remotes/origin/ln/ioswitch:6639ca76cd9278e2ed5ef2984cd78c4a94b61f75, features 0x1
BTRFS: device fsid 1134284f-4191-47ec-82f5-0ae157a9d68d devid 1 transid 5 /dev/loop0
BTRFS info (device loop0): disk space caching is enabled
BTRFS info (device loop0): has skinny extents
BTRFS info (device loop0): flagging fs with big metadata feature
BTRFS info (device loop0): creating UUID tree
pxd_vm_open off 0 start 140710722981888 end 140710743957504
pxd_vm_open off 0 start 140710722981888 end 140710743957504
io_uring_vm_close
read 0 write 0 sequence 1
read 0 write 0 sequence 1
pxd_control_open: pxd-control-0(1) open OK
Device 1 added ffff8ca037bf0000 with mode 0x2 fastpath 1 npath 0
device 1 setting up fastpath target with mode 0x48002(LARW), paths 0
For pxd device 1 IO suspended
For pxd device 1 IO resumed
device 1 setup through nativepath (0)
pxd device 1: adjusting queue limits nfd 0
pxd_remove for device 1
pxd_control_release: pxd-control-0(1) close OK
io_uring_vm_close
pxd: driver unloaded
```

