### PR TITLE
Ensure no failover if IO to local replica

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -874,8 +874,7 @@ struct pxd_device* find_pxd_device(struct pxd_context *ctx, uint64_t dev_id)
 	return pxd_dev;
 }
 
-static int __pxd_update_path(struct pxd_device *pxd_dev,
-		struct pxd_update_path_out *update_path);
+static int __pxd_update_path(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path);
 ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 {
 	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);

--- a/pxd.c
+++ b/pxd.c
@@ -873,7 +873,8 @@ struct pxd_device* find_pxd_device(struct pxd_context *ctx, uint64_t dev_id)
 	return pxd_dev;
 }
 
-static int __pxd_update_path(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path);
+static int __pxd_update_path(struct pxd_device *pxd_dev, bool can_failover,
+		struct pxd_update_path_out *update_path);
 ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 {
 	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
@@ -898,7 +899,7 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 		module_put(THIS_MODULE);
 
 		if (add->enable_fp && add->paths.count > 0) {
-			__pxd_update_path(pxd_dev, &add->paths);
+			__pxd_update_path(pxd_dev, add->can_failover, &add->paths);
 		} else {
 			disableFastPath(pxd_dev, false);
 		}
@@ -950,7 +951,7 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 		goto out_id;
 
 	if (add->enable_fp) {
-		err = pxd_init_fastpath_target(pxd_dev, &add->paths);
+		err = pxd_init_fastpath_target(pxd_dev, add->can_failover, &add->paths);
 		if (err) {
 			pxd_fastpath_cleanup(pxd_dev);
 			goto out_id;
@@ -1148,7 +1149,8 @@ copy_error:
 }
 
 
-static int __pxd_update_path(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path)
+static int __pxd_update_path(struct pxd_device *pxd_dev, bool can_failover,
+		struct pxd_update_path_out *update_path)
 {
 	if (pxd_dev->using_blkque) {
 		printk(KERN_WARNING"%llu: block device registered for native path - cannot update for fastpath\n", pxd_dev->dev_id);
@@ -1157,7 +1159,7 @@ static int __pxd_update_path(struct pxd_device *pxd_dev, struct pxd_update_path_
 		printk(KERN_ERR"%llu: device already in fast path - cannot update\n", pxd_dev->dev_id);
 		return -EINVAL;
 	}
-	return pxd_init_fastpath_target(pxd_dev, update_path);
+	return pxd_init_fastpath_target(pxd_dev, can_failover, update_path);
 }
 
 ssize_t pxd_update_path(struct fuse_conn *fc, struct pxd_update_path_out *update_path)
@@ -1181,7 +1183,7 @@ ssize_t pxd_update_path(struct fuse_conn *fc, struct pxd_update_path_out *update
 		return -ENOENT;
 	}
 
-	err = __pxd_update_path(pxd_dev, update_path);
+	err = __pxd_update_path(pxd_dev, pxd_dev->fp.can_failover, update_path);
 	spin_unlock(&pxd_dev->lock);
 	return err;
 }
@@ -1533,7 +1535,7 @@ static ssize_t pxd_fastpath_update(struct device *dev, struct device_attribute *
 	update_out.count = i;
 	update_out.dev_id = pxd_dev->dev_id;
 
-	__pxd_update_path(pxd_dev, &update_out);
+	__pxd_update_path(pxd_dev, false, &update_out);
 	kfree(tmp);
 
 	return count;

--- a/pxd.h
+++ b/pxd.h
@@ -108,6 +108,7 @@ struct pxd_init_out {
  */
 struct pxd_update_path_out {
 	uint64_t dev_id;
+	bool   can_failover; /***< switch IO to userspace on any error */
 	size_t count; // count of paths below.
 	char devpath[MAX_PXD_BACKING_DEVS][MAX_PXD_DEVPATH_LEN+1];
 };
@@ -132,7 +133,6 @@ struct pxd_add_ext_out {
 	int32_t discard_size;	/**< block device discard size in bytes */
 	mode_t  open_mode; /**< backing file open mode O_RDONLY|O_SYNC|O_DIRECT etc */
 	bool    enable_fp; /**< enable fast path */
-	bool    can_failover; /***< always allow fallback to userspace on any error */
 	struct pxd_update_path_out paths; /**< backing device paths */
 };
 

--- a/pxd.h
+++ b/pxd.h
@@ -131,8 +131,8 @@ struct pxd_add_ext_out {
 	int32_t queue_depth;	/**< use queue depth 0 to bypass queueing */
 	int32_t discard_size;	/**< block device discard size in bytes */
 	mode_t  open_mode; /**< backing file open mode O_RDONLY|O_SYNC|O_DIRECT etc */
-	int     enable_fp; /**< enable fast path */
-	bool strict; /***< unused, always allow fallback */
+	bool    enable_fp; /**< enable fast path */
+	bool    can_failover; /***< always allow fallback to userspace on any error */
 	struct pxd_update_path_out paths; /**< backing device paths */
 };
 

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1085,8 +1085,7 @@ void pxd_fastpath_cleanup(struct pxd_device *pxd_dev)
 	}
 }
 
-int pxd_init_fastpath_target(struct pxd_device *pxd_dev,
-		struct pxd_update_path_out *update_path)
+int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path)
 {
 	char modestr[32];
 	mode_t mode = 0;

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -526,7 +526,7 @@ static void pxd_complete_io(struct bio* bio, int error)
 	if (atomic_read(&head->fails)) {
 		status = -EIO; // mark failure
 	}
-	if (status) {
+	if (pxd_dev->fp.can_failover && status) {
 		dofree = false;
 		atomic_inc(&pxd_dev->fp.nerror);
 		pxd_failover_initiate(pxd_dev, head);
@@ -541,7 +541,7 @@ static void pxd_complete_io(struct bio* bio, int error)
 	if (atomic_read(&head->fails)) {
 		status = -EIO; // mark failure
 	}
-	if (status) {
+	if (pxd_dev->fp.can_failover && status) {
 		dofree = false;
 		atomic_inc(&pxd_dev->fp.nerror);
 		pxd_failover_initiate(pxd_dev, head);
@@ -556,7 +556,7 @@ static void pxd_complete_io(struct bio* bio, int error)
 	if (atomic_read(&head->fails)) {
 		status = -EIO; // mark failure
 	}
-	if (status) {
+	if (pxd_dev->fp.can_failover && status) {
 		dofree = false;
 		atomic_inc(&pxd_dev->fp.nerror);
 		pxd_failover_initiate(pxd_dev, head);
@@ -992,7 +992,6 @@ void disableFastPath(struct pxd_device *pxd_dev, bool skipsync)
 	}
 
 	pxd_suspend_io(pxd_dev);
-
 	if (PXD_ACTIVE(pxd_dev)) {
 		printk(KERN_WARNING"%s: pxd device %llu fastpath disabled with active IO (%d)\n",
 			__func__, pxd_dev->dev_id, PXD_ACTIVE(pxd_dev));
@@ -1011,6 +1010,7 @@ void disableFastPath(struct pxd_device *pxd_dev, bool skipsync)
 		}
 	}
 	pxd_dev->fp.fastpath = false;
+	pxd_dev->fp.can_failover = false;
 	pxd_dev->fp.active_failover = PXD_FP_FAILOVER_NONE;
 
 	pxd_resume_io(pxd_dev);
@@ -1085,7 +1085,8 @@ void pxd_fastpath_cleanup(struct pxd_device *pxd_dev)
 	}
 }
 
-int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path)
+int pxd_init_fastpath_target(struct pxd_device *pxd_dev, bool can_failover,
+		struct pxd_update_path_out *update_path)
 {
 	char modestr[32];
 	mode_t mode = 0;
@@ -1108,6 +1109,7 @@ int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_
 			pxd_dev->dev_id, pxd_dev->fp.device_path[i]);
 	}
 	pxd_dev->fp.nfd = update_path->count;
+	pxd_dev->fp.can_failover = can_failover;
 	enableFastPath(pxd_dev, true);
 	pxd_resume_io(pxd_dev);
 

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1085,7 +1085,7 @@ void pxd_fastpath_cleanup(struct pxd_device *pxd_dev)
 	}
 }
 
-int pxd_init_fastpath_target(struct pxd_device *pxd_dev, bool can_failover,
+int pxd_init_fastpath_target(struct pxd_device *pxd_dev,
 		struct pxd_update_path_out *update_path)
 {
 	char modestr[32];
@@ -1109,7 +1109,7 @@ int pxd_init_fastpath_target(struct pxd_device *pxd_dev, bool can_failover,
 			pxd_dev->dev_id, pxd_dev->fp.device_path[i]);
 	}
 	pxd_dev->fp.nfd = update_path->count;
-	pxd_dev->fp.can_failover = can_failover;
+	pxd_dev->fp.can_failover = update_path->can_failover;
 	enableFastPath(pxd_dev, true);
 	pxd_resume_io(pxd_dev);
 

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -60,6 +60,7 @@ struct pxd_fastpath_extension {
 	pxd_failover_state_t active_failover;
 	// debug
 	bool force_fail;
+	bool can_failover; // can device failover to userspace on any error
 
 	int bg_flush_enabled; // dynamically enable bg flush from driver
 	int n_flush_wrsegs; // num of PXD_LBS write segments to force flush
@@ -88,7 +89,7 @@ int fastpath_init(void);
 void fastpath_cleanup(void);
 
 struct pxd_update_path_out;
-int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path);
+int pxd_init_fastpath_target(struct pxd_device *pxd_dev, bool can_failover, struct pxd_update_path_out *update_path);
 
 // per device initialization for fastpath
 int pxd_fastpath_init(struct pxd_device *pxd_dev);

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -89,7 +89,7 @@ int fastpath_init(void);
 void fastpath_cleanup(void);
 
 struct pxd_update_path_out;
-int pxd_init_fastpath_target(struct pxd_device *pxd_dev, bool can_failover, struct pxd_update_path_out *update_path);
+int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path);
 
 // per device initialization for fastpath
 int pxd_fastpath_init(struct pxd_device *pxd_dev);

--- a/pxd_fastpath_stub.c
+++ b/pxd_fastpath_stub.c
@@ -17,7 +17,7 @@ void pxdctx_set_connected(struct pxd_context *ctx, bool enable) {}
 
 void enableFastPath(struct pxd_device *pxd_dev, bool force) {}
 void disableFastPath(struct pxd_device *pxd_dev, bool) {}
-int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path)
+int pxd_init_fastpath_target(struct pxd_device *pxd_dev, bool can_failover, struct pxd_update_path_out *update_path)
 {
 	// unsupported
 	printk(KERN_WARNING"px driver does not support fastpath - kernel version not supported\n");

--- a/pxd_fastpath_stub.c
+++ b/pxd_fastpath_stub.c
@@ -16,7 +16,7 @@ void pxdctx_set_connected(struct pxd_context *ctx, bool enable) {}
 
 void enableFastPath(struct pxd_device *pxd_dev, bool force) {}
 void disableFastPath(struct pxd_device *pxd_dev, bool force) {}
-int pxd_init_fastpath_target(struct pxd_device *pxd_dev, bool can_failover, struct pxd_update_path_out *update_path)
+int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path)
 {
 	// unsupported
 	printk(KERN_WARNING"px driver does not support fastpath - kernel version not supported\n");


### PR DESCRIPTION
As replica paths are attached during kernel device add, also specify if the replica is local.
If the device attached is local and is a single replica, then do not failover during IO errors.

With fastpath disabled:
https://jenkins.portworx.co/job/DEV/job/Porx-05/247

With fastpath enabled:
https://jenkins.portworx.co/job/DEV/job/Porx-03/286