### PR TITLE
PWX-17949: fix bdev entry func for 5.9 kernel

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -379,6 +379,9 @@ static const struct block_device_operations pxd_bd_ops = {
 	.owner			= THIS_MODULE,
 	.open			= pxd_open,
 	.release		= pxd_release,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+	.submit_io		= pxd_make_request_fastpath,
+#endif
 };
 
 static void pxd_update_stats(struct fuse_req *req, int rw, unsigned int count)

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1426,7 +1426,7 @@ void pxd_make_request_fastpath(struct request_queue *q, struct bio *bio)
 	}
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,1)
-	bio_start_io_acct(bio);
+	iot->start = bio_start_io_acct(bio);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0) || \
     (LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0) && \
      defined(bvec_iter_sectors))

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1292,15 +1292,22 @@ out_file_failed:
 }
 
 /* fast path make request function, io entry point */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+blk_qc_t pxd_make_request_fastpath(struct bio *bio)
+{
+	struct request_queue *q = bio->bi_disk->queue;
+	struct pxd_device *pxd_dev = bio->bi_disk->private_data;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 blk_qc_t pxd_make_request_fastpath(struct request_queue *q, struct bio *bio)
 #define BLK_QC_RETVAL BLK_QC_T_NONE
+{
+	struct pxd_device *pxd_dev = q->queuedata;
 #else
 void pxd_make_request_fastpath(struct request_queue *q, struct bio *bio)
 #define BLK_QC_RETVAL
-#endif
 {
 	struct pxd_device *pxd_dev = q->queuedata;
+#endif
 	int rw = bio_data_dir(bio);
 	struct pxd_io_tracker *head;
 

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -94,7 +94,9 @@ void pxd_fastpath_cleanup(struct pxd_device *pxd_dev);
 void pxdctx_set_connected(struct pxd_context *ctx, bool enable);
 
 // IO entry point
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+blk_qc_t pxd_make_request_fastpath(struct bio *bio);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 blk_qc_t pxd_make_request_fastpath(struct request_queue *q, struct bio *bio);
 #define BLK_QC_RETVAL BLK_QC_T_NONE
 #else


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

Compilation fix for 5.9 kernel is incomplete with no method registered to handle IO for the virtual px block device.
This PR introduces the submit_io method to complete it.