### PR TITLE
 Compile fixes for 5.8.x, 4.12.x & 4.13.x EL7 kernels.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -31,7 +31,7 @@ endif
 MINKVER=3.10
 FPATH_MINKVER=3.10
 BLKMQ_MINKVER=4.18
-KERNELVER=$(shell echo $(KVERSION) | /bin/sed 's/\([0-9].[0-9]\+\).*/\1/g')
+KERNELVER=$(shell echo $(CHK_KVER) | /bin/sed 's/\([0-9].[0-9]\+\).*/\1/g')
 
 majorfn=$(shell echo "$1" | /bin/sed 's/\(.*\)\.\(.*\)/\1/g')
 minorfn=$(shell echo "$1" | /bin/sed 's/\(.*\)\.\(.*\)/\2/g')
@@ -85,20 +85,20 @@ endif
 ifeq ($(call verlater,${kmajor},${fp_major}),0)
 PXDEFINES += -D__PX_FASTPATH__
 px-objs += pxd_fastpath.o
-$(info Kernel fast path enabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
+$(info Kernel fast path enabled, current kernel version $(CHK_KVER) need minimum $(FPATH_MINKVER))
 else
 ifeq ($(call versame,${kmajor},${fp_major}),0)
 ifeq ($(call versameorlater,${kminor},${fp_minor}),0)
 PXDEFINES += -D__PX_FASTPATH__
 px-objs += pxd_fastpath.o
-$(info Kernel fast path enabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
+$(info Kernel fast path enabled, current kernel version $(CHK_KVER) need minimum $(FPATH_MINKVER))
 else
 px-objs += pxd_fastpath_stub.o
-$(warning Kernel fast path disabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
+$(warning Kernel fast path disabled, current kernel version $(CHK_KVER) need minimum $(FPATH_MINKVER))
 endif
 else
 px-objs += pxd_fastpath_stub.o
-$(warning Kernel fast path disabled, current kernel version $(KVERSION) need minimum $(FPATH_MINKVER))
+$(warning Kernel fast path disabled, current kernel version $(CHK_KVER) need minimum $(FPATH_MINKVER))
 endif
 endif
 

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -49,7 +49,7 @@
 #define SUBMIT_BIO(bio)  submit_bio(BIO_OP(bio), bio)
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
 #define BIOSET_CREATE(sz, pad)   bioset_create(sz, pad, 0)
 #else
 #define BIOSET_CREATE(sz, pad)   bioset_create(sz, pad)


### PR DESCRIPTION
Kernel compilation issues for 5.8.x, 4.12.x & 4.13.x EL7 & EL8

tested builds with these ones: 

4.12.0-1.el7.elrepo.x86_64
4.13.3-1.el7.elrepo.x86_64
4.14.5-1.el7.elrepo.x86_64
4.17.0-1.el7.elrepo.x86_64
5.6.13-1.el7.elrepo.x86_64
5.6.14-1.el7.elrepo.x86_64
5.8.1-1.el7.elrepo.x86_64
5.8.2-1.el7.elrepo.x86_64