### PR TITLE
remove support for bg sync

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -263,7 +263,8 @@ static bool __pxd_device_qfull(struct pxd_device *pxd_dev)
 	}
 
 	if (pxd_dev->congested) {
-		if (ncount < (3*pxd_dev->qdepth)/4) {
+		// If there is window, allow IO. avoiding hysteresis around congestion increases IO latency
+		if (ncount < pxd_dev->qdepth) {
 			spin_lock(&pxd_dev->lock);
 			if (pxd_dev->congested) {
 				pxd_dev->congested = false;
@@ -1533,33 +1534,6 @@ static ssize_t pxd_active_show(struct device *dev,
 	return ncount;
 }
 
-static ssize_t pxd_sync_show(struct device *dev,
-                     struct device_attribute *attr, char *buf)
-{
-	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
-	return sprintf(buf, "sync: %u/%u %s\n",
-			atomic_read(&pxd_dev->fp.nsync_active),
-			atomic_read(&pxd_dev->fp.nsync),
-			(pxd_dev->fp.bg_flush_enabled ? "(enabled)" : "(disabled)"));
-}
-
-static ssize_t pxd_sync_store(struct device *dev, struct device_attribute *attr,
-			   const char *buf, size_t count)
-{
-	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
-	int enable = 0;
-
-	sscanf(buf, "%d", &enable);
-
-	if (enable) {
-		pxd_dev->fp.bg_flush_enabled = 1;
-	} else {
-		pxd_dev->fp.bg_flush_enabled = 0;
-	}
-
-	return count;
-}
-
 static ssize_t pxd_mode_show(struct device *dev,
                      struct device_attribute *attr, char *buf)
 {
@@ -1568,30 +1542,6 @@ static ssize_t pxd_mode_show(struct device *dev,
 
 	decode_mode(pxd_dev->mode, modestr);
 	return sprintf(buf, "mode: %#x/%s\n", pxd_dev->mode, modestr);
-}
-
-static ssize_t pxd_wrsegment_show(struct device *dev,
-		struct device_attribute *attr, char *buf)
-{
-	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
-	return sprintf(buf, "write segment size(bytes): %d\n", pxd_dev->fp.n_flush_wrsegs * PXD_LBS);
-}
-
-static ssize_t pxd_wrsegment_store(struct device *dev, struct device_attribute *attr,
-		const char *buf, size_t count)
-{
-	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
-	int nbytes, nsegs;
-
-	sscanf(buf, "%d", &nbytes);
-
-	nsegs = nbytes/PXD_LBS; // num of write segments
-	if (nsegs < MAX_WRITESEGS_FOR_FLUSH) {
-		nsegs = MAX_WRITESEGS_FOR_FLUSH;
-	}
-
-	pxd_dev->fp.n_flush_wrsegs = nsegs;
-	return count;
 }
 
 static ssize_t pxd_congestion_show(struct device *dev,
@@ -1805,9 +1755,7 @@ static DEVICE_ATTR(major, S_IRUGO, pxd_major_show, NULL);
 static DEVICE_ATTR(minor, S_IRUGO, pxd_minor_show, NULL);
 static DEVICE_ATTR(timeout, S_IRUGO|S_IWUSR, pxd_timeout_show, pxd_timeout_store);
 static DEVICE_ATTR(active, S_IRUGO, pxd_active_show, NULL);
-static DEVICE_ATTR(sync, S_IRUGO|S_IWUSR, pxd_sync_show, pxd_sync_store);
 static DEVICE_ATTR(congested, S_IRUGO|S_IWUSR, pxd_congestion_show, pxd_congestion_set);
-static DEVICE_ATTR(writesegment, S_IRUGO|S_IWUSR, pxd_wrsegment_show, pxd_wrsegment_store);
 static DEVICE_ATTR(fastpath, S_IRUGO|S_IWUSR, pxd_fastpath_state, pxd_fastpath_update);
 static DEVICE_ATTR(mode, S_IRUGO, pxd_mode_show, NULL);
 static DEVICE_ATTR(debug, S_IRUGO|S_IWUSR, pxd_debug_show, pxd_debug_store);;
@@ -1818,9 +1766,7 @@ static struct attribute *pxd_attrs[] = {
 	&dev_attr_minor.attr,
 	&dev_attr_timeout.attr,
 	&dev_attr_active.attr,
-	&dev_attr_sync.attr,
 	&dev_attr_congested.attr,
-	&dev_attr_writesegment.attr,
 	&dev_attr_fastpath.attr,
 	&dev_attr_mode.attr,
 	&dev_attr_debug.attr,

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -49,7 +49,6 @@ struct pxd_device {
 	bool connected;
 	mode_t mode;
 	bool using_blkque; // this is persistent, how the block device registered with kernel
-	atomic_t switch_active; // whether fallback or failover is active
 
 #define PXD_ACTIVE(pxd_dev)  (atomic_read(&pxd_dev->ncount))
 	// congestion handling
@@ -85,7 +84,6 @@ void pxd_check_q_decongested(struct pxd_device *pxd_dev);
 #endif
 
 #define SEGMENT_SIZE (1024 * 1024)
-#define MAX_WRITESEGS_FOR_FLUSH ((4*SEGMENT_SIZE)/PXD_LBS)
 
 // slow path make request io entry point
 struct request_queue;

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -174,58 +174,7 @@ static int _pxd_flush(struct pxd_device *pxd_dev, struct file *file)
 		ret = -EIO;
 	}
 	atomic_inc(&pxd_dev->fp.nio_flush);
-	atomic_set(&pxd_dev->fp.nwrite_counter, 0);
 	return ret;
-}
-
-static int pxd_should_flush(struct pxd_device *pxd_dev, int *active)
-{
-	*active = atomic_read(&pxd_dev->fp.nsync_active);
-	if (pxd_dev->fp.bg_flush_enabled &&
-		(atomic_read(&pxd_dev->fp.nwrite_counter) > pxd_dev->fp.n_flush_wrsegs) &&
-		!*active) {
-		atomic_set(&pxd_dev->fp.nsync_active, 1);
-		return 1;
-	}
-	return 0;
-}
-
-static void pxd_issue_sync(struct pxd_device *pxd_dev, struct file *file)
-{
-	struct block_device *bdev = bdget_disk(pxd_dev->disk, 0);
-	int ret;
-
-	if (!bdev) return;
-
-	ret = vfs_fsync(file, 0);
-	if (unlikely(ret && ret != -EINVAL && ret != -EIO)) {
-		printk(KERN_WARNING"device %llu fsync failed with %d\n",
-				pxd_dev->dev_id, ret);
-	}
-
-	spin_lock(&pxd_dev->fp.sync_event.lock);
-	atomic_set(&pxd_dev->fp.nwrite_counter, 0);
-	atomic_set(&pxd_dev->fp.nsync_active, 0);
-	atomic_inc(&pxd_dev->fp.nsync);
-	spin_unlock(&pxd_dev->fp.sync_event.lock);
-
-	wake_up(&pxd_dev->fp.sync_event);
-}
-
-static void pxd_check_write_cache_flush(struct pxd_device *pxd_dev, struct file *file)
-{
-	int sync_wait, sync_now;
-
-	spin_lock(&pxd_dev->fp.sync_event.lock);
-	sync_now = pxd_should_flush(pxd_dev, &sync_wait);
-
-	if (sync_wait) {
-		wait_event_interruptible_locked(pxd_dev->fp.sync_event,
-				!atomic_read(&pxd_dev->fp.nsync_active));
-	}
-	spin_unlock(&pxd_dev->fp.sync_event.lock);
-
-	if (sync_now) pxd_issue_sync(pxd_dev, file);
 }
 
 static int _pxd_bio_discard(struct pxd_device *pxd_dev, struct file *file, struct bio *bio, loff_t pos)
@@ -326,7 +275,6 @@ static int pxd_send(struct pxd_device *pxd_dev, struct file *file, struct bio *b
 		}
 	}
 #endif
-	atomic_add(nsegs, &pxd_dev->fp.nwrite_counter);
 	atomic_inc(&pxd_dev->fp.nio_write);
 	return 0;
 }
@@ -729,9 +677,6 @@ static int __do_bio_filebacked(struct pxd_device *pxd_dev, struct pxd_io_tracker
 			if (ret < 0) goto out;
 		}
 
-		/* Before any newer writes happen, make sure previous write/sync complete */
-		pxd_check_write_cache_flush(pxd_dev, iot->file);
-
 		ret = pxd_send(pxd_dev, iot->file, bio, pos);
 		if (ret < 0) goto out;
 
@@ -807,7 +752,6 @@ static int __do_bio_filebacked(struct pxd_device *pxd_dev, struct pxd_io_tracker
 			goto out;
 		}
 		/* Before any newer writes happen, make sure previous write/sync complete */
-		pxd_check_write_cache_flush(pxd_dev, iot->file);
 		ret = pxd_send(pxd_dev, iot->file, bio, pos);
 
 		if (!ret) {
@@ -1218,22 +1162,8 @@ int pxd_fastpath_init(struct pxd_device *pxd_dev)
 	int i;
 	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
 
-	memset(fp, 0, sizeof(struct pxd_fastpath_extension));
 	// will take slow path, if additional info not provided.
-#if 0
-	// configure bg flush based on passed mode of operation
-	if (pxd_dev->mode & O_DIRECT) {
-		fp->bg_flush_enabled = false; // avoids high latency
-		printk("For pxd device %llu background flush disabled\n", pxd_dev->dev_id);
-	} else {
-		fp->bg_flush_enabled = true; // introduces high latency
-		printk("For pxd device %llu background flush enabled\n", pxd_dev->dev_id);
-	}
-#else
-	fp->bg_flush_enabled = false; // avoids high latency
-#endif
-
-	fp->n_flush_wrsegs = MAX_WRITESEGS_FOR_FLUSH;
+	memset(fp, 0, sizeof(struct pxd_fastpath_extension));
 
 	// device temporary IO suspend
 	rwlock_init(&fp->suspend_lock);
@@ -1260,10 +1190,6 @@ int pxd_fastpath_init(struct pxd_device *pxd_dev)
 	fp->force_fail = false; // debug to force faspath failover
 	INIT_LIST_HEAD(&fp->failQ);
 
-	init_waitqueue_head(&fp->sync_event);
-
-	atomic_set(&fp->nsync_active, 0);
-	atomic_set(&fp->nsync, 0);
 	atomic_set(&fp->nio_discard, 0);
 	atomic_set(&fp->nio_flush, 0);
 	atomic_set(&fp->nio_flush_nop, 0);
@@ -1272,13 +1198,8 @@ int pxd_fastpath_init(struct pxd_device *pxd_dev)
 	atomic_set(&fp->nio_write, 0);
 	atomic_set(&fp->nswitch,0);
 	atomic_set(&fp->nslowPath,0);
-	atomic_set(&fp->nwrite_counter,0);
 	atomic_set(&pxd_dev->fp.ncomplete, 0);
 	atomic_set(&pxd_dev->fp.nerror, 0);
-
-	for (i = 0; i < MAX_NUMNODES; i++) {
-		atomic_set(&fp->index[i], 0);
-	}
 
 	return 0;
 }

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -973,12 +973,13 @@ int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush, bool coe)
 {
 	int rc = 0;
 
-	if (atomic_cmpxchg(&pxd_dev->fp.app_suspend, 0, 1) != 0) {
+	if (atomic_read(&pxd_dev->fp.app_suspend) == 1) {
 		return -EBUSY;
 	}
+
 	rc = pxd_request_suspend_internal(pxd_dev, skip_flush, coe);
-	if (rc) {
-		atomic_set(&pxd_dev->fp.app_suspend, 0);
+	if (!rc) {
+		atomic_set(&pxd_dev->fp.app_suspend, 1);
 	}
 
 	return rc;

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -71,13 +71,7 @@ struct pxd_fastpath_extension {
 	bool can_failover; // can device failover to userspace on any error
 	struct list_head failQ; // protected by fail_lock
 
-	int bg_flush_enabled; // dynamically enable bg flush from driver
-	int n_flush_wrsegs; // num of PXD_LBS write segments to force flush
-
 	char device_path[MAX_PXD_BACKING_DEVS][MAX_PXD_DEVPATH_LEN+1];
-	wait_queue_head_t   sync_event;
-	atomic_t nsync_active; // [global] currently active?
-	atomic_t nsync; // [global] number of forced syncs completed
 	atomic_t nio_discard;
 	atomic_t nio_preflush;
 	atomic_t nio_flush;
@@ -89,8 +83,6 @@ struct pxd_fastpath_extension {
 	atomic_t nslowPath; // [global] total requests through slow path
 	atomic_t ncomplete; // [global] total completed requests
 	atomic_t nerror; // [global] total IO error
-	atomic_t nwrite_counter; // [global] completed writes, gets cleared on a threshold
-	atomic_t index[MAX_NUMNODES]; // [global] read path IO optimization - last cpu
 };
 
 // global initialization during module init for fastpath


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

Remove support for background sync. This code path is not needed anymore, has been disabled since long time.
The rootcause is block device registered for fastpath does not honour queue depth and gets enqueued very large IO, which keeps syncing in the background forever even after the original app is done. This has been handled now through suspending IO to device if pending IO is over a congestion threshold.