### PR TITLE
run flush in background with a timeout

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -777,7 +777,7 @@ static int fuse_notify_suspend(struct fuse_conn *conn, unsigned int size,
 		printk(KERN_ERR "device %llu not found\n", req.dev_id);
 		return -EINVAL;
 	}
-	return pxd_request_suspend(pxd_dev, req.skip_flush);
+	return pxd_request_suspend(pxd_dev, req.skip_flush, req.coe);
 }
 
 static int fuse_notify_resume(struct fuse_conn *conn, unsigned int size,

--- a/pxd.c
+++ b/pxd.c
@@ -1677,7 +1677,7 @@ static ssize_t pxd_debug_store(struct device *dev,
 		break;
 	case 'S': /* app suspend */
 		printk("dev:%llu - requesting IO suspend\n", pxd_dev->dev_id);
-		pxd_request_suspend(pxd_dev, false);
+		pxd_request_suspend(pxd_dev, false, true);
 		break;
 	case 'R': /* app resume */
 		printk("dev:%llu - requesting IO resume\n", pxd_dev->dev_id);

--- a/pxd.h
+++ b/pxd.h
@@ -44,7 +44,7 @@
 // use by fastpath for congestion control
 #define DEFAULT_CONGESTION_THRESHOLD MAX_CONGESTION_THRESHOLD
 
-#define MAX_PXD_BACKING_DEVS (3)  /**< maximum number of replica targets for each user vol */
+#define MAX_PXD_BACKING_DEVS (5)  /**< maximum number of replica targets for each user vol */
 #define MAX_PXD_DEVPATH_LEN (127) /**< device path length */
 
 /** fuse opcodes */

--- a/pxd.h
+++ b/pxd.h
@@ -181,6 +181,7 @@ struct pxd_fastpath_out {
 struct pxd_suspend {
 	uint64_t dev_id;
 	bool skip_flush;
+	bool coe; // continue to be in suspend state, even on error
 };
 
 struct pxd_resume {

--- a/pxd.h
+++ b/pxd.h
@@ -44,7 +44,7 @@
 // use by fastpath for congestion control
 #define DEFAULT_CONGESTION_THRESHOLD MAX_CONGESTION_THRESHOLD
 
-#define MAX_PXD_BACKING_DEVS (5)  /**< maximum number of replica targets for each user vol */
+#define MAX_PXD_BACKING_DEVS (3)  /**< maximum number of replica targets for each user vol */
 #define MAX_PXD_DEVPATH_LEN (127) /**< device path length */
 
 /** fuse opcodes */

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -869,16 +869,42 @@ static void pxd_process_io(struct pxd_io_tracker *head)
 	}
 }
 
+// background pxd syncer work function
+static void __pxd_syncer(struct work_struct *wi)
+{
+	struct pxd_device *pxd_dev = container_of(wi, struct pxd_device, fp.syncwi);
+	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
+	int nfd = fp->nfd;
+	int i;
+
+	pxd_dev->fp.sync_rc = 0;
+	for (i = 0; i < nfd; i++) {
+		if (fp->file[i] > 0) {
+			int rc = vfs_fsync(fp->file[i], 0);
+			if (unlikely(rc && rc != -EINVAL && rc != -EIO)) {
+				printk(KERN_ERR"device %llu fsync failed with %d\n", pxd_dev->dev_id, rc);
+				pxd_dev->fp.sync_rc = rc;
+				break;
+			}
+		}
+	}
+
+	complete(&pxd_dev->fp.sync_complete);
+}
+
 // external request to suspend IO on fastpath device
 int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush)
 {
 	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
-	int nfd = fp->nfd;
-	int i;
 	int rc;
 
 	if (pxd_dev->using_blkque || fp->app_suspend) {
 		return -EINVAL;
+	}
+
+	// check if previous sync instance is still active
+	if (!skip_flush && work_busy(&pxd_dev->fp.syncwi)) {
+		return -EBUSY;
 	}
 
 	fp->app_suspend = true;
@@ -886,16 +912,19 @@ int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush)
 
 	if (skip_flush) return 0;
 
-	rc = 0;
-	for (i = 0; i < nfd; i++) {
-		if (fp->file[i] > 0) {
-			rc = vfs_fsync(fp->file[i], 0);
-			if (unlikely(rc && rc != -EINVAL && rc != -EIO)) {
-				printk(KERN_ERR"device %llu fsync failed with %d\n", pxd_dev->dev_id, rc);
-				goto fail;
-			}
-		}
+	reinit_completion(&pxd_dev->fp.sync_complete);
+	queue_work(pxd_dev->fp.wq, &pxd_dev->fp.syncwi);
+#define SYNC_TIMEOUT (60000)
+	if (!wait_for_completion_timeout(&pxd_dev->fp.sync_complete,
+						msecs_to_jiffies(SYNC_TIMEOUT))) {
+		// suspend aborted as sync timedout
+		rc = -EBUSY;
+		goto fail;
 	}
+
+	rc = pxd_dev->fp.sync_rc;
+	// sync operation failed
+	if (rc) goto fail;
 
 	printk(KERN_NOTICE"device %llu suspended IO from userspace\n", pxd_dev->dev_id);
 	return 0;
@@ -1096,6 +1125,8 @@ int pxd_fastpath_init(struct pxd_device *pxd_dev)
 		printk(KERN_ERR"pxd_dev:%llu failed allocating workqueue\n", pxd_dev->dev_id);
 		return -ENOMEM;
 	}
+	init_completion(&fp->sync_complete);
+	INIT_WORK(&fp->syncwi, __pxd_syncer);
 
 	// failover init
 	spin_lock_init(&fp->fail_lock);

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -913,7 +913,7 @@ bool pxd_sync_work_pending(struct pxd_device *pxd_dev)
 }
 
 // external request to suspend IO on fastpath device
-int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush)
+int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush, bool coe)
 {
 	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
 	int i;
@@ -961,6 +961,11 @@ int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush)
 	printk(KERN_NOTICE"device %llu suspended IO from userspace\n", pxd_dev->dev_id);
 	return 0;
 fail:
+	if (coe) {
+		printk(KERN_NOTICE"device %llu sync failed %d, continuing with suspend\n",
+				pxd_dev->dev_id, rc);
+		return 0;
+	}
 	pxd_resume_io(pxd_dev);
 	fp->app_suspend = false;
 	return rc;

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -905,7 +905,7 @@ bool pxd_sync_work_pending(struct pxd_device *pxd_dev)
 		return true;
 	}
 
-	for (i=0; i<MAX_PXD_BACKING_DEVS; i++) {
+	for (i = 0; i < MAX_PXD_BACKING_DEVS; i++) {
 		busy |= work_busy(&pxd_dev->fp.syncwi[i].ws);
 	}
 
@@ -1164,7 +1164,7 @@ int pxd_fastpath_init(struct pxd_device *pxd_dev)
 	}
 	init_completion(&fp->sync_complete);
 	atomic_set(&fp->sync_done, 0);
-	for (i=0; i<MAX_PXD_BACKING_DEVS; i++) {
+	for (i = 0; i < MAX_PXD_BACKING_DEVS; i++) {
 		INIT_WORK(&fp->syncwi[i].ws, __pxd_syncer);
 		fp->syncwi[i].index = i;
 		fp->syncwi[i].pxd_dev = pxd_dev;

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -43,6 +43,13 @@ struct pxd_io_tracker {
 	struct bio clone;    // cloned bio [ALL]
 };
 
+struct pxd_sync_ws {
+	struct work_struct ws;
+	struct pxd_device *pxd_dev;
+	int index; // file index
+	int rc; // result
+};
+
 struct pxd_fastpath_extension {
 	bool app_suspend; // userspace suspended IO
 	// Extended information
@@ -52,9 +59,9 @@ struct pxd_fastpath_extension {
 	int nfd;
 	struct file *file[MAX_PXD_BACKING_DEVS];
 	struct workqueue_struct *wq;
-	struct work_struct syncwi;
+	struct pxd_sync_ws syncwi[MAX_PXD_BACKING_DEVS];
 	struct completion sync_complete;
-	int sync_rc;
+	atomic_t sync_done;
 
 	// failover work item
 	spinlock_t  fail_lock;

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -52,6 +52,9 @@ struct pxd_fastpath_extension {
 	int nfd;
 	struct file *file[MAX_PXD_BACKING_DEVS];
 	struct workqueue_struct *wq;
+	struct work_struct syncwi;
+	struct completion sync_complete;
+	int sync_rc;
 
 	// failover work item
 	spinlock_t  fail_lock;

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -131,6 +131,6 @@ void pxd_suspend_io(struct pxd_device*);
 void pxd_resume_io(struct pxd_device*);
 
 // external request from userspace to control io path
-int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush);
+int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush, bool coe);
 int pxd_request_resume(struct pxd_device *pxd_dev);
 #endif /* _PXD_FASTPATH_H_ */

--- a/pxd_fastpath_stub.c
+++ b/pxd_fastpath_stub.c
@@ -30,6 +30,6 @@ void pxd_suspend_io(struct pxd_device* pxd_dev) { }
 void pxd_resume_io(struct pxd_device* pxd_dev) { }
 int pxd_switch_fastpath(struct pxd_device* pxd_dev) {return -1;}
 int pxd_switch_nativepath(struct pxd_device* pxd_dev) {return -1;}
-int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush) { return 0; }
+int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush, bool coe) { return 0; }
 int pxd_request_resume(struct pxd_device *pxd_dev) { return 0; }
 #endif


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

When devices are suspended, replica paths are synced inline. 
This PR takes the sync to a background thread run from a work queue.
There is an associated timeout, (1min) currently, after which sync and suspend operation is aborted.