### PR TITLE
fastpath suspend/resume from userspace

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -760,6 +760,32 @@ static int fuse_notify_get_features(struct fuse_conn *conn, unsigned int size,
 	return pxd_supported_features();
 }
 
+static int fuse_notify_suspend(struct fuse_conn *conn, unsigned int size,
+		struct iov_iter *iter) {
+	struct pxd_suspend req;
+	size_t len = sizeof(req);
+
+	if (copy_from_iter(&req, len, iter) != len) {
+		printk(KERN_ERR "%s: can't copy arg\n", __func__);
+		return -EFAULT;
+	}
+
+	return pxd_request_suspend(conn, &req);
+}
+
+static int fuse_notify_resume(struct fuse_conn *conn, unsigned int size,
+		struct iov_iter *iter) {
+	struct pxd_resume req;
+	size_t len = sizeof(req);
+
+	if (copy_from_iter(&req, len, iter) != len) {
+		printk(KERN_ERR "%s: can't copy arg\n", __func__);
+		return -EFAULT;
+	}
+
+	return pxd_request_resume(conn, &req);
+}
+
 static int fuse_notify(struct fuse_conn *fc, enum fuse_notify_code code,
 		       unsigned int size, struct iov_iter *iter)
 {
@@ -780,6 +806,10 @@ static int fuse_notify(struct fuse_conn *fc, enum fuse_notify_code code,
 		return fuse_notify_set_fastpath(fc, size, iter);
 	case PXD_GET_FEATURES:
 		return fuse_notify_get_features(fc, size, iter);
+	case PXD_SUSPEND:
+		return fuse_notify_suspend(fc, size, iter);
+	case PXD_RESUME:
+		return fuse_notify_resume(fc, size, iter);
 	default:
 		return -EINVAL;
 	}

--- a/dev.c
+++ b/dev.c
@@ -774,7 +774,7 @@ static int fuse_notify_suspend(struct fuse_conn *conn, unsigned int size,
 
 	pxd_dev = find_pxd_device(ctx, req.dev_id);
 	if (!pxd_dev) {
-		printk(KERN_ERR "device %llu not found", req.dev_id);
+		printk(KERN_ERR "device %llu not found\n", req.dev_id);
 		return -EINVAL;
 	}
 	return pxd_request_suspend(pxd_dev, req.skip_flush);
@@ -794,7 +794,7 @@ static int fuse_notify_resume(struct fuse_conn *conn, unsigned int size,
 
 	pxd_dev = find_pxd_device(ctx, req.dev_id);
 	if (!pxd_dev) {
-		printk(KERN_ERR "device %llu not found", req.dev_id);
+		printk(KERN_ERR "device %llu not found\n", req.dev_id);
 		return -EINVAL;
 	}
 

--- a/pxd.c
+++ b/pxd.c
@@ -1579,6 +1579,14 @@ static ssize_t pxd_debug_store(struct device *dev,
 		printk("dev:%llu - IO fast path switch\n", pxd_dev->dev_id);
 		pxd_switch_fastpath(pxd_dev);
 		break;
+	case 'S': /* app suspend */
+		printk("dev:%llu - requesting IO suspend\n", pxd_dev->dev_id);
+		pxd_request_suspend(pxd_dev, false);
+		break;
+	case 'R': /* app resume */
+		printk("dev:%llu - requesting IO resume\n", pxd_dev->dev_id);
+		pxd_request_resume(pxd_dev);
+		break;
 	default:
 		/* no action */
 		printk("dev:%llu - no action for %c\n", pxd_dev->dev_id, buf[0]);

--- a/pxd.c
+++ b/pxd.c
@@ -1124,6 +1124,7 @@ ssize_t pxd_read_init(struct fuse_conn *fc, struct iov_iter *iter)
 		id.dev_id = pxd_dev->dev_id;
 		id.local_minor = pxd_dev->minor;
 		id.fastpath = 0;
+		id.count = (uint8_t) atomic_read(&pxd_dev->fp.suspend);
 		if (pxd_dev->fp.fastpath) id.fastpath = 1;
 		id.blkmq_device = 0;
 		if (pxd_dev->using_blkque) id.blkmq_device = 1;

--- a/pxd.c
+++ b/pxd.c
@@ -1124,10 +1124,11 @@ ssize_t pxd_read_init(struct fuse_conn *fc, struct iov_iter *iter)
 		id.dev_id = pxd_dev->dev_id;
 		id.local_minor = pxd_dev->minor;
 		id.fastpath = 0;
-		id.count = (uint8_t) atomic_read(&pxd_dev->fp.suspend);
-		if (pxd_dev->fp.fastpath) id.fastpath = 1;
 		id.blkmq_device = 0;
+		id.suspend = 0;
+		if (pxd_dev->fp.fastpath) id.fastpath = 1;
 		if (pxd_dev->using_blkque) id.blkmq_device = 1;
+		if (pxd_dev->fp.app_suspend) id.suspend = 1;
 		if (copy_to_iter(&id, sizeof(id), iter) != sizeof(id)) {
 			printk(KERN_ERR "%s: copy dev id error copied %ld\n", __func__,
 				copied);
@@ -1547,8 +1548,9 @@ static ssize_t pxd_debug_show(struct device *dev,
 	int suspend;
 
 	suspend=pxd_suspend_state(pxd_dev);
-	return sprintf(buf, "nfd:%d,suspend:%d,fastpath:%d,mqdevice:%d\n",
-			pxd_dev->fp.nfd, suspend, pxd_dev->fp.fastpath, pxd_dev->using_blkque);
+	return sprintf(buf, "nfd:%d,suspend:%d,fastpath:%d,mqdevice:%d,app_suspend:%d\n",
+			pxd_dev->fp.nfd, suspend, pxd_dev->fp.fastpath, pxd_dev->using_blkque,
+			pxd_dev->fp.app_suspend);
 }
 
 static ssize_t pxd_debug_store(struct device *dev,

--- a/pxd.c
+++ b/pxd.c
@@ -435,12 +435,9 @@ static void pxd_write_request(struct fuse_req *req, uint32_t size, uint64_t off,
 		fuse_convert_zero_writes(req);
 }
 
-static int pxd_discard_request(struct fuse_req *req, uint32_t size, uint64_t off,
+static void pxd_discard_request(struct fuse_req *req, uint32_t size, uint64_t off,
 			uint32_t minor, uint32_t flags)
 {
-	struct request_queue *q = req->pxd_dev->disk->queue;
-	unsigned int max_discard_size;
-
 	req->in.opcode = PXD_DISCARD;
 	if (!req->pxd_dev->using_blkque) {
 		req->end = pxd_process_write_reply;
@@ -449,22 +446,6 @@ static int pxd_discard_request(struct fuse_req *req, uint32_t size, uint64_t off
 	}
 
 	pxd_req_misc(req, size, off, minor, flags);
-
-	/* when block device is registered in non blk mq mode, discard limits are not
-	 * honoured. Sanity check discard size is within limits.
-	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)
-	max_discard_size = blk_queue_get_max_sectors(q, REQ_OP_DISCARD) << SECTOR_SHIFT;
-#else
-	max_discard_size = blk_queue_get_max_sectors(q, REQ_DISCARD) << SECTOR_SHIFT;
-#endif
-	if (size > max_discard_size) {
-		printk(KERN_ERR"device %llu discard size %u received over limit %u\n",
-				req->pxd_dev->dev_id, size, max_discard_size);
-		return -EINVAL;
-	}
-
-	return 0;
 }
 
 static void pxd_write_same_request(struct fuse_req *req, uint32_t size, uint64_t off,
@@ -484,7 +465,6 @@ static void pxd_write_same_request(struct fuse_req *req, uint32_t size, uint64_t
 static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 			uint32_t minor, uint32_t op, uint32_t flags)
 {
-	int rc = 0;
 	trace_pxd_request(req->in.unique, size, off, minor, flags);
 
 	atomic_inc(&req->pxd_dev->ncount);
@@ -499,7 +479,7 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 		pxd_read_request(req, size, off, minor, flags);
 		break;
 	case REQ_OP_DISCARD:
-		rc = pxd_discard_request(req, size, off, minor, flags);
+		pxd_discard_request(req, size, off, minor, flags);
 		break;
 	case REQ_OP_FLUSH:
 		pxd_write_request(req, 0, 0, minor, REQ_FUA);
@@ -510,7 +490,7 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 		return -1;
 	}
 
-	return rc;
+	return 0;
 }
 
 #else
@@ -518,7 +498,6 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 	uint32_t minor, uint32_t flags)
 {
-	int rc = 0;
 	trace_pxd_request(req->in.unique, size, off, minor, flags);
 
 	atomic_inc(&req->pxd_dev->ncount);
@@ -537,7 +516,7 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 	case REQ_DISCARD:
 		/* FALLTHROUGH */
 	case REQ_WRITE | REQ_DISCARD:
-		rc = pxd_discard_request(req, size, off, minor, flags);
+		pxd_discard_request(req, size, off, minor, flags);
 		break;
 	default:
 		printk(KERN_ERR"[%llu] REQ_OP_UNKNOWN(%#x): size=%d, off=%lld, minor=%d, flags=%#x\n",
@@ -545,7 +524,7 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 		return -1;
 	}
 
-	return rc;
+	return 0;
 }
 #endif
 

--- a/pxd.h
+++ b/pxd.h
@@ -63,6 +63,8 @@ enum pxd_opcode {
 	PXD_SET_FASTPATH,   /**< enable/disable fastpath */
 	PXD_GET_FEATURES,   /**< get features */
 	PXD_COMPLETE,		/**< complete kernel operation */
+	PXD_SUSPEND,		/**< IO suspend */
+	PXD_RESUME,			/**< IO resume */
 	PXD_LAST,
 };
 
@@ -172,6 +174,21 @@ struct pxd_fastpath_out {
 	int enable;
 	int cleanup; // only meaningful while disabling
 };
+
+/**
+ * PXD_SUSPEND/PXD_RESUME request from user space
+ */
+struct pxd_suspend {
+	uint64_t dev_id;
+	bool skip_flush;
+};
+
+struct pxd_resume {
+	uint64_t dev_id;
+};
+
+struct pxd_context;
+struct pxd_device* find_pxd_device(struct pxd_context *ctx, uint64_t dev_id);
 
 /**
  * PXD_GET_FEATURES request from user space

--- a/pxd.h
+++ b/pxd.h
@@ -81,7 +81,8 @@ enum pxd_opcode {
 /** Device identification passed from kernel on initialization */
 struct pxd_dev_id {
 	uint32_t local_minor; 	/**< minor number assigned by kernel */
-	uint8_t pad[3];
+	uint8_t pad[2];
+	uint8_t count; // io suspend count
 	uint8_t fastpath:1, blkmq_device:1, unused:6;
 	uint64_t dev_id;	/**< global device id */
 	uint64_t size;		/**< device size known by kernel in bytes */

--- a/pxd.h
+++ b/pxd.h
@@ -81,9 +81,8 @@ enum pxd_opcode {
 /** Device identification passed from kernel on initialization */
 struct pxd_dev_id {
 	uint32_t local_minor; 	/**< minor number assigned by kernel */
-	uint8_t pad[2];
-	uint8_t count; // io suspend count
-	uint8_t fastpath:1, blkmq_device:1, unused:6;
+	uint8_t pad[3];
+	uint8_t fastpath:1, blkmq_device:1, suspend:1, unused:5;
 	uint64_t dev_id;	/**< global device id */
 	uint64_t size;		/**< device size known by kernel in bytes */
 };

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -894,7 +894,7 @@ int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush)
 		}
 	}
 
-	printk(KERN_NOTICE"device %llu suspended IO from userspace", pxd_dev->dev_id);
+	printk(KERN_NOTICE"device %llu suspended IO from userspace\n", pxd_dev->dev_id);
 	return 0;
 }
 
@@ -919,7 +919,7 @@ int pxd_request_resume(struct pxd_device *pxd_dev)
 
 	pxd_resume_io(pxd_dev);
 	pxd_dev->fp.app_suspend = false;
-	printk(KERN_NOTICE"device %llu resumed IO from userspace", pxd_dev->dev_id);
+	printk(KERN_NOTICE"device %llu resumed IO from userspace\n", pxd_dev->dev_id);
 	return 0;
 }
 

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -15,6 +15,7 @@
 
 struct pxd_device;
 struct pxd_context;
+struct fuse_conn;
 
 typedef enum pxd_failover_state {
         PXD_FP_FAILOVER_NONE = 0,
@@ -120,4 +121,8 @@ int pxd_switch_fastpath(struct pxd_device*);
 int pxd_switch_nativepath(struct pxd_device*);
 void pxd_suspend_io(struct pxd_device*);
 void pxd_resume_io(struct pxd_device*);
+
+// external request from userspace to control io path
+int pxd_request_suspend(struct fuse_conn *fc, struct pxd_suspend *req);
+int pxd_request_resume(struct fuse_conn *fc, struct pxd_resume *req);
 #endif /* _PXD_FASTPATH_H_ */

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -120,6 +120,6 @@ void pxd_suspend_io(struct pxd_device*);
 void pxd_resume_io(struct pxd_device*);
 
 // external request from userspace to control io path
-int pxd_request_suspend(struct fuse_conn *fc, struct pxd_suspend *req);
-int pxd_request_resume(struct fuse_conn *fc, struct pxd_resume *req);
+int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush);
+int pxd_request_resume(struct pxd_device *pxd_dev);
 #endif /* _PXD_FASTPATH_H_ */

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -43,11 +43,8 @@ struct pxd_io_tracker {
 	struct bio clone;    // cloned bio [ALL]
 };
 
-struct pcpu_fpstate {
-	int suspend;
-};
-
 struct pxd_fastpath_extension {
+	bool app_suspend; // userspace suspended IO
 	// Extended information
 	atomic_t suspend;
 	rwlock_t suspend_lock;

--- a/pxd_fastpath_stub.c
+++ b/pxd_fastpath_stub.c
@@ -31,4 +31,7 @@ void pxd_suspend_io(struct pxd_device*) { }
 void pxd_resume_io(struct pxd_device*) { }
 int pxd_switch_fastpath(struct pxd_device*) {return -1;}
 int pxd_switch_nativepath(struct pxd_device*) {return -1;}
+int pxd_request_suspend(struct fuse_conn *fc, struct pxd_suspend *req) { return 0; }
+int pxd_request_resume(struct fuse_conn *fc, struct pxd_resume *req) { return 0; }
+
 #endif

--- a/pxd_fastpath_stub.c
+++ b/pxd_fastpath_stub.c
@@ -31,7 +31,7 @@ void pxd_suspend_io(struct pxd_device*) { }
 void pxd_resume_io(struct pxd_device*) { }
 int pxd_switch_fastpath(struct pxd_device*) {return -1;}
 int pxd_switch_nativepath(struct pxd_device*) {return -1;}
-int pxd_request_suspend(struct fuse_conn *fc, struct pxd_suspend *req) { return 0; }
-int pxd_request_resume(struct fuse_conn *fc, struct pxd_resume *req) { return 0; }
+int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush) { return 0; }
+int pxd_request_resume(struct pxd_device *pxd_dev) { return 0; }
 
 #endif


### PR DESCRIPTION
Add new interface to allow suspend/resume IO of fastpath device from userspace.
porx userspace should release on restart if device found in suspend state and restart any state machine that require device to be IO suspended in fast path.

This goes with https://github.com/portworx/porx/pull/6306