### PR TITLE
Fix compilation failure on 4.15.0-1077-gcp & 4.15.0-1092-azure.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -126,12 +126,16 @@ PXDEFINES += -D__PX_BLKMQ__
 endif
 endif
 
+ifdef FORCE_CONTAINER_CC
+FORCE_CC=CC=$(FORCE_CONTAINER_CC)
+endif
+
 ccflags-y := $(ADDCCFLAGS) -Wframe-larger-than=2048 -Werror -I$(src) $(KBUILD_CPPFLAGS) $(PXDEFINES)
 
 .PHONY: rpm
 
 all: px_version.c
-	make -C $(KERNELPATH) $(KERNELOTHEROPT) M=$(CURDIR) modules
+	make $(FORCE_CC) -C $(KERNELPATH) $(KERNELOTHEROPT) M=$(CURDIR) modules
 
 insert: all
 	insmod px.ko $(PXD_NUM_CONTEXT_EXPORTED)

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -105,7 +105,7 @@
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0) || \
     (LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0) && \
-     defined(QUEUE_FLAG_PREEMPT_ONLY))
+     defined(blk_queue_fua))
 #define QUEUE_FLAG_SET(flag,q) blk_queue_flag_set(flag, q);
 #else
 #define QUEUE_FLAG_SET(flag,q) queue_flag_set_unlocked(flag, q);


### PR DESCRIPTION
Travis builds uses the 4.15.0-1077-gcp kernel and we failed to build on that one.  Issue was also seen on autopilot automation run using 4.15.0-1092-azure.