### PR TITLE
fix race during restart with previous abort

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1706,11 +1706,12 @@ static int pxd_control_open(struct inode *inode, struct file *file)
 		return -EINVAL;
 	}
 
+	// abort work cannot be active while restarting requests
+	cancel_delayed_work_sync(&ctx->abort_work);
 	rc = fuse_restart_requests(fc);
 	if (rc != 0)
 		return rc;
 
-	cancel_delayed_work_sync(&ctx->abort_work);
 	spin_lock(&ctx->lock);
 	pxd_timeout_secs = PXD_TIMER_SECS_DEFAULT;
 	fc->connected = 1;


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

During UT runs some of the tests fail with a race condition between restarting requests during new connection and previous abort running in parallel.

Below is the kernel crash traceback.
```
[Fri Jul 24 10:27:26 2020] pxd_control_open: pxd-control-0(1) open OK
[Fri Jul 24 10:27:26 2020] Device 1 added ffff8e74ccf60000 with mode 0x2 fastpath 1 npath 0
[Fri Jul 24 10:27:26 2020] device 1 setting up fastpath target with mode 0x48002(LARW), paths 0
[Fri Jul 24 10:27:26 2020] For pxd device 1 IO suspended
[Fri Jul 24 10:27:26 2020] For pxd device 1 IO resumed
[Fri Jul 24 10:27:26 2020] device 1 setup through nativepath (0)
[Fri Jul 24 10:27:26 2020] pxd device 1: adjusting queue limits nfd 0
[Fri Jul 24 10:27:27 2020] pxd_control_release: pxd-control-0(1) close OK
[Fri Jul 24 10:27:58 2020] PXD_TIMEOUT (pxd/pxd-control-0:0): Aborting all requests...
[Fri Jul 24 10:27:58 2020] read 1 write 2 sequence 3
[Fri Jul 24 10:27:58 2020] fc->request_map 00000000da481829
[Fri Jul 24 10:27:58 2020] completion entry at 2
[Fri Jul 24 10:27:58 2020] set write to 2
[Fri Jul 24 10:27:58 2020] opcode 8193 unique 262145
[Fri Jul 24 10:27:58 2020] BUG: unable to handle kernel NULL pointer dereference at 0000000000000040
[Fri Jul 24 10:27:58 2020] PGD 0 P4D 0
[Fri Jul 24 10:27:58 2020] Oops: 0000 [#1] SMP NOPTI
[Fri Jul 24 10:27:58 2020] CPU: 1 PID: 2954 Comm: t Tainted: G        W  OE     4.20.17-042017-generic #201903190933
[Fri Jul 24 10:27:58 2020] Hardware name: innotek GmbH VirtualBox/VirtualBox, BIOS VirtualBox 12/01/2006
[Fri Jul 24 10:27:58 2020] RIP: 0010:fuse_restart_requests+0x2fa/0x310 [px]
[Fri Jul 24 10:27:58 2020] Code: e8 7e de b8 c3 49 8d 44 24 04 48 8b 53 28 44 8b 4d c4 48 c1 e0 05 48 03 43 20 45 89 cf 48 8b 40 08 25 ff ff 03 00 48 8b 04 c2 <4c> 8b 60 40 e9 65 fd ff ff 0f 1f 00 66 2e 0f 1f 84 00 00 00 00 00
[Fri Jul 24 10:27:58 2020] RSP: 0018:ffffb165c29dbb88 EFLAGS: 00010202
[Fri Jul 24 10:27:58 2020] RAX: 0000000000000000 RBX: ffff8e74db680020 RCX: 0000000000000006
[Fri Jul 24 10:27:58 2020] RDX: ffff8e74cb600000 RSI: 0000000000000082 RDI: ffff8e74dfd16440
[Fri Jul 24 10:27:58 2020] RBP: ffffb165c29dbbd0 R08: 0000000000000001 R09: 0000000000000002
[Fri Jul 24 10:27:58 2020] R10: 0000000000000004 R11: 0000000000000000 R12: 0000000000000001
[Fri Jul 24 10:27:58 2020] R13: 0000000000000001 R14: ffffb165c38e9000 R15: 0000000000000002
[Fri Jul 24 10:27:58 2020] FS:  00007fc9a0f8bd80(0000) GS:ffff8e74dfd00000(0000) knlGS:0000000000000000
[Fri Jul 24 10:27:58 2020] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[Fri Jul 24 10:27:58 2020] CR2: 0000000000000040 CR3: 00000001dd84a002 CR4: 00000000000606e0
[Fri Jul 24 10:27:58 2020] Call Trace:
[Fri Jul 24 10:27:58 2020]  pxd_control_open+0x65/0x130 [px]
[Fri Jul 24 10:27:58 2020]  misc_open+0x123/0x180
[Fri Jul 24 10:27:58 2020]  chrdev_open+0xd3/0x1b0
[Fri Jul 24 10:27:58 2020]  ? cdev_default_release+0x20/0x20
[Fri Jul 24 10:27:58 2020]  do_dentry_open+0x138/0x360
[Fri Jul 24 10:27:58 2020]  vfs_open+0x2d/0x30
[Fri Jul 24 10:27:58 2020]  path_openat+0x2d4/0x16d0
[Fri Jul 24 10:27:58 2020]  ? pty_write+0x7c/0xa0
[Fri Jul 24 10:27:58 2020]  do_filp_open+0x93/0x100
[Fri Jul 24 10:27:58 2020]  ? __alloc_fd+0xb2/0x140
[Fri Jul 24 10:27:58 2020]  do_sys_open+0x184/0x210
[Fri Jul 24 10:27:58 2020]  __x64_sys_openat+0x20/0x30
[Fri Jul 24 10:27:58 2020]  do_syscall_64+0x5a/0x110
[Fri Jul 24 10:27:58 2020]  entry_SYSCALL_64_after_hwframe+0x44/0xa9
[Fri Jul 24 10:27:58 2020] RIP: 0033:0x7fc99e7d8dae
[Fri Jul 24 10:27:58 2020] Code: 89 54 24 08 e8 73 f2 ff ff 8b 74 24 0c 48 8b 3c 24 41 89 c0 44 8b 54 24 08 b8 01 01 00 00 89 f2 48 89 fe bf 9c ff ff ff 0f 05 <48> 3d 00 f0 ff ff 77 30 44 89 c7 89 44 24 08 e8 9e f2 ff ff 8b 44
[Fri Jul 24 10:27:58 2020] RSP: 002b:00007ffed9a2e230 EFLAGS: 00000293 ORIG_RAX: 0000000000000101
[Fri Jul 24 10:27:58 2020] RAX: ffffffffffffffda RBX: 00007ffed9a2e2f8 RCX: 00007fc99e7d8dae
[Fri Jul 24 10:27:58 2020] RDX: 0000000000000802 RSI: 00005626994390d9 RDI: 00000000ffffff9c
[Fri Jul 24 10:27:58 2020] RBP: 00007ffed9a2e550 R08: 0000000000000000 R09: 0000000000000004
[Fri Jul 24 10:27:58 2020] R10: 0000000000000000 R11: 0000000000000293 R12: 00007ffed9a2e300
[Fri Jul 24 10:27:58 2020] R13: 00007ffed9a2e310 R14: 00007ffed9a2e2f0 R15: 00007ffed9a2e2e8
[Fri Jul 24 10:27:58 2020] Modules linked in: px(OE) xt_conntrack ipt_MASQUERADE nf_conntrack_netlink nfnetlink xfrm_user xfrm_algo xt_addrtype iptable_filter iptable_nat nf_nat_ipv4 nf_nat nf_conntrack nf_defrag_ipv6 nf_defrag_ipv4 bpfilter br_netfilter bridge stp llc overlay dm_cache_smq dm_cache dm_persistent_data dm_bio_prison dm_bufio intel_rapl_perf input_leds serio_raw joydev vboxguest mac_hid sch_fq_codel ib_iser rdma_cm iw_cm ib_cm ib_core iscsi_tcp libiscsi_tcp libiscsi scsi_transport_iscsi nfsd auth_rpcgss nfs_acl lockd grace sunrpc ip_tables x_tables autofs4 btrfs zstd_compress raid10 raid456 async_raid6_recov async_memcpy async_pq async_xor async_tx xor raid6_pq libcrc32c raid1 raid0 multipath linear hid_generic usbhid hid crct10dif_pclmul crc32_pclmul ghash_clmulni_intel vmwgfx ttm drm_kms_helper syscopyarea sysfillrect sysimgblt fb_sys_fops drm aesni_intel aes_x86_64 crypto_simd drm_panel_orientation_quirks cryptd glue_helper psmouse cfbfillrect cfbimgblt cfbcopyarea fb ahci fbdev libahci
[Fri Jul 24 10:27:58 2020]  i2c_piix4 video e1000 ide_pci_generic i2c_core piix ide_core pata_acpi [last unloaded: px]
[Fri Jul 24 10:27:58 2020] CR2: 0000000000000040
[Fri Jul 24 10:27:58 2020] ---[ end trace 0f34372e055e5532 ]---
[Fri Jul 24 10:27:58 2020] RIP: 0010:fuse_restart_requests+0x2fa/0x310 [px]
[Fri Jul 24 10:27:58 2020] Code: e8 7e de b8 c3 49 8d 44 24 04 48 8b 53 28 44 8b 4d c4 48 c1 e0 05 48 03 43 20 45 89 cf 48 8b 40 08 25 ff ff 03 00 48 8b 04 c2 <4c> 8b 60 40 e9 65 fd ff ff 0f 1f 00 66 2e 0f 1f 84 00 00 00 00 00
[Fri Jul 24 10:27:58 2020] RSP: 0018:ffffb165c29dbb88 EFLAGS: 00010202
[Fri Jul 24 10:27:58 2020] RAX: 0000000000000000 RBX: ffff8e74db680020 RCX: 0000000000000006
[Fri Jul 24 10:27:58 2020] RDX: ffff8e74cb600000 RSI: 0000000000000082 RDI: ffff8e74dfd16440
[Fri Jul 24 10:27:58 2020] RBP: ffffb165c29dbbd0 R08: 0000000000000001 R09: 0000000000000002
[Fri Jul 24 10:27:58 2020] R10: 0000000000000004 R11: 0000000000000000 R12: 0000000000000001
[Fri Jul 24 10:27:58 2020] R13: 0000000000000001 R14: ffffb165c38e9000 R15: 0000000000000002
[Fri Jul 24 10:27:58 2020] FS:  00007fc9a0f8bd80(0000) GS:ffff8e74dfd00000(0000) knlGS:0000000000000000
[Fri Jul 24 10:27:58 2020] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[Fri Jul 24 10:27:58 2020] CR2: 0000000000000040 CR3: 00000001dd84a002 CR4: 00000000000606e0
[Fri Jul 24 10:28:24 2020] watchdog: BUG: soft lockup - CPU#0 stuck for 23s! [kworker/0:1:13]
[Fri Jul 24 10:28:24 2020] Modules linked in: px(OE) xt_conntrack ipt_MASQUERADE nf_conntrack_netlink nfnetlink xfrm_user xfrm_algo xt_addrtype iptable_filter iptable_nat nf_nat_ipv4 nf_nat nf_conntrack nf_defrag_ipv6 nf_defrag_ipv4 bpfilter br_netfilter bridge stp llc overlay dm_cache_smq dm_cache dm_persistent_data dm_bio_prison dm_bufio intel_rapl_perf input_leds serio_raw joydev vboxguest mac_hid sch_fq_codel ib_iser rdma_cm iw_cm ib_cm ib_core iscsi_tcp libiscsi_tcp libiscsi scsi_transport_iscsi nfsd auth_rpcgss nfs_acl lockd grace sunrpc ip_tables x_tables autofs4 btrfs zstd_compress raid10 raid456 async_raid6_recov async_memcpy async_pq async_xor async_tx xor raid6_pq libcrc32c raid1 raid0 multipath linear hid_generic usbhid hid crct10dif_pclmul crc32_pclmul ghash_clmulni_intel vmwgfx ttm drm_kms_helper syscopyarea sysfillrect sysimgblt fb_sys_fops drm aesni_intel aes_x86_64 crypto_simd drm_panel_orientation_quirks cryptd glue_helper psmouse cfbfillrect cfbimgblt cfbcopyarea fb ahci fbdev libahci
[Fri Jul 24 10:28:24 2020]  i2c_piix4 video e1000 ide_pci_generic i2c_core piix ide_core pata_acpi [last unloaded: px]
[Fri Jul 24 10:28:24 2020] CPU: 0 PID: 13 Comm: kworker/0:1 Tainted: G      D W  OE     4.20.17-042017-generic #201903190933
[Fri Jul 24 10:28:24 2020] Hardware name: innotek GmbH VirtualBox/VirtualBox, BIOS VirtualBox 12/01/2006
[Fri Jul 24 10:28:24 2020] Workqueue: events pxd_abort_context [px]
[Fri Jul 24 10:28:24 2020] RIP: 0010:native_safe_halt+0x6/0x10
[Fri Jul 24 10:28:24 2020] Code: ff ff 7f 5d c3 65 48 8b 04 25 00 5c 01 00 f0 80 48 02 20 48 8b 00 a8 08 75 c3 eb 8b 90 90 90 90 90 90 90 90 55 48 89 e5 fb f4 <5d> c3 0f 1f 84 00 00 00 00 00 55 48 89 e5 f4 5d c3 90 90 90 90 90
[Fri Jul 24 10:28:24 2020] RSP: 0018:ffffb165c0cb7dc0 EFLAGS: 00000202 ORIG_RAX: ffffffffffffff13
[Fri Jul 24 10:28:24 2020] RAX: 0000000000000003 RBX: 0000000000000246 RCX: 0000000000000008
[Fri Jul 24 10:28:24 2020] RDX: 0000000000000000 RSI: 0000000000000003 RDI: ffffb165c38e9008
[Fri Jul 24 10:28:24 2020] RBP: ffffb165c0cb7dc0 R08: 0000000000000008 R09: 00000000000000cc
[Fri Jul 24 10:28:24 2020] R10: ffff8e74da7f0dc8 R11: 0000000000000001 R12: ffff8e74dfc23900
[Fri Jul 24 10:28:24 2020] R13: 0000000000000000 R14: 0000000000000001 R15: 0000000000000100
[Fri Jul 24 10:28:24 2020] FS:  0000000000000000(0000) GS:ffff8e74dfc00000(0000) knlGS:0000000000000000
[Fri Jul 24 10:28:24 2020] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[Fri Jul 24 10:28:24 2020] CR2: 00007f95de281230 CR3: 00000001dd84a005 CR4: 00000000000606f0
[Fri Jul 24 10:28:24 2020] Call Trace:
[Fri Jul 24 10:28:24 2020]  kvm_wait+0x52/0x60
[Fri Jul 24 10:28:24 2020]  __pv_queued_spin_lock_slowpath+0x274/0x2b0
[Fri Jul 24 10:28:24 2020]  _raw_spin_lock+0x1f/0x30
[Fri Jul 24 10:28:24 2020]  fuse_end_queued_requests+0x4d/0xa0 [px]
[Fri Jul 24 10:28:24 2020]  pxd_abort_context+0x57/0x80 [px]
[Fri Jul 24 10:28:24 2020]  process_one_work+0x20f/0x410
[Fri Jul 24 10:28:24 2020]  worker_thread+0x34/0x400
[Fri Jul 24 10:28:24 2020]  kthread+0x120/0x140
[Fri Jul 24 10:28:24 2020]  ? process_one_work+0x410/0x410
[Fri Jul 24 10:28:24 2020]  ? __kthread_parkme+0x70/0x70
[Fri Jul 24 10:28:24 2020]  ret_from_fork+0x35/0x40
[Fri Jul 24 10:28:52 2020] watchdog: BUG: soft lockup - CPU#0 stuck for 22s! [kworker/0:1:13]
[Fri Jul 24 10:28:52 2020] Modules linked in: px(OE) xt_conntrack ipt_MASQUERADE nf_conntrack_netlink nfnetlink xfrm_user xfrm_algo xt_addrtype iptable_filter iptable_nat nf_nat_ipv4 nf_nat nf_conntrack nf_defrag_ipv6 nf_defrag_ipv4 bpfilter br_netfilter bridge stp llc overlay dm_cache_smq dm_cache dm_persistent_data dm_bio_prison dm_bufio intel_rapl_perf input_leds serio_raw joydev vboxguest mac_hid sch_fq_codel ib_iser rdma_cm iw_cm ib_cm ib_core iscsi_tcp libiscsi_tcp libiscsi scsi_transport_iscsi nfsd auth_rpcgss nfs_acl lockd grace sunrpc ip_tables x_tables autofs4 btrfs zstd_compress raid10 raid456 async_raid6_recov async_memcpy async_pq async_xor async_tx xor raid6_pq libcrc32c raid1 raid0 multipath linear hid_generic usbhid hid crct10dif_pclmul crc32_pclmul ghash_clmulni_intel vmwgfx ttm drm_kms_helper syscopyarea sysfillrect sysimgblt fb_sys_fops drm aesni_intel aes_x86_64 crypto_simd drm_panel_orientation_quirks cryptd glue_helper psmouse cfbfillrect cfbimgblt cfbcopyarea fb ahci fbdev libahci
[Fri Jul 24 10:28:52 2020]  i2c_piix4 video e1000 ide_pci_generic i2c_core piix ide_core pata_acpi [last unloaded: px]
[Fri Jul 24 10:28:52 2020] CPU: 0 PID: 13 Comm: kworker/0:1 Tainted: G      D W  OEL    4.20.17-042017-generic #201903190933
[Fri Jul 24 10:28:52 2020] Hardware name: innotek GmbH VirtualBox/VirtualBox, BIOS VirtualBox 12/01/2006
[Fri Jul 24 10:28:52 2020] Workqueue: events pxd_abort_context [px]
[Fri Jul 24 10:28:52 2020] RIP: 0010:native_safe_halt+0x6/0x10
[Fri Jul 24 10:28:52 2020] Code: ff ff 7f 5d c3 65 48 8b 04 25 00 5c 01 00 f0 80 48 02 20 48 8b 00 a8 08 75 c3 eb 8b 90 90 90 90 90 90 90 90 55 48 89 e5 fb f4 <5d> c3 0f 1f 84 00 00 00 00 00 55 48 89 e5 f4 5d c3 90 90 90 90 90
[Fri Jul 24 10:28:52 2020] RSP: 0018:ffffb165c0cb7dc0 EFLAGS: 00000202 ORIG_RAX: ffffffffffffff13
[Fri Jul 24 10:28:52 2020] RAX: 0000000000000003 RBX: 0000000000000246 RCX: 0000000000000008
[Fri Jul 24 10:28:52 2020] RDX: 0000000000000000 RSI: 0000000000000003 RDI: ffffb165c38e9008
[Fri Jul 24 10:28:52 2020] RBP: ffffb165c0cb7dc0 R08: 0000000000000008 R09: 00000000000000cc
[Fri Jul 24 10:28:52 2020] R10: ffff8e74da7f0dc8 R11: 0000000000000001 R12: ffff8e74dfc23900
[Fri Jul 24 10:28:52 2020] R13: 0000000000000000 R14: 0000000000000001 R15: 0000000000000100
[Fri Jul 24 10:28:52 2020] FS:  0000000000000000(0000) GS:ffff8e74dfc00000(0000) knlGS:0000000000000000
[Fri Jul 24 10:28:52 2020] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[Fri Jul 24 10:28:52 2020] CR2: 00007f95de281230 CR3: 00000001dd84a005 CR4: 00000000000606f0
[Fri Jul 24 10:28:52 2020] Call Trace:
[Fri Jul 24 10:28:52 2020]  kvm_wait+0x52/0x60
[Fri Jul 24 10:28:52 2020]  __pv_queued_spin_lock_slowpath+0x274/0x2b0
[Fri Jul 24 10:28:52 2020]  _raw_spin_lock+0x1f/0x30
[Fri Jul 24 10:28:52 2020]  fuse_end_queued_requests+0x4d/0xa0 [px]
[Fri Jul 24 10:28:52 2020]  pxd_abort_context+0x57/0x80 [px]
[Fri Jul 24 10:28:52 2020]  process_one_work+0x20f/0x410
[Fri Jul 24 10:28:52 2020]  worker_thread+0x34/0x400
[Fri Jul 24 10:28:52 2020]  kthread+0x120/0x140
[Fri Jul 24 10:28:52 2020]  ? process_one_work+0x410/0x410
[Fri Jul 24 10:28:52 2020]  ? __kthread_parkme+0x70/0x70
[Fri Jul 24 10:28:52 2020]  ret_from_fork+0x35/0x40
```

