### PR TITLE
align struct to old release

### DIFF
--- a/pxd.h
+++ b/pxd.h
@@ -244,8 +244,8 @@ struct pxd_rdwr_in_v1 {
 	uint32_t dev_minor;		/**< minor device number */
 	uint32_t size;		/**< read/write/discard size in bytes */
 	uint32_t flags;		/**< bio flags */
-	uint32_t pad; 
 	uint64_t chksum;	/**< buffer checksum */
+	uint32_t pad; 
 	uint64_t offset;	/**< device offset in bytes */
 };
 


### PR DESCRIPTION
The below struct change though allows proper alignment results in breaking backward compatibility.
The below change puts the definition to earlier, more details on failing upgrade test and analysis in jira.

https://portworx.atlassian.net/browse/PWX-16058