### PR TITLE
pwx-17109 : support for making a process into a IO flusher

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -287,8 +287,9 @@ static long pxd_ioflusher_state(void __user *argp)
 		return -EOPNOTSUPP;
 	}
 
-	if (argp == NULL)
+	if (argp == NULL) {
 		return -EINVAL;
+	}
 
 	if (copy_from_user(&io_flusher_args, argp, sizeof(io_flusher_args))) {
 		return -EFAULT;
@@ -301,9 +302,9 @@ static long pxd_ioflusher_state(void __user *argp)
 	} else {
 		struct task_struct *temp_task;
 		struct pid *pid = NULL;
-		rcu_read_lock();
 		pid = find_pid_ns(io_flusher_args.pid, ns);
 		if (pid == NULL) {
+			rcu_read_unlock();
 			printk("Input pid %d does not exist", io_flusher_args.pid);
 			return -ENOENT;
 		}

--- a/pxd.c
+++ b/pxd.c
@@ -41,6 +41,12 @@
 #define PXD_TIMER_SECS_DEFAULT 600
 #define PXD_TIMER_SECS_MAX (U32_MAX)
 
+#define PF_IO_FLUSHER (PF_MEMALLOC_NOIO | PF_LESS_THROTTLE)
+#define IS_SET_IO_FLUSHER_FLAG(flg) ((flg & PF_IO_FLUSHER) == PF_IO_FLUSHER)
+#define IS_SET_IO_FLUSHER(task) (IS_SET_IO_FLUSHER_FLAG((task->flags)))
+#define SET_IO_FLUSHER(task) (task->flags |= PF_IO_FLUSHER)
+#define CLEAR_IO_FLUSHER(task) (task->flags &= ~(PF_IO_FLUSHER))
+
 #define TOSTRING_(x) #x
 #define VERTOSTR(x) TOSTRING_(x)
 
@@ -239,22 +245,12 @@ static long pxd_ioctl_run_user_queue(struct file *file)
 	return 0;
 }
 
-#define PF_IO_FLUSHER (PF_MEMALLOC_NOIO | PF_LESS_THROTTLE)
-#define IS_SET_IO_FLUSHER_FLAG(flg) ((flg & PF_IO_FLUSHER) == PF_IO_FLUSHER)
-#define IS_SET_IO_FLUSHER(task) (IS_SET_IO_FLUSHER_FLAG((task->flags)))
-#define SET_IO_FLUSHER(task) task->flags |= PF_IO_FLUSHER
-#define CLEAR_IO_FLUSHER(task) task->flags &= ~(PF_IO_FLUSHER)
-static void print_io_flusher_state(unsigned int old_flags, unsigned int new_flags,
+static void print_io_flusher_state(unsigned int new_flags,
 				   pid_t pid, pid_t ppid, char *comm)
 {
 	if (IS_SET_IO_FLUSHER_FLAG(new_flags)) {
-		if (IS_SET_IO_FLUSHER_FLAG(old_flags)) {
-			printk("Process %s pid %d parent pid %d IO_FLUSHER is set\n",
+		printk("Process %s pid %d parent pid %d IO_FLUSHER is set\n",
 			       comm, pid, ppid);
-		} else {
-			printk("Process %s pid %d parent pid %d IO_FLUSHER turned on\n",
-			       comm, pid, ppid);
-		}
 	} else {
 		printk("Process %s pid %d parent pid %d IO_FLUSHER not set\n", comm, pid,
 				ppid);
@@ -266,9 +262,12 @@ static int is_io_flusher_supported(void)
 	#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,10,0) && LINUX_VERSION_CODE <= KERNEL_VERSION(5,8,0)
 		#if defined(PF_MEMALLOC_NOIO) && defined(PF_LESS_THROTTLE)
 			return 1;
+		#else
+			return 0;
 		#endif
+	#else
+		return 0;
 	#endif
-	return 0;
 }
 
 static long pxd_ioflusher_state(void __user *argp)
@@ -302,7 +301,6 @@ static long pxd_ioflusher_state(void __user *argp)
 	} else {
 		struct task_struct *temp_task;
 		struct pid *pid = NULL;
-		//printk("user specified pid %d\n", io_flusher_args.pid);
 		rcu_read_lock();
 		pid = find_pid_ns(io_flusher_args.pid, ns);
 		if (pid == NULL) {
@@ -325,22 +323,20 @@ static long pxd_ioflusher_state(void __user *argp)
 	old_flags = task->flags;
 	switch (io_flusher_args.io_flusher_action) {
 	case PXD_IO_FLUSHER_GET:
-		if (IS_SET_IO_FLUSHER(task)) {
-			is_io_flusher_set = 1;
-		}
 		break;
 	case PXD_IO_FLUSHER_SET:
 		SET_IO_FLUSHER(task);
-		is_io_flusher_set = 1;
 		break;
 	case PXD_IO_FLUSHER_CLEAR:
 		CLEAR_IO_FLUSHER(task);
-		is_io_flusher_set = 0;
 		break;
 	}
 	new_flags = task->flags;
 	put_task_struct(task);
-	print_io_flusher_state(old_flags, new_flags, pid, ppid, comm);
+
+	is_io_flusher_set = IS_SET_IO_FLUSHER_FLAG(new_flags);
+
+	print_io_flusher_state(new_flags, pid, ppid, comm);
 
 	if (copy_to_user(argp + offsetof(struct pxd_ioctl_io_flusher_args, is_io_flusher_set),
 			&is_io_flusher_set, sizeof(is_io_flusher_set))) {

--- a/pxd.h
+++ b/pxd.h
@@ -35,6 +35,7 @@
 #define PXD_IOC_UNREGISTER_FILE	_IO(PXD_IOCTL_MAGIC, 7)		/* 0x505807 */
 #define PXD_IOC_RESIZE			_IO(PXD_IOCTL_MAGIC, 8)		/* 0x505808 */
 #define PXD_IOC_FPCLEANUP		_IO(PXD_IOCTL_MAGIC, 9)		/* 0x505809 */
+#define PXD_IOC_IO_FLUSHER		_IO(PXD_IOCTL_MAGIC, 10)	/* 0x50580a */
 
 #define PXD_MAX_DEVICES	512			/**< maximum number of devices supported */
 #define PXD_MAX_IO		(1024*1024)	/**< maximum io size in bytes */
@@ -247,7 +248,7 @@ struct pxd_rdwr_in_v1 {
 	uint32_t size;		/**< read/write/discard size in bytes */
 	uint32_t flags;		/**< bio flags */
 	uint64_t chksum;	/**< buffer checksum */
-	uint32_t pad; 
+	uint32_t pad;
 	uint64_t offset;	/**< device offset in bytes */
 };
 
@@ -321,6 +322,19 @@ struct pxd_ioctl_init_args {
 
 	/** list of devices */
 	struct pxd_dev_id devices[PXD_MAX_DEVICES];
+};
+
+/** sub-actions for PXD_IOC_IO_FLUSHER ioctl */
+enum pxd_io_flusher_action {
+	PXD_IO_FLUSHER_GET = 0,	/**<  check IO FLUSHER state of the process */
+	PXD_IO_FLUSHER_SET = 1,	/**< set IO FLUSHER state of the process */
+	PXD_IO_FLUSHER_CLEAR = 2,	/**< clear IO FLUSHER state of the process */
+};
+
+struct pxd_ioctl_io_flusher_args {
+	pid_t pid; /**< pid of the process which is examined, 0 for current process */
+	uint32_t io_flusher_action; /**< one of pxd_io_flusher_action */
+	int is_io_flusher_set; /**< output argument, will be updated by driver */
 };
 
 #endif /* PXD_H_ */


### PR DESCRIPTION

https://portworx.atlassian.net/browse/PWX-17109

This change adds a new IOCTL to help tag a process as a IO_FLUSHER. When tagged as IO_FLUSHER, the kernel memory allocation does not try to wait on dirty pages to flushed. This helps to get away with buffers that were dirty as a result of mkfs on newly created pxd device. The wait on flush of these dirty buffers would lead to a cyclic dependency and thereby cause a deadlock
