### PR TITLE
El8 compilation fixed for 4.18.0-193.el8.x86_64 kernels.

### DIFF
--- a/io.c
+++ b/io.c
@@ -1119,8 +1119,8 @@ static int io_syncfs(struct io_kiocb *req, const struct sqe_submit *s,
 		struct block_device *bdev = I_BDEV(inode);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,8,0)
 		ret = blkdev_issue_flush(bdev, GFP_KERNEL, NULL);
-#else	
-		ret = blkdev_issue_flush(bdev, GFP_KERNEL);	
+#else
+		ret = blkdev_issue_flush(bdev, GFP_KERNEL);
 #endif
 	}
 
@@ -1916,7 +1916,7 @@ static int io_sq_thread(void *data)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,8,0)
 				unuse_mm(cur_mm);
 #else
-				kthread_unuse_mm(cur_mm);				
+				kthread_unuse_mm(cur_mm);
 #endif
 				mmput(cur_mm);
 				cur_mm = NULL;
@@ -2685,7 +2685,7 @@ static void io_uring_vm_close(struct vm_area_struct *vma)
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,11,0)
 static int io_uring_vm_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
-#elif LINUX_VERSION_CODE < KERNEL_VERSION(5,1,0)
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(5,1,0) && !defined(__EL8__)
 static int io_uring_vm_fault(struct vm_fault *vmf)
 #else
 static vm_fault_t io_uring_vm_fault(struct vm_fault *vmf)

--- a/pxd.c
+++ b/pxd.c
@@ -1954,7 +1954,7 @@ static void pxd_vm_close(struct vm_area_struct *vma)
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,11,0)
 static int pxd_vm_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
-#elif LINUX_VERSION_CODE < KERNEL_VERSION(5,1,0)
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(5,1,0) && !defined(__EL8__)
 static int pxd_vm_fault(struct vm_fault *vmf)
 #else
 static vm_fault_t pxd_vm_fault(struct vm_fault *vmf)


### PR DESCRIPTION
Distro testing failed to find/build KO for 4.18.0-193.el8.x86_64.   Add define check for EL8 for  backport to 4.10.0-xxx