### PR TITLE
fastpath fail scenario cleanup

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -666,14 +666,14 @@ void pxd_process_ioswitch_complete(struct fuse_conn *fc, struct fuse_req *req,
 		spin_unlock(&pxd_dev->fp.fail_lock);
 	}
 
+	// reopen the suspended device
+	pxd_request_resume_internal(pxd_dev);
+
 	BUG_ON(atomic_read(&pxd_dev->fp.ioswitch_active) == 0);
 	atomic_set(&pxd_dev->fp.ioswitch_active, 0);
 
 	// reissue any failed IOs from local list
 	pxd_reissuefailQ(pxd_dev, &ios, status);
-
-	// reopen the suspended device
-	pxd_request_resume_internal(pxd_dev);
 }
 
 static

--- a/pxd.c
+++ b/pxd.c
@@ -1730,7 +1730,7 @@ static ssize_t pxd_debug_store(struct device *dev,
 		break;
 	case 'x': /* switch fastpath*/
 		printk("dev:%llu - IO fast path switch\n", pxd_dev->dev_id);
-		pxd_switch_fastpath(pxd_dev);
+		pxd_debug_switch_fastpath(pxd_dev);
 		break;
 	case 'S': /* app suspend */
 		printk("dev:%llu - requesting IO suspend\n", pxd_dev->dev_id);

--- a/pxd.c
+++ b/pxd.c
@@ -1718,7 +1718,7 @@ static ssize_t pxd_debug_store(struct device *dev,
 		break;
 	case 'X': /* switch native path */
 		printk("dev:%llu - IO native path switch - ctrl failover\n", pxd_dev->dev_id);
-		pxd_switch_nativepath(pxd_dev);
+		pxd_debug_switch_nativepath(pxd_dev);
 		break;
 	case 's': /* suspend */
 		printk("dev:%llu - IO suspend\n", pxd_dev->dev_id);

--- a/pxd.h
+++ b/pxd.h
@@ -34,6 +34,7 @@
 #define PXD_IOC_REGISTER_FILE	_IO(PXD_IOCTL_MAGIC, 6)		/* 0x505806 */
 #define PXD_IOC_UNREGISTER_FILE	_IO(PXD_IOCTL_MAGIC, 7)		/* 0x505807 */
 #define PXD_IOC_RESIZE			_IO(PXD_IOCTL_MAGIC, 8)		/* 0x505808 */
+#define PXD_IOC_FPCLEANUP		_IO(PXD_IOCTL_MAGIC, 9)		/* 0x505809 */
 
 #define PXD_MAX_DEVICES	512			/**< maximum number of devices supported */
 #define PXD_MAX_IO		(1024*1024)	/**< maximum io size in bytes */
@@ -177,6 +178,7 @@ struct pxd_fastpath_out {
 	uint64_t dev_id;
 	int enable;
 	int cleanup; // only meaningful while disabling
+	int context_id;
 };
 
 /**

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -111,5 +111,20 @@
 #define QUEUE_FLAG_SET(flag,q) queue_flag_set_unlocked(flag, q);
 #endif
 
+static inline unsigned int get_op_flags(struct bio *bio)
+{
+	unsigned int op_flags;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,8,0)
+	op_flags = 0; // Not present in older kernels
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(4,9,0)
+	op_flags = (bio->bi_opf & ((1 << BIO_OP_SHIFT) - 1));
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
+	op_flags = bio_flags(bio);
+#else
+	op_flags = ((bio->bi_opf & ~REQ_OP_MASK) >> REQ_OP_BITS);
+#endif
+	return op_flags;
+}
+
 
 #endif //GDFS_PXD_COMPAT_H

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -433,12 +433,12 @@ static int remap_io_status(int status)
 // @return - update reconciled error code
 static int reconcile_io_status(struct pxd_io_tracker *head)
 {
+	struct pxd_io_tracker *repl;
 	int status = 0;
 	int tmp;
 
 	BUG_ON(head->magic != PXD_IOT_MAGIC);
-	while (!list_empty(&head->replicas)) {
-		struct pxd_io_tracker *repl = list_first_entry(&head->replicas, struct pxd_io_tracker, item);
+	list_for_each_entry(repl, &head->replicas, item) {
 		BUG_ON(repl->magic != PXD_IOT_MAGIC);
 
 		tmp = remap_io_status(repl->status);

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1418,7 +1418,7 @@ int pxd_suspend_state(struct pxd_device *pxd_dev)
 	return atomic_read(&pxd_dev->fp.suspend);
 }
 
-int pxd_switch_fastpath(struct pxd_device* pxd_dev)
+int pxd_debug_switch_fastpath(struct pxd_device* pxd_dev)
 {
 	return 0;
 }

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -525,7 +525,6 @@ static void pxd_complete_io(struct bio* bio, int error)
 	_generic_end_io_acct(pxd_dev->disk->queue, bio_data_dir(bio), &pxd_dev->disk->part0, iot->start);
 #endif
 
-	BUG_ON(pxd_dev->magic != PXD_DEV_MAGIC);
 	atomic_inc(&pxd_dev->fp.ncomplete);
 	atomic_dec(&pxd_dev->ncount);
 

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1423,7 +1423,7 @@ int pxd_switch_fastpath(struct pxd_device* pxd_dev)
 	return 0;
 }
 
-int pxd_switch_nativepath(struct pxd_device* pxd_dev)
+int pxd_debug_switch_nativepath(struct pxd_device* pxd_dev)
 {
 	if (pxd_dev->fp.fastpath) {
 		printk(KERN_WARNING"pxd_dev %llu in fastpath, forcing failover\n",

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -468,11 +468,11 @@ static void pxd_complete_io(struct bio* bio, int error)
 
 		if (failed) {
 			printk("FAILED IO %s: dev m %d g %lld %s at %ld len %d bytes %d pages "
-				"flags 0x%x\n", __func__,
+				"flags 0x%lx\n", __func__,
 			pxd_dev->minor, pxd_dev->dev_id,
 			bio_data_dir(bio) == WRITE ? "wr" : "rd",
 			BIO_SECTOR(bio) * SECTOR_SIZE, BIO_SIZE(bio),
-			bio->bi_vcnt, bio->bi_flags);
+			bio->bi_vcnt, (long unsigned int)bio->bi_flags);
 		}
 
 		return;

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -475,7 +475,7 @@ static void pxd_complete_io(struct bio* bio, int error)
 	struct pxd_device *pxd_dev = bio->bi_private;
 	struct pxd_io_tracker *head = iot->head;
 	unsigned int flags = get_op_flags(bio);
-	int blkrc = 0;
+	int blkrc;
 
 	BUG_ON(iot->magic != PXD_IOT_MAGIC);
 	BUG_ON(head->magic != PXD_IOT_MAGIC);
@@ -484,18 +484,13 @@ static void pxd_complete_io(struct bio* bio, int error)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0) ||  \
     (LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0) && \
      defined(bvec_iter_sectors))
-		if (bio->bi_status) {
-			blkrc = blk_status_to_errno(bio->bi_status);
-		}
+		blkrc = blk_status_to_errno(bio->bi_status);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
-		if (bio->bi_error) {
-			blkrc = bio->bi_error;
-		}
+		blkrc = bio->bi_error;
 #else
-		if (error) {
-			blkrc = error;
-		}
+		blkrc = error;
 #endif
+
 	if (blkrc != 0) {
 		printk_ratelimited("FAILED IO %s (err=%d): dev m %d g %lld %s at %ld len %d bytes %d pages "
 				"flags 0x%lx\n", __func__, blkrc,

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -364,29 +364,6 @@ static void __pxd_cleanup_block_io(struct pxd_io_tracker *head)
 	bio_put(&head->clone);
 }
 
-// will block IO on this device until failover is complete
-static void pxd_fastpath_attach_fail(struct pxd_device *pxd_dev)
-{
-	int rc;
-	spin_lock(&pxd_dev->fp.fail_lock);
-	pxd_dev->fp.active_failover = true;
-	spin_unlock(&pxd_dev->fp.fail_lock);
-
-	rc = pxd_initiate_failover(pxd_dev);
-	// If userspace cannot be informed of a failover event, fail IO on this device.
-	if (rc) {
-		pxd_dev->connected = false; // all future IO also fails.
-		printk(KERN_ERR"%s: pxd%llu: failover failed %d, aborting IO\n", __func__, pxd_dev->dev_id, rc);
-		spin_lock(&pxd_dev->fp.fail_lock);
-		pxd_dev->fp.active_failover = false;
-		spin_unlock(&pxd_dev->fp.fail_lock);
-		return;
-	}
-
-	printk(KERN_INFO"%s: Device %llu failover initiated, fastpath attach failed\n",
-		__func__, pxd_dev->dev_id);
-}
-
 static void pxd_io_failover(struct work_struct *ws)
 {
 	struct pxd_io_tracker *head = container_of(ws, struct pxd_io_tracker, wi);
@@ -1080,7 +1057,7 @@ void enableFastPath(struct pxd_device *pxd_dev, bool force)
 	}
 
 	pxd_suspend_io(pxd_dev);
-	pxd_dev->fp.fastpath = true;
+
 	decode_mode(mode, modestr);
 	for (i = 0; i < nfd; i++) {
 		if (fp->file[i] > 0) { /* valid fd exists already */
@@ -1122,6 +1099,7 @@ void enableFastPath(struct pxd_device *pxd_dev, bool force)
 		}
 	}
 
+	pxd_dev->fp.fastpath = true;
 	pxd_resume_io(pxd_dev);
 
 	printk(KERN_INFO"pxd_dev %llu fastpath %d mode %#x setting up with %d backing volumes, [%px,%px,%px]\n",
@@ -1138,8 +1116,10 @@ out_file_failed:
 	memset(fp->file, 0, sizeof(fp->file));
 	memset(fp->device_path, 0, sizeof(fp->device_path));
 
-	pxd_fastpath_attach_fail(pxd_dev);
+	pxd_dev->fp.fastpath = false;
 	pxd_resume_io(pxd_dev);
+	printk(KERN_INFO"%s: Device %llu no backing volume setup, will take slow path\n",
+		__func__, pxd_dev->dev_id);
 }
 
 void disableFastPath(struct pxd_device *pxd_dev, bool skipsync)

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -510,7 +510,6 @@ static void pxd_complete_io(struct bio* bio, int error)
 	iot->status = blkrc;
 	if (!atomic_dec_and_test(&head->active)) {
 		// not all responses have come back
-		// but update head status if this is a failure
 		return;
 	}
 

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -632,10 +632,8 @@ static void _pxd_setup(struct pxd_device *pxd_dev, bool enable)
 		printk(KERN_NOTICE "device %llu called to disable IO\n", pxd_dev->dev_id);
 		pxd_dev->connected = false;
 		pxd_abortfailQ(pxd_dev);
-		disableFastPath(pxd_dev, false);
 	} else {
 		printk(KERN_NOTICE "device %llu called to enable IO\n", pxd_dev->dev_id);
-		enableFastPath(pxd_dev, true);
 		pxd_dev->connected = true;
 	}
 }

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -437,6 +437,7 @@ static void pxd_complete_io(struct bio* bio, int error)
 	struct pxd_io_tracker *head = iot->head;
 	bool dofree = true;
 	int blkrc = 0;
+	unsigned int flags = get_op_flags(bio);
 
 	BUG_ON(iot->magic != PXD_IOT_MAGIC);
 	BUG_ON(head->magic != PXD_IOT_MAGIC);
@@ -450,11 +451,11 @@ static void pxd_complete_io(struct bio* bio, int error)
 		}
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
 		if (bio->bi_error) {
-			blkrc = bio->bi_status;
+			blkrc = bio->bi_error;
 		}
 #else
 		if (error) {
-			blkrc = bio->bi_status;
+			blkrc = error;
 		}
 #endif
 	if (blkrc != 0) {
@@ -463,7 +464,7 @@ static void pxd_complete_io(struct bio* bio, int error)
 			pxd_dev->minor, pxd_dev->dev_id,
 			bio_data_dir(bio) == WRITE ? "wr" : "rd",
 			BIO_SECTOR(bio) * SECTOR_SIZE, BIO_SIZE(bio),
-			bio->bi_vcnt, (long unsigned int)bio->bi_opf);
+			bio->bi_vcnt, (long unsigned int)flags);
 	}
 
 	fput(iot->file);

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -113,7 +113,7 @@ int get_thread_count(int id);
 
 void pxd_fastpath_adjust_limits(struct pxd_device *pxd_dev, struct request_queue *topque);
 int pxd_suspend_state(struct pxd_device *pxd_dev);
-int pxd_switch_fastpath(struct pxd_device*);
+int pxd_debug_switch_fastpath(struct pxd_device*);
 int pxd_switch_nativepath(struct pxd_device*);
 void pxd_suspend_io(struct pxd_device*);
 void pxd_resume_io(struct pxd_device*);

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -117,6 +117,7 @@ int pxd_debug_switch_fastpath(struct pxd_device*);
 int pxd_debug_switch_nativepath(struct pxd_device*);
 void pxd_suspend_io(struct pxd_device*);
 void pxd_resume_io(struct pxd_device*);
+int pxd_fastpath_vol_cleanup(struct pxd_device *pxd_dev);
 
 // external request from userspace to control io path
 int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush, bool coe);

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -26,11 +26,11 @@ struct pxd_io_tracker {
 	struct list_head replicas; // only replica needs this
 	struct list_head item; // only HEAD needs this
 	atomic_t active; // only HEAD has refs to all active IO
-	atomic_t fails; // should be zero, non-zero indicates atleast one path failed
 	struct file* file;
 
 	unsigned long start; // start time [HEAD]
 	struct bio *orig;    // original request bio [HEAD]
+	int status; // should be zero, non-zero indicates consolidated fail status
 
 	struct work_struct wi; // work item
 

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -114,7 +114,7 @@ int get_thread_count(int id);
 void pxd_fastpath_adjust_limits(struct pxd_device *pxd_dev, struct request_queue *topque);
 int pxd_suspend_state(struct pxd_device *pxd_dev);
 int pxd_debug_switch_fastpath(struct pxd_device*);
-int pxd_switch_nativepath(struct pxd_device*);
+int pxd_debug_switch_nativepath(struct pxd_device*);
 void pxd_suspend_io(struct pxd_device*);
 void pxd_resume_io(struct pxd_device*);
 

--- a/pxd_fastpath_stub.c
+++ b/pxd_fastpath_stub.c
@@ -35,6 +35,7 @@ int pxd_request_suspend_internal(struct pxd_device *pxd_dev, bool skip_flush, bo
 int pxd_request_resume(struct pxd_device *pxd_dev) { return 0; }
 int pxd_request_resume_internal(struct pxd_device *pxd_dev) { return 0; }
 int pxd_request_ioswitch(struct pxd_device *pxd_dev, int code) { return -1; }
+int pxd_fastpath_vol_cleanup(struct pxd_device *pxd_dev) { return -1; }
 
 void pxd_reissuefailQ(struct pxd_device *pxd_dev, struct list_head *ios, int status){}
 void pxd_abortfailQ(struct pxd_device *pxd_dev) { }

--- a/pxd_fastpath_stub.c
+++ b/pxd_fastpath_stub.c
@@ -28,7 +28,7 @@ int pxd_suspend_state(struct pxd_device *pxd_dev) {return 0;}
 
 void pxd_suspend_io(struct pxd_device* pxd_dev) { }
 void pxd_resume_io(struct pxd_device* pxd_dev) { }
-int pxd_switch_fastpath(struct pxd_device* pxd_dev) {return -1;}
+int pxd_debug_switch_fastpath(struct pxd_device* pxd_dev) {return -1;}
 int pxd_switch_nativepath(struct pxd_device* pxd_dev) {return -1;}
 int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush, bool coe) { return 0; }
 int pxd_request_suspend_internal(struct pxd_device *pxd_dev, bool skip_flush, bool coe) { return 0; }

--- a/pxd_fastpath_stub.c
+++ b/pxd_fastpath_stub.c
@@ -29,7 +29,7 @@ int pxd_suspend_state(struct pxd_device *pxd_dev) {return 0;}
 void pxd_suspend_io(struct pxd_device* pxd_dev) { }
 void pxd_resume_io(struct pxd_device* pxd_dev) { }
 int pxd_debug_switch_fastpath(struct pxd_device* pxd_dev) {return -1;}
-int pxd_switch_nativepath(struct pxd_device* pxd_dev) {return -1;}
+int pxd_debug_switch_nativepath(struct pxd_device* pxd_dev) {return -1;}
 int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush, bool coe) { return 0; }
 int pxd_request_suspend_internal(struct pxd_device *pxd_dev, bool skip_flush, bool coe) { return 0; }
 int pxd_request_resume(struct pxd_device *pxd_dev) { return 0; }


### PR DESCRIPTION
Fastpath volume operations failure cleanups.

If in the final stage of attaching a fastpath volume fails, then it cannot be immediately allowed to service IO in the native path, because SAN setup has put targets in fastpath mode, wherien the file handles are closed.
So they will remain in suspended state until a final cleanup request is issued.

Also do not ever update fastpath state without informed userspace.

This has been tested with userspace https://github.com/portworx/porx/pull/6505