### PR TITLE
fastpath failover 

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1750,6 +1750,14 @@ static ssize_t pxd_debug_store(struct device *dev,
 	return count;
 }
 
+static ssize_t pxd_inprogress_show(struct device *dev,
+                     struct device_attribute *attr, char *buf)
+{
+	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
+
+	return sprintf(buf, "%d", pxd_dev->ncount);
+}
+
 static DEVICE_ATTR(size, S_IRUGO, pxd_size_show, NULL);
 static DEVICE_ATTR(major, S_IRUGO, pxd_major_show, NULL);
 static DEVICE_ATTR(minor, S_IRUGO, pxd_minor_show, NULL);
@@ -1758,7 +1766,8 @@ static DEVICE_ATTR(active, S_IRUGO, pxd_active_show, NULL);
 static DEVICE_ATTR(congested, S_IRUGO|S_IWUSR, pxd_congestion_show, pxd_congestion_set);
 static DEVICE_ATTR(fastpath, S_IRUGO|S_IWUSR, pxd_fastpath_state, pxd_fastpath_update);
 static DEVICE_ATTR(mode, S_IRUGO, pxd_mode_show, NULL);
-static DEVICE_ATTR(debug, S_IRUGO|S_IWUSR, pxd_debug_show, pxd_debug_store);;
+static DEVICE_ATTR(debug, S_IRUGO|S_IWUSR, pxd_debug_show, pxd_debug_store);
+static DEVICE_ATTR(inprogress, S_IRUGO, pxd_inprogress_show, NULL);
 
 static struct attribute *pxd_attrs[] = {
 	&dev_attr_size.attr,
@@ -1770,6 +1779,7 @@ static struct attribute *pxd_attrs[] = {
 	&dev_attr_fastpath.attr,
 	&dev_attr_mode.attr,
 	&dev_attr_debug.attr,
+	&dev_attr_inprogress_attr,
 	NULL
 };
 

--- a/pxd.c
+++ b/pxd.c
@@ -432,6 +432,10 @@ int pxd_handle_device_limits(struct fuse_req *req, uint32_t *size, uint64_t *off
 	BUG_ON(rq_sectors != bio_sectors(req->bio));
 
 	max_sectors = blk_queue_get_max_sectors(q, op);
+	if (!max_sectors) {
+		return -EIO;
+	}
+
 	while (rq_sectors > max_sectors) {
 		struct bio *b;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0) || \

--- a/pxd.c
+++ b/pxd.c
@@ -1755,7 +1755,7 @@ static ssize_t pxd_inprogress_show(struct device *dev,
 {
 	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
 
-	return sprintf(buf, "%d", pxd_dev->ncount);
+	return sprintf(buf, "%d", atomic_read(&pxd_dev->ncount));
 }
 
 static DEVICE_ATTR(size, S_IRUGO, pxd_size_show, NULL);
@@ -1779,7 +1779,7 @@ static struct attribute *pxd_attrs[] = {
 	&dev_attr_fastpath.attr,
 	&dev_attr_mode.attr,
 	&dev_attr_debug.attr,
-	&dev_attr_inprogress_attr,
+	&dev_attr_inprogress.attr,
 	NULL
 };
 

--- a/pxd.c
+++ b/pxd.c
@@ -670,7 +670,7 @@ void pxd_process_ioswitch_complete(struct fuse_conn *fc, struct fuse_req *req,
 	atomic_set(&pxd_dev->fp.ioswitch_active, 0);
 
 	// reissue the pending IOs
-	__pxd_reissuefailQ(pxd_dev, &ios, status);
+	pxd_reissuefailQ(pxd_dev, &ios, status);
 }
 
 static

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -54,7 +54,7 @@ struct pxd_device {
 	// congestion handling
 	atomic_t ncount; // [global] total active requests, always modify with pxd_dev.lock
 	unsigned int qdepth;
-	bool congested;
+	atomic_t congested;
 	unsigned int nr_congestion_on;
 	unsigned int nr_congestion_off;
 

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -389,7 +389,6 @@ static void pxd_io_failover(struct work_struct *ws)
 	spin_unlock(&pxd_dev->fp.fail_lock);
 
 	if (cleanup) {
-		disableFastPath(pxd_dev, true);
 		rc = pxd_initiate_failover(pxd_dev);
 		// If userspace cannot be informed of a failover event, force abort all IO.
 		if (rc) {
@@ -399,6 +398,7 @@ static void pxd_io_failover(struct work_struct *ws)
 			pxd_dev->fp.active_failover = PXD_FP_FAILOVER_NONE;
 			spin_unlock(&pxd_dev->fp.fail_lock);
 		}
+		disableFastPath(pxd_dev, true);
 	} else if (reroute) {
 		printk_ratelimited(KERN_ERR"%s: pxd%llu: resuming IO in native path.\n", __func__, pxd_dev->dev_id);
 		atomic_inc(&pxd_dev->fp.nslowPath);

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1393,13 +1393,9 @@ void pxd_fastpath_adjust_limits(struct pxd_device *pxd_dev, struct request_queue
 					blk_queue_max_discard_sectors(topque, bdlimit);
 				}
 
-				// write zero
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
-				curlimit = blk_queue_get_max_sectors(topque, REQ_OP_WRITE_ZEROES);
-				bdlimit = blk_queue_get_max_sectors(bque, REQ_OP_WRITE_ZEROES);
-				if ((curlimit == 0) || (bdlimit < curlimit)) {
-					blk_queue_max_write_zeroes_sectors(topque, bdlimit);
-				}
+				// write zero
+				// do not support write zero!!
 
 				// write same
 				curlimit = blk_queue_get_max_sectors(topque, REQ_OP_WRITE_SAME);
@@ -1413,6 +1409,7 @@ void pxd_fastpath_adjust_limits(struct pxd_device *pxd_dev, struct request_queue
 	}
 
 	// ensure few block properties are still as expected.
+	blk_queue_max_write_zeroes_sectors(topque, 0);
 	blk_queue_logical_block_size(topque, PXD_LBS);
 	blk_queue_physical_block_size(topque, PXD_LBS);
 	return;

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1353,7 +1353,6 @@ void pxd_fastpath_adjust_limits(struct pxd_device *pxd_dev, struct request_queue
 	struct gendisk *disk;
 	struct request_queue *bque;
 	char name[BDEVNAME_SIZE];
-	unsigned int curlimit, bdlimit;
 
 	printk(KERN_INFO"pxd device %llu: adjusting queue limits nfd %d\n", pxd_dev->dev_id, pxd_dev->fp.nfd);
 
@@ -1380,30 +1379,6 @@ void pxd_fastpath_adjust_limits(struct pxd_device *pxd_dev, struct request_queue
 				printk(KERN_INFO"pxd device %llu queue limits adjusted with block dev %p(%s)\n",
 					pxd_dev->dev_id, bdev, bdevname(bdev, name));
 				blk_queue_stack_limits(topque, bque);
-
-				// discard
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
-				curlimit = blk_queue_get_max_sectors(topque, REQ_OP_DISCARD);
-				bdlimit = blk_queue_get_max_sectors(bque, REQ_OP_DISCARD);
-#else
-				curlimit = blk_queue_get_max_sectors(topque, REQ_DISCARD);
-				bdlimit = blk_queue_get_max_sectors(bque, REQ_DISCARD);
-#endif
-				if ((curlimit == 0) || (bdlimit < curlimit)) {
-					blk_queue_max_discard_sectors(topque, bdlimit);
-				}
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
-				// write zero
-				// do not support write zero!!
-
-				// write same
-				curlimit = blk_queue_get_max_sectors(topque, REQ_OP_WRITE_SAME);
-				bdlimit = blk_queue_get_max_sectors(bque, REQ_OP_WRITE_SAME);
-				if ((curlimit == 0) || (bdlimit < curlimit)) {
-					blk_queue_max_write_same_sectors(topque, bdlimit);
-				}
-#endif
 			}
 		}
 	}

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1429,7 +1429,8 @@ void __pxd_add2failQ(struct pxd_device *pxd_dev, struct pxd_io_tracker *iot)
 	list_add_tail(&iot->item, &pxd_dev->fp.failQ);
 }
 
-void __pxd_reissuefailQ(struct pxd_device *pxd_dev, struct list_head *ios, int status)
+// no locking needed, @ios is a local list of IO to be reissued.
+void pxd_reissuefailQ(struct pxd_device *pxd_dev, struct list_head *ios, int status)
 {
 	while (!list_empty(ios)) {
 		struct pxd_io_tracker *head = list_first_entry(ios, struct pxd_io_tracker, item);

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1409,7 +1409,9 @@ void pxd_fastpath_adjust_limits(struct pxd_device *pxd_dev, struct request_queue
 	}
 
 	// ensure few block properties are still as expected.
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
 	blk_queue_max_write_zeroes_sectors(topque, 0);
+#endif
 	blk_queue_logical_block_size(topque, PXD_LBS);
 	blk_queue_physical_block_size(topque, PXD_LBS);
 	return;

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1387,7 +1387,7 @@ void pxd_fastpath_adjust_limits(struct pxd_device *pxd_dev, struct request_queue
 				curlimit = blk_queue_get_max_sectors(topque, REQ_DISCARD);
 				bdlimit = blk_queue_get_max_sectors(bque, REQ_DISCARD);
 #endif
-				if (bdlimit < curlimit) {
+				if ((curlimit == 0) || (bdlimit < curlimit)) {
 					blk_queue_max_discard_sectors(topque, bdlimit);
 				}
 
@@ -1395,14 +1395,14 @@ void pxd_fastpath_adjust_limits(struct pxd_device *pxd_dev, struct request_queue
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
 				curlimit = blk_queue_get_max_sectors(topque, REQ_OP_WRITE_ZEROES);
 				bdlimit = blk_queue_get_max_sectors(bque, REQ_OP_WRITE_ZEROES);
-				if (bdlimit < curlimit) {
+				if ((curlimit == 0) || (bdlimit < curlimit)) {
 					blk_queue_max_write_zeroes_sectors(topque, bdlimit);
 				}
 
 				// write same
 				curlimit = blk_queue_get_max_sectors(topque, REQ_OP_WRITE_SAME);
 				bdlimit = blk_queue_get_max_sectors(bque, REQ_OP_WRITE_SAME);
-				if (bdlimit < curlimit) {
+				if ((curlimit == 0) || (bdlimit < curlimit)) {
 					blk_queue_max_write_same_sectors(topque, bdlimit);
 				}
 #endif

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -380,11 +380,12 @@ static void pxd_io_failover(struct work_struct *ws)
 	case PXD_FP_FAILOVER_NONE:
 		if (pxd_dev->fp.fastpath) {
 			pxd_dev->fp.active_failover = PXD_FP_FAILOVER_ACTIVE;
+			__pxd_add2failQ(pxd_dev, head);
 			cleanup = true;
 		} else {
 			reroute = true;
 		}
-		// fallthrough
+		break;
 	case PXD_FP_FAILOVER_ACTIVE:
 		__pxd_add2failQ(pxd_dev, head);
 	}
@@ -1446,7 +1447,6 @@ void __pxd_reissuefailQ(struct pxd_device *pxd_dev, struct list_head *ios, int s
 		__pxd_cleanup_block_io(head);
 	}
 }
-
 
 void __pxd_abortfailQ(struct pxd_device *pxd_dev)
 {

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -17,11 +17,6 @@ struct pxd_device;
 struct pxd_context;
 struct fuse_conn;
 
-typedef enum pxd_failover_state {
-        PXD_FP_FAILOVER_NONE = 0,
-        PXD_FP_FAILOVER_ACTIVE = 1,
-} pxd_failover_state_t;
-
 // Added metadata for each bio
 struct pxd_io_tracker {
 #define PXD_IOT_MAGIC (0xbeefcafe)
@@ -66,7 +61,7 @@ struct pxd_fastpath_extension {
 
 	// failover work item
 	spinlock_t  fail_lock;
-	pxd_failover_state_t active_failover;
+	bool active_failover; // is failover active
 	bool force_fail; // debug
 	bool can_failover; // can device failover to userspace on any error
 	struct list_head failQ; // protected by fail_lock

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -131,8 +131,8 @@ int pxd_request_resume_internal(struct pxd_device *pxd_dev);
 int pxd_request_ioswitch(struct pxd_device *pxd_dev, int code);
 
 // handle IO reroutes and switch events
+void pxd_reissuefailQ(struct pxd_device *pxd_dev, struct list_head *ios, int status);
 void pxd_abortfailQ(struct pxd_device *pxd_dev);
 void __pxd_abortfailQ(struct pxd_device *pxd_dev);
-void __pxd_reissuefailQ(struct pxd_device *pxd_dev, struct list_head *ios, int status);
 
 #endif /* _PXD_FASTPATH_H_ */

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -131,8 +131,8 @@ int pxd_request_resume_internal(struct pxd_device *pxd_dev);
 int pxd_request_ioswitch(struct pxd_device *pxd_dev, int code);
 
 // handle IO reroutes and switch events
-int __pxd_reissuefailQ(struct pxd_device *pxd_dev, int status);
 void pxd_abortfailQ(struct pxd_device *pxd_dev);
 void __pxd_abortfailQ(struct pxd_device *pxd_dev);
+void __pxd_reissuefailQ(struct pxd_device *pxd_dev, struct list_head *ios, int status);
 
 #endif /* _PXD_FASTPATH_H_ */

--- a/pxd_fastpath_stub.c
+++ b/pxd_fastpath_stub.c
@@ -36,7 +36,7 @@ int pxd_request_resume(struct pxd_device *pxd_dev) { return 0; }
 int pxd_request_resume_internal(struct pxd_device *pxd_dev) { return 0; }
 int pxd_request_ioswitch(struct pxd_device *pxd_dev, int code) { return -1; }
 
-void __pxd_reissuefailQ(struct pxd_device *pxd_dev, struct list_head *ios, int status){}
+void pxd_reissuefailQ(struct pxd_device *pxd_dev, struct list_head *ios, int status){}
 void pxd_abortfailQ(struct pxd_device *pxd_dev) { }
 void __pxd_abortfailQ(struct pxd_device *pxd_dev) { }
 #endif

--- a/pxd_fastpath_stub.c
+++ b/pxd_fastpath_stub.c
@@ -36,7 +36,7 @@ int pxd_request_resume(struct pxd_device *pxd_dev) { return 0; }
 int pxd_request_resume_internal(struct pxd_device *pxd_dev) { return 0; }
 int pxd_request_ioswitch(struct pxd_device *pxd_dev, int code) { return -1; }
 
-int __pxd_reissuefailQ(struct pxd_device *pxd_dev, int status) { return -1; }
+void __pxd_reissuefailQ(struct pxd_device *pxd_dev, struct list_head *ios, int status){}
 void pxd_abortfailQ(struct pxd_device *pxd_dev) { }
 void __pxd_abortfailQ(struct pxd_device *pxd_dev) { }
 #endif


### PR DESCRIPTION
The final set of changes to get fastpath failover stable. dmthin BVT has been running longer than before.

https://jenkins.portworx.dev/job/DEV/job/Porx-04/313/console

porx side changes will be separate on 
https://github.com/portworx/porx/pull/6505
once more tests pass.