### PR TITLE
honour block device limits for all cases

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -703,7 +703,6 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 	int rc;
 	trace_pxd_request(req->in.unique, size, off, minor, flags);
 
-	atomic_inc(&req->pxd_dev->ncount);
 	switch (op) {
 	case REQ_OP_WRITE_SAME:
 		rc = pxd_write_same_request(req, size, off, minor, flags);
@@ -726,6 +725,7 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 		return -1;
 	}
 
+	if (rc == 0) atomic_inc(&req->pxd_dev->ncount);
 	return rc;
 }
 
@@ -737,7 +737,6 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 	int rc;
 	trace_pxd_request(req->in.unique, size, off, minor, flags);
 
-	atomic_inc(&req->pxd_dev->ncount);
 	switch (flags & (REQ_WRITE | REQ_DISCARD | REQ_WRITE_SAME)) {
 	case REQ_WRITE:
 		/* FALLTHROUGH */
@@ -761,6 +760,7 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 		return -1;
 	}
 
+	if (rc == 0) atomic_inc(&req->pxd_dev->ncount);
 	return rc;
 }
 #endif

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1328,6 +1328,66 @@ void pxd_make_request_fastpath(struct request_queue *q, struct bio *bio)
 		return BLK_QC_RETVAL;
 	}
 
+	/*
+	 * Use blk_queue_split() to ensure queue limits are always honoured.
+	 * same as kernel dm commit: 89f5fa47476eda56402e29fff3c5097f5c2a1e19
+	 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+	blk_queue_split(&bio);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
+	blk_queue_split(q, &bio);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,2,0)
+	blk_queue_split(q, &bio, q->bio_split);
+#else
+{
+	unsigned op = 0; // READ
+	sector_t rq_size = BIO_SIZE(bio);
+	sector_t max_size;
+
+	switch (bio->bi_rw & (REQ_WRITE | REQ_DISCARD | REQ_WRITE_SAME)) {
+	case REQ_WRITE:
+		/* FALLTHROUGH */
+	case (REQ_WRITE | REQ_WRITE_SAME):
+		if (flags & REQ_WRITE_SAME)
+			op = REQ_WRITE_SAME;
+		else
+			op = REQ_WRITE;
+		break;
+	case REQ_DISCARD:
+		/* FALLTHROUGH */
+	case REQ_WRITE | REQ_DISCARD:
+		op = REQ_DISCARD;
+		break;
+	default:
+		printk(KERN_ERR"[%lu] REQ_OP_UNKNOWN(flags=%#x): size=%d, off=%lld, minor=%d\n",
+			pxd_dev->dev_id, bio->bi_rw, rq_size, max_size, pxd_dev->minor);
+		bio_io_error(bio);
+		return BLK_QC_RETVAL;
+	}
+
+	max_size = blk_queue_get_max_bytes(q, op);
+
+	if (!max_size) {
+		bio_io_error(bio);
+		return BLK_QC_RETVAL;
+	}
+
+	if (rq_size > max_size) {
+		struct bio_pair *bp = bio_split(bio, max_size >> SECTOR_SHIFT);
+		if (!bp) {
+			bio_io_error(bio);
+			return BLK_QC_RETVAL;
+		}
+
+		// process the split BIOs in next submission
+		generic_make_request(&bp->bio1);
+		generic_make_request(&bp->bio2);
+		bio_pair_release(bp);
+		return BLK_QC_RETVAL;
+	}
+}
+#endif
+
 	pxd_check_q_congested(pxd_dev);
 	read_lock(&pxd_dev->fp.suspend_lock);
 	if (!pxd_dev->fp.fastpath) {

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1373,7 +1373,7 @@ void pxd_make_request_fastpath(struct request_queue *q, struct bio *bio)
 	}
 
 	if (rq_sectors > max_sectors) {
-		struct bio_pair *bp = bio_split(bio, max_sectors >> SECTOR_SHIFT);
+		struct bio_pair *bp = bio_split(bio, max_sectors);
 		if (!bp) {
 			bio_io_error(bio);
 			return BLK_QC_RETVAL;

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1359,6 +1359,8 @@ void pxd_make_request_fastpath(struct request_queue *q, struct bio *bio)
 	case REQ_WRITE | REQ_DISCARD:
 		op = REQ_DISCARD;
 		break;
+	case 0: // read
+		break;
 	default:
 		printk(KERN_ERR"[%llu] REQ_OP_UNKNOWN(flags=%#x): size=%lu, minor=%d\n",
 			pxd_dev->dev_id, flags, rq_sectors, pxd_dev->minor);

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1360,14 +1360,13 @@ void pxd_make_request_fastpath(struct request_queue *q, struct bio *bio)
 		op = REQ_DISCARD;
 		break;
 	default:
-		printk(KERN_ERR"[%lu] REQ_OP_UNKNOWN(flags=%#x): size=%u, max_size=%u, minor=%d\n",
-			pxd_dev->dev_id, flags, rq_sectors, max_sectors, pxd_dev->minor);
+		printk(KERN_ERR"[%llu] REQ_OP_UNKNOWN(flags=%#x): size=%lu, minor=%d\n",
+			pxd_dev->dev_id, flags, rq_sectors, pxd_dev->minor);
 		bio_io_error(bio);
 		return BLK_QC_RETVAL;
 	}
 
 	max_sectors = blk_queue_get_max_sectors(q, op);
-
 	if (!max_sectors) {
 		bio_io_error(bio);
 		return BLK_QC_RETVAL;


### PR DESCRIPTION
While using non blk mq device registration, block device limits may not be honoured always.
It was partially handled for few versions with bio_split.
Extending the bits to honour all versions with this changeset.

Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

**Test Logs**
```
[root@ip-70-0-83-247 px-fuse]# pxctl v c -s 10 -r 3 vol2r3
Volume successfully created: 686228160905618492
[root@ip-70-0-83-247 px-fuse]# pxctl v i -e vol2r3
        Volume                   :  686228160905618492
        Name                     :  vol2r3
        Size                     :  10 GiB
        Format                   :  ext4
        HA                       :  3
        IO Priority              :  HIGH
        Creation time            :  Dec 8 13:58:45 UTC 2020
        Shared                   :  no
        Status                   :  up
        State                    :  detached
        Mount Options            :  discard
        ScanPolicy               :  repair_on_mount
        ProxyWrite               :  false
        Reads                    :  0
        Reads MS                 :  0
        Bytes Read               :  0
        Writes                   :  0
        Writes MS                :  0
        Bytes Written            :  0
        IOs in progress          :  0
        Bytes used               :  132 MiB
        Replica sets on nodes:
                Set 0
                  Node           : 70.0.83.247 (Pool b7cabb64-9f70-48e1-bb2a-ebfe00e3b1f3 )
                  Node           : 70.0.98.48 (Pool b441b10b-d4d6-40a7-a3cd-68d5be386069 )
                  Node           : 70.0.88.215 (Pool 02ed2519-a25a-42ad-ad90-90fcf3e9e748 )
        Replication Status       :  Detached

        Displaying extended volume state:
        Fastpath preferred      : true
        Fastpath promoted       : false
        Fastpath dirty          : false
        Fastpath attached       : FASTPATH_INACTIVE
[root@ip-70-0-83-247 px-fuse]# pxctl host attach vol2r3
Volume successfully attached at: /dev/pxd/pxd686228160905618492
[root@ip-70-0-83-247 px-fuse]# pxctl v i -e vol2r3
        Volume                   :  686228160905618492
        Name                     :  vol2r3
        Size                     :  10 GiB
        Format                   :  ext4
        HA                       :  3
        IO Priority              :  HIGH
        Creation time            :  Dec 8 13:58:45 UTC 2020
        Shared                   :  no
        Status                   :  up
        State                    :  Attached: c06c40e5-fb8e-4d4a-8c91-6f5d350ef74a (70.0.83.247)
        Last Attached            :  Dec 8 13:59:04 UTC 2020
        Device Path              :  /dev/pxd/pxd686228160905618492
        Mount Options            :  discard
        ScanPolicy               :  repair_on_mount
        ProxyWrite               :  false
        Reads                    :  43
        Reads MS                 :  7
        Bytes Read               :  1060864
        Writes                   :  0
        Writes MS                :  0
        Bytes Written            :  0
        IOs in progress          :  0
        Bytes used               :  132 MiB
        Replica sets on nodes:
                Set 0
                  Node           : 70.0.83.247 (Pool b7cabb64-9f70-48e1-bb2a-ebfe00e3b1f3 )
                  Node           : 70.0.98.48 (Pool b441b10b-d4d6-40a7-a3cd-68d5be386069 )
                  Node           : 70.0.88.215 (Pool 02ed2519-a25a-42ad-ad90-90fcf3e9e748 )
        Replication Status       :  Up

        Displaying extended volume state:
        Fastpath preferred      : true
        Fastpath promoted       : true
        Fastpath dirty          : false
        Fastpath attached       : FASTPATH_ACTIVE
        Fastpath coordinator    : c06c40e5-fb8e-4d4a-8c91-6f5d350ef74a
        Fastpath replicas       : 3
        Fastpath replica property follows:
                Replica : 0
                        On Node         : c06c40e5-fb8e-4d4a-8c91-6f5d350ef74a
                        Protocol        : FASTPATH_PROTO_ISCSI
                        Secure          : true
                        Exported        : true
                                Target  : /dev/pwx0/686228160905618492
                                Source  : /dev/pwx0/686228160905618492
                                Type    : Block device
                        Imported        : true
                                Mapped local device: /dev/pwx0/686228160905618492
                Replica : 1
                        On Node         : 4008d10f-79ac-48ae-8a73-029b1779da39
                        Protocol        : FASTPATH_PROTO_ISCSI
                        Secure          : true
                        Exported        : true
                                Target  : iqn.2019-08.px.px-int-c0-12-8-dev-porx-05-489-261:uuid.504f5258-0001-0002-0985-f8e065a6243c
                                Source  : /dev/pwx0/686228160905618492
                                Type    : Block device
                        Imported        : true
                                Mapped local device: /dev/pxfp/pxd686228160905618492-node1
                Replica : 2
                        On Node         : c02c8464-f7be-4d75-a9be-56b01075f4e1
                        Protocol        : FASTPATH_PROTO_ISCSI
                        Secure          : true
                        Exported        : true
                                Target  : iqn.2019-08.px.px-int-c0-12-8-dev-porx-05-489-261:uuid.504f5258-0002-0002-0985-f8e065a6243c
                                Source  : /dev/pwx0/686228160905618492
                                Type    : Block device
                        Imported        : true
                                Mapped local device: /dev/pxfp/pxd686228160905618492-node2
[root@ip-70-0-83-247 px-fuse]# 
[root@ip-70-0-83-247 ~]# mkfs.xfs -f /dev/pxd/pxd686228160905618492
meta-data=/dev/pxd/pxd686228160905618492 isize=512    agcount=16, agsize=163840 blks
         =                       sectsz=4096  attr=2, projid32bit=1
         =                       crc=1        finobt=0, sparse=0
data     =                       bsize=4096   blocks=2621440, imaxpct=25
         =                       sunit=256    swidth=768 blks
naming   =version 2              bsize=4096   ascii-ci=0 ftype=1
log      =internal log           bsize=4096   blocks=2560, version=2
         =                       sectsz=4096  sunit=1 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
[root@ip-70-0-83-247 ~]#
```