### PR TITLE
PWX-17271: Compilation issues with 5.9.8-flatcar.

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -616,7 +616,9 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 	}
 #else
 	if (pxd_dev->fastpath) {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+	  q = blk_alloc_queue(NUMA_NO_NODE);	  
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0)
 		q = blk_alloc_queue(pxd_make_request_fastpath, NUMA_NO_NODE);
 #else
 		q = blk_alloc_queue(GFP_KERNEL);
@@ -625,11 +627,12 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 			err = -ENOMEM;
 			goto out_disk;
 		}
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,9,0)
 		// add hooks to control congestion only while using fastpath
 		q->backing_dev_info->congested_fn = pxd_device_congested;
 		q->backing_dev_info->congested_data = pxd_dev;
-
+#endif
+		
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,7,0)
 		blk_queue_make_request(q, pxd_make_request_fastpath);
 #endif


### PR DESCRIPTION
PWX-17271:  Compilation fixes for flatcar with kernel 5.9.8-flatcar.

Note needed to disable below for kernel 5.9.0 and above: 

        // add hooks to control congestion only while using fastpath
        q->backing_dev_info->congested_fn = pxd_device_congested;
        q->backing_dev_info->congested_data = pxd_dev;