### PR TITLE
px_fuse ioctl to abort ios

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -1079,6 +1079,15 @@ __acquires(fc->lock)
 	end_requests(fc, &fc->processing);
 }
 
+void fuse_abort_all_ios(struct fuse_conn *fc)
+{
+	printk(KERN_INFO "PXD_IOCTL : Aborting all requests...");
+	spin_lock(&fc->lock);
+	fc->allow_disconnected = 0;
+	end_queued_requests(fc);
+	spin_unlock(&fc->lock);
+}
+
 static void fuse_conn_free_allocs(struct fuse_conn *fc)
 {
 	if (fc->per_cpu_ids)

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -218,6 +218,8 @@ void fuse_conn_put(struct fuse_conn *fc);
 
 void fuse_restart_requests(struct fuse_conn *fc);
 
+void fuse_abort_all_ios(struct fuse_conn *fc);
+
 ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add);
 ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove);
 ssize_t pxd_update_size(struct fuse_conn *fc, struct pxd_update_size_out *update_size);

--- a/pxd.c
+++ b/pxd.c
@@ -99,6 +99,26 @@ static long pxd_ioctl_init(struct file *file, void __user *argp)
 	return pxd_read_init(&ctx->fc, &iter);
 }
 
+
+static long pxd_ioctl_abort_ios(struct file *file, void __user *argp)
+{
+	struct pxd_context *ctx = NULL;
+	struct pxd_abort_ios abort_ios_args;
+	long ret = 0;
+
+	if (copy_from_user(&abort_ios_args, argp, sizeof(abort_ios_args))) {
+		return -EFAULT;
+	}
+
+	ctx =  &pxd_contexts[abort_ios_args.context_id];
+	if (!ctx || ctx->id >= pxd_num_contexts_exported) {
+		return -EFAULT;
+	}
+
+	fuse_abort_all_ios(&ctx->fc);
+	return ret;
+}
+
 static long pxd_control_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 {
 	void __user *argp = (void __user *)arg;
@@ -142,6 +162,8 @@ static long pxd_control_ioctl(struct file *file, unsigned int cmd, unsigned long
 	case PXD_IOC_INIT:
 		status = pxd_ioctl_init(file, argp);
 		break;
+	case PXD_IOC_ABORT_IOS:
+		return pxd_ioctl_abort_ios(file, (void __user *)arg);
 	default:
 		break;
 	}

--- a/pxd.h
+++ b/pxd.h
@@ -28,6 +28,7 @@
 #define PXD_IOC_DUMP_FC_INFO	_IO(PXD_IOCTL_MAGIC, 1)		/* 0x505801 */
 #define PXD_IOC_GET_VERSION		_IO(PXD_IOCTL_MAGIC, 2)		/* 0x505802 */
 #define PXD_IOC_INIT		_IO(PXD_IOCTL_MAGIC, 3)		/* 0x505803 */
+#define PXD_IOC_ABORT_IOS		_IO(PXD_IOCTL_MAGIC, 4)		/* 0x505804 */
 
 #define PXD_MAX_DEVICES	512			/**< maximum number of devices supported */
 #define PXD_MAX_IO		(1024*1024)	/**< maximum io size in bytes */
@@ -143,6 +144,13 @@ struct pxd_read_data_out {
 	uint64_t unique;	/**< request id */
 	int32_t iovcnt;		/**< number of iovec entries */
 	uint32_t offset;	/**< offset into data */
+};
+
+/**
+ * PXD_ABORT_IOS ioctl from user space
+ */
+struct pxd_abort_ios {
+	int context_id;
 };
 
 /**


### PR DESCRIPTION
new ioctl to abort all iOS
Note: this should be used as a last resort to avoid node restart when px is stuck