### PR TITLE
Vjs px fuse ioctl abort ios v2.6.0

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -1093,7 +1093,7 @@ void fuse_abort_all_ios(struct fuse_conn *fc)
 	printk(KERN_INFO "PXD_IOCTL : Aborting all requests...");
 	spin_lock(&fc->lock);
 	fc->allow_disconnected = 0;
-	end_queued_requests(fc);
+	fuse_end_queued_requests(fc);
 	spin_unlock(&fc->lock);
 }
 

--- a/dev.c
+++ b/dev.c
@@ -1088,6 +1088,15 @@ __acquires(fc->lock)
 	end_requests(fc, &fc->processing);
 }
 
+void fuse_abort_all_ios(struct fuse_conn *fc)
+{
+	printk(KERN_INFO "PXD_IOCTL : Aborting all requests...");
+	spin_lock(&fc->lock);
+	fc->allow_disconnected = 0;
+	end_queued_requests(fc);
+	spin_unlock(&fc->lock);
+}
+
 static void fuse_conn_free_allocs(struct fuse_conn *fc)
 {
 	if (fc->per_cpu_ids)

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -228,6 +228,8 @@ struct fuse_conn *fuse_conn_get(struct fuse_conn *fc);
 
 void fuse_restart_requests(struct fuse_conn *fc);
 
+void fuse_abort_all_ios(struct fuse_conn *fc);
+
 ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add);
 ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove);
 ssize_t pxd_update_size(struct fuse_conn *fc, struct pxd_update_size *update_size);

--- a/pxd.c
+++ b/pxd.c
@@ -123,6 +123,25 @@ static long pxd_ioctl_resize(struct file *file, void __user *argp)
 	return ret;
 }
 
+static long pxd_ioctl_abort_ios(struct file *file, void __user *argp)
+{
+	struct pxd_context *ctx = NULL;
+	struct pxd_abort_ios abort_ios_args;
+	long ret = 0;
+
+	if (copy_from_user(&abort_ios_args, argp, sizeof(abort_ios_args))) {
+		return -EFAULT;
+	}
+
+	ctx =  &pxd_contexts[abort_ios_args.context_id];
+	if (!ctx || ctx->id >= pxd_num_contexts_exported) {
+		return -EFAULT;
+	}
+
+	fuse_abort_all_ios(&ctx->fc);
+	return ret;
+}
+
 static long pxd_control_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 {
 	void __user *argp = (void __user *)arg;
@@ -168,6 +187,8 @@ static long pxd_control_ioctl(struct file *file, unsigned int cmd, unsigned long
 		break;
 	case PXD_IOC_RESIZE:
 		return pxd_ioctl_resize(file, (void __user *)arg);
+	case PXD_IOC_ABORT_IOS:
+		return pxd_ioctl_abort_ios(file, (void __user *)arg);
 	default:
 		break;
 	}

--- a/pxd.h
+++ b/pxd.h
@@ -29,7 +29,7 @@
 #define PXD_IOC_GET_VERSION		_IO(PXD_IOCTL_MAGIC, 2)		/* 0x505802 */
 #define PXD_IOC_INIT		_IO(PXD_IOCTL_MAGIC, 3)		/* 0x505803 */
 #define PXD_IOC_RESIZE			_IO(PXD_IOCTL_MAGIC, 4)		/* 0x505804 */
-#define PXD_IOC_ABORT_IOS		_IO(PXD_IOCTL_MAGIC, 4)		/* 0x505804 */
+#define PXD_IOC_ABORT_IOS		_IO(PXD_IOCTL_MAGIC, 9)		/* 0x505809 */
 
 #define PXD_MAX_DEVICES	512			/**< maximum number of devices supported */
 #define PXD_MAX_IO		(1024*1024)	/**< maximum io size in bytes */

--- a/pxd.h
+++ b/pxd.h
@@ -29,6 +29,7 @@
 #define PXD_IOC_GET_VERSION		_IO(PXD_IOCTL_MAGIC, 2)		/* 0x505802 */
 #define PXD_IOC_INIT		_IO(PXD_IOCTL_MAGIC, 3)		/* 0x505803 */
 #define PXD_IOC_RESIZE			_IO(PXD_IOCTL_MAGIC, 4)		/* 0x505804 */
+#define PXD_IOC_ABORT_IOS		_IO(PXD_IOCTL_MAGIC, 4)		/* 0x505804 */
 
 #define PXD_MAX_DEVICES	512			/**< maximum number of devices supported */
 #define PXD_MAX_IO		(1024*1024)	/**< maximum io size in bytes */
@@ -152,6 +153,13 @@ struct pxd_read_data_out {
 struct pxd_update_size {
 	uint64_t dev_id;
 	size_t size;
+	int context_id;
+};
+
+/*
+ * PXD_ABORT_IOS ioctl from user space
+ */
+struct pxd_abort_ios {
 	int context_id;
 };
 


### PR DESCRIPTION
This change adds a new IOCTL to abort all IOs in a specific pxd_context