### PR TITLE
PWX-18027: fix fuse 'req' leak

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -210,18 +210,16 @@ static void request_end(struct fuse_conn *fc, struct fuse_req *req,
 	int status)
 {
 	u64 uid = req->in.unique;
-#ifdef __PX_BLKMQ__
-	bool using_blkque = req->pxd_dev->using_blkque;
-#endif
+	bool shouldfree = false;
+
+	/* 'req->end' is always set if the context gets used.
+	 * if error happens during processing, error path handling does free request.
+	 */
 	if (req->end)
-		req->end(fc, req, status);
+		shouldfree = req->end(fc, req, status);
 	fuse_put_unique(fc, uid);
 
-#ifndef __PX_BLKMQ__
-	fuse_request_free(req);
-#else
-	if (!using_blkque) fuse_request_free(req);
-#endif
+	if (shouldfree) fuse_request_free(req);
 }
 
 void fuse_request_send_nowait(struct fuse_conn *fc, struct fuse_req *req, bool force)

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -63,7 +63,8 @@ struct fuse_req {
 	};
 
 	/** Request completion callback */
-	void (*end)(struct fuse_conn *, struct fuse_req *, int status);
+	/** return: 'true' to free the request, 'false' otherwise */
+	bool (*end)(struct fuse_conn *, struct fuse_req *, int status);
 
 	/** Associate request queue */
 	struct request_queue *queue;

--- a/pxd.c
+++ b/pxd.c
@@ -452,16 +452,18 @@ static void pxd_request_complete(struct fuse_conn *fc, struct fuse_req *req)
 			req->pxd_rdwr_in.offset);
 }
 
-static void pxd_process_read_reply(struct fuse_conn *fc, struct fuse_req *req,
+static bool pxd_process_read_reply(struct fuse_conn *fc, struct fuse_req *req,
 	int status)
 {
 	trace_pxd_reply(req->in.unique, 0u);
 	pxd_update_stats(req, 0, BIO_SIZE(req->bio) / SECTOR_SIZE);
 	BIO_ENDIO(req->bio, status);
 	pxd_request_complete(fc, req);
+
+	return true;
 }
 
-static void pxd_process_write_reply(struct fuse_conn *fc, struct fuse_req *req,
+static bool pxd_process_write_reply(struct fuse_conn *fc, struct fuse_req *req,
 	int status)
 {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) || defined(REQ_PREFLUSH)
@@ -472,29 +474,35 @@ static void pxd_process_write_reply(struct fuse_conn *fc, struct fuse_req *req,
 	pxd_update_stats(req, 1, BIO_SIZE(req->bio) / SECTOR_SIZE);
 	BIO_ENDIO(req->bio, status);
 	pxd_request_complete(fc, req);
+
+	return true;
 }
 
 /* only used by the USE_REQUESTQ_MODEL definition */
-static void pxd_process_read_reply_q(struct fuse_conn *fc, struct fuse_req *req,
+static bool pxd_process_read_reply_q(struct fuse_conn *fc, struct fuse_req *req,
 	int status)
 {
 	pxd_request_complete(fc, req);
 #ifndef __PX_BLKMQ__
 	blk_end_request(req->rq, status, blk_rq_bytes(req->rq));
+	return true;
 #else
 	blk_mq_end_request(req->rq, errno_to_blk_status(status));
+	return false;
 #endif
 }
 
 /* only used by the USE_REQUESTQ_MODEL definition */
-static void pxd_process_write_reply_q(struct fuse_conn *fc, struct fuse_req *req,
+static bool pxd_process_write_reply_q(struct fuse_conn *fc, struct fuse_req *req,
 	int status)
 {
 	pxd_request_complete(fc, req);
 #ifndef __PX_BLKMQ__
 	blk_end_request(req->rq, status, blk_rq_bytes(req->rq));
+	return true;
 #else
 	blk_mq_end_request(req->rq, errno_to_blk_status(status));
+	return false;
 #endif
 }
 
@@ -773,7 +781,7 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 #endif
 
 static
-void pxd_process_ioswitch_complete(struct fuse_conn *fc, struct fuse_req *req,
+bool pxd_process_ioswitch_complete(struct fuse_conn *fc, struct fuse_req *req,
 	int status)
 {
 	struct pxd_device *pxd_dev = req->pxd_dev;
@@ -802,6 +810,8 @@ void pxd_process_ioswitch_complete(struct fuse_conn *fc, struct fuse_req *req,
 
 	// reissue any failed IOs from local list
 	pxd_reissuefailQ(pxd_dev, &ios, status);
+
+	return true;
 }
 
 static


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

# issue #
when fastpath devices are switched iopath, the fuse context that gets used for communication between porx and px-fuse does not get freed resulting in following exception during rmmod eventually.

```
[Thu Jan  7 16:34:30 2021] BUG pxd_fuse_request (Tainted: G           OE    ): Objects remaining in pxd_fuse_request on __kmem_cache_shutdown()
```
