### PR TITLE
Allow greater than 300sec timeout values

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -36,7 +36,8 @@
 #endif
 
 #define PXD_TIMER_SECS_MIN 30
-#define PXD_TIMER_SECS_MAX 600
+#define PXD_TIMER_SECS_DEFAULT 600
+#define PXD_TIMER_SECS_MAX (U32_MAX)
 
 #define TOSTRING_(x) #x
 #define VERTOSTR(x) TOSTRING_(x)
@@ -48,7 +49,7 @@ static DEFINE_IDA(pxd_minor_ida);
 struct pxd_context *pxd_contexts;
 uint32_t pxd_num_contexts = PXD_NUM_CONTEXTS;
 uint32_t pxd_num_contexts_exported = PXD_NUM_CONTEXT_EXPORTED;
-uint32_t pxd_timeout_secs = PXD_TIMER_SECS_MAX;
+uint32_t pxd_timeout_secs = PXD_TIMER_SECS_DEFAULT;
 uint32_t pxd_detect_zero_writes = 0;
 
 module_param(pxd_num_contexts_exported, uint, 0644);
@@ -1267,7 +1268,7 @@ static ssize_t pxd_minor_show(struct device *dev,
 static ssize_t pxd_timeout_show(struct device *dev,
 		     struct device_attribute *attr, char *buf)
 {
-	return sprintf(buf, "%d\n", pxd_timeout_secs);
+	return sprintf(buf, "%u\n", pxd_timeout_secs);
 }
 
 ssize_t pxd_timeout_store(struct device *dev, struct device_attribute *attr,
@@ -1280,18 +1281,20 @@ ssize_t pxd_timeout_store(struct device *dev, struct device_attribute *attr,
 	if (ctx == NULL)
 		return -ENXIO;
 
-	sscanf(buf, "%d", &new_timeout_secs);
+	sscanf(buf, "%u", &new_timeout_secs);
 	if (new_timeout_secs < PXD_TIMER_SECS_MIN ||
 			new_timeout_secs > PXD_TIMER_SECS_MAX) {
 		return -EINVAL;
 	}
 
-	if (!ctx->fc.connected)
+	if (!ctx->fc.connected) {
 		cancel_delayed_work_sync(&ctx->abort_work);
+	}
 	spin_lock(&ctx->lock);
 	pxd_timeout_secs = new_timeout_secs;
-	if (!ctx->fc.connected)
+	if (!ctx->fc.connected) {
 		schedule_delayed_work(&ctx->abort_work, pxd_timeout_secs * HZ);
+	}
 	spin_unlock(&ctx->lock);
 
 	return count;
@@ -1708,7 +1711,7 @@ static int pxd_control_open(struct inode *inode, struct file *file)
 
 	cancel_delayed_work_sync(&ctx->abort_work);
 	spin_lock(&ctx->lock);
-	pxd_timeout_secs = PXD_TIMER_SECS_MAX;
+	pxd_timeout_secs = PXD_TIMER_SECS_DEFAULT;
 	fc->connected = 1;
 	spin_unlock(&ctx->lock);
 
@@ -1735,10 +1738,12 @@ static int pxd_control_release(struct inode *inode, struct file *file)
 	}
 
 	spin_lock(&ctx->lock);
-	if (ctx->fc.connected == 0)
+	if (ctx->fc.connected == 0) {
 		pxd_printk("%s: not opened\n", __func__);
-	else
+	} else {
 		ctx->fc.connected = 0;
+	}
+
 	schedule_delayed_work(&ctx->abort_work, pxd_timeout_secs * HZ);
 	spin_unlock(&ctx->lock);
 
@@ -1766,7 +1771,7 @@ static void pxd_abort_context(struct work_struct *work)
 
 	BUG_ON(fc->connected);
 
-	printk(KERN_INFO "PXD_TIMEOUT (%s:%u): Aborting all requests...",
+	printk(KERN_ERR "PXD_TIMEOUT (%s:%u): Aborting all requests...",
 		ctx->name, ctx->id);
 
 	fc->allow_disconnected = 0;

--- a/pxd_fastpath_stub.c
+++ b/pxd_fastpath_stub.c
@@ -5,7 +5,6 @@
 #include "pxd_core.h"
 #include "pxd_fastpath.h"
 
-int pxd_device_congested(void *data, int cond) { return 0; }
 int fastpath_init(void) { return 0; }
 void fastpath_cleanup(void) {}
 
@@ -16,7 +15,7 @@ void pxd_fastpath_cleanup(struct pxd_device *pxd_dev) {}
 void pxdctx_set_connected(struct pxd_context *ctx, bool enable) {}
 
 void enableFastPath(struct pxd_device *pxd_dev, bool force) {}
-void disableFastPath(struct pxd_device *pxd_dev, bool) {}
+void disableFastPath(struct pxd_device *pxd_dev, bool force) {}
 int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path)
 {
 	// unsupported
@@ -27,8 +26,8 @@ int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_
 void pxd_fastpath_adjust_limits(struct pxd_device *pxd_dev, struct request_queue *topque) {}
 int pxd_suspend_state(struct pxd_device *pxd_dev) {return 0;}
 
-void pxd_suspend_io(struct pxd_device*) { }
-void pxd_resume_io(struct pxd_device*) { }
-int pxd_switch_fastpath(struct pxd_device*) {return -1;}
-int pxd_switch_nativepath(struct pxd_device*) {return -1;}
+void pxd_suspend_io(struct pxd_device* pxd_dev) { }
+void pxd_resume_io(struct pxd_device* pxd_dev) { }
+int pxd_switch_fastpath(struct pxd_device* pxd_dev) {return -1;}
+int pxd_switch_nativepath(struct pxd_device* pxd_dev) {return -1;}
 #endif


### PR DESCRIPTION
We need to be able to set the timeout to a higher value. This is required when a maintenance operation is undergoing on node which would keep it down for more than 10 minutes.