### PR TITLE
PWX-18057: px-fastpath support better discard handling

### DIFF
--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -38,6 +38,10 @@ struct pxd_io_tracker {
 	struct bio clone;    // cloned bio [ALL]
 };
 
+// helper functions
+struct block_device* get_bdev(struct file *fileh);
+unsigned get_mode(struct file *fileh);
+
 struct pxd_sync_ws {
 	struct work_struct ws;
 	struct pxd_device *pxd_dev;


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

# ISSUE #
fastpath specific.
imported remote replicas may not support discards.
For example, iscsi imported disks support only writesame/writezero but do not support discard.
Currently px-fuse driver shall report EOPNOTSUPP to the caller.
Instead handle this more gracefully by converting request to supported operation for each backing device.


# fastpath protocol = local #
```
root@bionic:/home/lns# pxctl host attach v1
Volume successfully attached at: /dev/pxd/pxd855549171283095927
root@bionic:/home/lns# pxctl v i -e v1
        Volume                   :  855549171283095927
        Name                     :  v1
        Size                     :  1.0 GiB
        Format                   :  none
        HA                       :  1
        IO Priority              :  HIGH
        Creation time            :  Jan 7 08:31:24 UTC 2021
        Shared                   :  no
        Status                   :  up
        State                    :  Attached: b93478dc-5caa-43bb-84e5-e3eed9aeb749 (10.0.2.15)
        Last Attached            :  Jan 8 11:35:47 UTC 2021
        Device Path              :  /dev/pxd/pxd855549171283095927
        ScanPolicy               :  repair_on_mount
        ProxyWrite               :  false
        Reads                    :  0
        Reads MS                 :  0
        Bytes Read               :  0
        Writes                   :  0
        Writes MS                :  0
        Bytes Written            :  0
        IOs in progress          :  0
        Bytes used               :  34 MiB
        Replica sets on nodes:
                Set 0
                  Node           : 10.0.2.15 (Pool cd58521c-4202-46eb-93c7-a510f6d35b63 )
        Replication Status       :  Up

        Displaying extended volume state:
        Fastpath preferred      : true
        Fastpath promoted       : true
        Fastpath dirty          : false
        Fastpath attached       : FASTPATH_ACTIVE
        Fastpath coordinator    : b93478dc-5caa-43bb-84e5-e3eed9aeb749
        Fastpath replicas       : 1
        Fastpath replica property follows:
                Replica : 0
                        On Node         : b93478dc-5caa-43bb-84e5-e3eed9aeb749
                        Protocol        : FASTPATH_PROTO_LOCAL
                        Secure          : true
                        Exported        : true
                                Target  : /dev/pwx0/855549171283095927
                                Source  : /dev/pwx0/855549171283095927
                                Type    : Block device
                        Imported        : true
                                Mapped local device: /dev/pwx0/855549171283095927
root@bionic:/home/lns# fio --direct=1 --bs=2M --size=1G --ioengine=libaio --rw=trim --iodepth=32 --name=/dev/pxd/pxd855549171283095927 --end_fsync=1
/dev/pxd/pxd855549171283095927: (g=0): rw=trim, bs=(R) 2048KiB-2048KiB, (W) 2048KiB-2048KiB, (T) 2048KiB-2048KiB, ioengine=libaio, iodepth=32
fio-3.1
Starting 1 process

/dev/pxd/pxd855549171283095927: (groupid=0, jobs=1): err= 0: pid=21593: Fri Jan  8 17:05:59 2021
   trim: IOPS=8533, BW=16.7GiB/s (17.9GB/s)(1024MiB/60msec)
    clat (nsec): min=108, max=1571, avg=204.18, stdev=98.68
     lat (usec): min=48, max=7114, avg=115.65, stdev=323.42
    clat percentiles (nsec):
     |  1.00th=[  120],  5.00th=[  137], 10.00th=[  151], 20.00th=[  165],
     | 30.00th=[  177], 40.00th=[  187], 50.00th=[  195], 60.00th=[  205],
     | 70.00th=[  215], 80.00th=[  225], 90.00th=[  243], 95.00th=[  262],
     | 99.00th=[  434], 99.50th=[ 1004], 99.90th=[ 1576], 99.95th=[ 1576],
     | 99.99th=[ 1576]
  lat (nsec)   : 250=91.80%, 500=7.23%, 1000=0.39%
  lat (usec)   : 2=0.59%
  cpu          : usr=10.17%, sys=0.00%, ctx=512, majf=0, minf=11
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,0,512, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=32

Run status group 0 (all jobs):
   TRIM: bw=16.7GiB/s (17.9GB/s), 16.7GiB/s-16.7GiB/s (17.9GB/s-17.9GB/s), io=1024MiB (1074MB), run=60-60msec

Disk stats (read/write):
  pxd!pxd855549171283095927: ios=0/0, merge=0/0, ticks=0/0, in_queue=0, util=0.00%
root@bionic:/home/lns#
```

# dmesg logs for local backing device #

dmesg with debug logs enabled (px device receives and processes discards correctly).
```
[Fri Jan  8 16:51:31 2021] pxd_read_init: pxd-control-0 init OK 0 devs version 11
[Fri Jan  8 16:52:01 2021] nfsd: last server has exited, flushing export cache
[Fri Jan  8 16:52:01 2021] NFSD: Using /var/lib/nfs/v4recovery as the NFSv4 state recovery directory
[Fri Jan  8 16:52:01 2021] NFSD: starting 90-second grace period (net f0000098)
[Fri Jan  8 16:55:04 2021] Device 855549171283095927 added ffff8f88cbb45800 with mode 0x40002 fastpath 1 npath 1
[Fri Jan  8 16:55:04 2021] device 855549171283095927 setting up fastpath target with mode 0x48002(LARW), paths 1
[Fri Jan  8 16:55:04 2021] For pxd device 855549171283095927 IO suspended
[Fri Jan  8 16:55:04 2021] For pxd device 855549171283095927 IO already suspended(2)
[Fri Jan  8 16:55:04 2021] device 855549171283095927:0, inode 18957 mode 0x48002
[Fri Jan  8 16:55:04 2021] device[855549171283095927:0] is a block device - inode 18957
[Fri Jan  8 16:55:04 2021] For pxd device 855549171283095927 IO still suspended(1)
[Fri Jan  8 16:55:04 2021] pxd_dev 855549171283095927 fastpath 1 mode 0x48002 setting up with 1 backing volumes, [ffff8f88cf69e100,0000000000000000,0000000000000000]
[Fri Jan  8 16:55:04 2021] For pxd device 855549171283095927 IO resumed
[Fri Jan  8 16:55:04 2021] dev855549171283095927 completed setting up 1 paths
[Fri Jan  8 16:55:04 2021] pxd device 855549171283095927: adjusting queue limits nfd 1
[Fri Jan  8 16:55:04 2021] pxd device 855549171283095927 queue limits adjusted with block dev 00000000a362652c(dm-5)
[Fri Jan  8 16:55:17 2021] fp_handle_special _discard supported_ handle discard start 0, nsectors 1928
[Fri Jan  8 16:55:17 2021] fp_handle_special _discard supported_ handle discard start 1928, nsectors 2048
[Fri Jan  8 16:55:17 2021] fp_handle_special _discard supported_ handle discard start 3976, nsectors 120
[Fri Jan  8 16:55:17 2021] fp_handle_special _discard supported_ handle discard start 4096, nsectors 1928
[Fri Jan  8 16:55:17 2021] fp_handle_special _discard supported_ handle discard start 6024, nsectors 2048
[Fri Jan  8 16:55:17 2021] fp_handle_special _discard supported_ handle discard start 8072, nsectors 120
[Fri Jan  8 16:55:17 2021] fp_handle_special _discard supported_ handle discard start 8192, nsectors 1928
[Fri Jan  8 16:55:17 2021] fp_handle_special _discard supported_ handle discard start 10120, nsectors 2048
[Fri Jan  8 16:55:17 2021] fp_handle_special _discard supported_ handle discard start 12168, nsectors 120
[Fri Jan  8 16:55:17 2021] fp_handle_special _discard supported_ handle discard start 12288, nsectors 1928
...
[Fri Jan  8 16:55:17 2021] fp_handle_special _discard supported_ handle discard start 2084864, nsectors 1928
[Fri Jan  8 16:55:17 2021] fp_handle_special _discard supported_ handle discard start 2086792, nsectors 2048
[Fri Jan  8 16:55:17 2021] fp_handle_special _discard supported_ handle discard start 2088840, nsectors 120
[Fri Jan  8 16:55:17 2021] fp_handle_special _discard supported_ handle discard start 2088960, nsectors 1928
[Fri Jan  8 16:55:17 2021] fp_handle_special _discard supported_ handle discard start 2090888, nsectors 2048
[Fri Jan  8 16:55:17 2021] fp_handle_special _discard supported_ handle discard start 2092936, nsectors 120
[Fri Jan  8 16:55:17 2021] fp_handle_special _discard supported_ handle discard start 2093056, nsectors 1928
[Fri Jan  8 16:55:17 2021] fp_handle_special _discard supported_ handle discard start 2094984, nsectors 2048
[Fri Jan  8 16:55:17 2021] fp_handle_special _discard supported_ handle discard start 2097032, nsectors 120
```


# fastpath protocol = iscsi #
For iscsi targets, discard is not supported but only writesame/writezero are.
px-fuse driver now converts discard to supported operation for each backing device.

```
[root@ip-70-0-73-153 px-fuse]# cat /etc/pwx/config.json
{
  "alertingurl": "",
  "clusterid": "testdiscard",
  "dataiface": "eth0",
  "kvdb": [
    "etcd:http://70.0.5.211:2379",
    "etcd:http://70.0.5.212:2379",
    "etcd:http://70.0.5.213:2379"
  ],
  "mgtiface": "eth0",
  "scheduler": "none",
  "secret": {
    "secret_type": "vault",
    "cluster_secret_key": ""
  },
  "storage": {
    "type": "dmthin",
    "fastpath_enable": true,
    "fastpath_protocol": "iscsi",
    "fastpath_secure": true,
    "devices": [
      "/dev/sde",
      "/dev/sdf",
      "/dev/sdg"
    ],
    "cache": [],
    "rt_opts": {},
    "max_storage_nodes_per_zone": 0,
    "journal_dev": "/dev/sdc",
    "system_metadata_dev": "",
    "kvdb_dev": ""
  },
  "version": "1.0"
}
[root@ip-70-0-73-153 px-fuse]# pxctl status
Status: PX is operational
License: Trial (expires in 31 days)
Node ID: 3a965693-f569-472a-9402-0108fbd3ade2
        IP: 70.0.73.153
        Local Storage Pool: 1 pool
        POOL    IO_PRIORITY     RAID_LEVEL      USABLE  USED    STATUS  ZONE    REGION
        0       HIGH            raid0           380 GiB 39 MiB  Online  default default
        Local Storage Devices: 3 devices
        Device  Path            Media Type              Size            Last-Scan
        0:0     /dev/sde        STORAGE_MEDIUM_SSD      128 GiB         08 Jan 21 12:00 UTC
        0:1     /dev/sdf        STORAGE_MEDIUM_SSD      128 GiB         08 Jan 21 12:00 UTC
        0:2     /dev/sdg        STORAGE_MEDIUM_SSD      128 GiB         08 Jan 21 12:00 UTC
        total                   -                       384 GiB
        Cache Devices:
         * No cache devices
        Journal Device:
        1       /dev/sdc1       STORAGE_MEDIUM_SSD
Cluster Summary
        Cluster ID: testdiscard
        Cluster UUID: 0ee2b160-08c0-4fd4-9e7d-b413bd4dc5a7
        Scheduler: none
        Nodes: 2 node(s) with storage (2 online)
        IP              ID                                      SchedulerNodeName       StorageNode     Used    Capacity        Status  StorageStatus   Version         Kernel                 OS
        70.0.74.230     c71fdb55-58e6-410e-b615-a324888cb0d3    N/A                     Yes             39 MiB  380 GiB         Online  Up              3.0.0.0-9bbcd09 4.20.13-1.el7.elrepo.x86_64     CentOS Linux 7 (Core)
        70.0.73.153     3a965693-f569-472a-9402-0108fbd3ade2    N/A                     Yes             39 MiB  380 GiB         Online  Up (This node)  3.0.0.0-9bbcd09 4.20.13-1.el7.elrepo.x86_64     CentOS Linux 7 (Core)
Global Storage Pool
        Total Used      :  78 MiB
        Total Capacity  :  759 GiB
[root@ip-70-0-73-153 px-fuse]# pxctl v c --fastpath --nodes c71fdb55-58e6-410e-b615-a324888cb0d3 -s 10 remoteiscsi
Volume successfully created: 644091672852787036
[root@ip-70-0-73-153 px-fuse]# pxctl host attach remoteiscsi
Volume successfully attached at: /dev/pxd/pxd644091672852787036
[root@ip-70-0-73-153 px-fuse]# pxctl v i -e remoteiscsi
        Volume                   :  644091672852787036
        Name                     :  remoteiscsi
        Size                     :  10 GiB
        Format                   :  ext4
        HA                       :  1
        IO Priority              :  HIGH
        Creation time            :  Jan 8 12:02:55 UTC 2021
        Shared                   :  no
        Status                   :  up
        State                    :  Attached: 3a965693-f569-472a-9402-0108fbd3ade2 (70.0.73.153)
        Last Attached            :  Jan 8 12:03:10 UTC 2021
        Device Path              :  /dev/pxd/pxd644091672852787036
        Mount Options            :  discard
        ScanPolicy               :  repair_on_mount
        ProxyWrite               :  false
        Reads                    :  40
        Reads MS                 :  30
        Bytes Read               :  1060864
        Writes                   :  0
        Writes MS                :  0
        Bytes Written            :  0
        IOs in progress          :  0
        Bytes used               :  132 MiB
        Replica sets on nodes:
                Set 0
                  Node           : 70.0.74.230 (Pool 8a86f4c3-6626-4aca-a818-0ccc97784963 )
        Replication Status       :  Up

        Displaying extended volume state:
        Fastpath preferred      : true
        Fastpath promoted       : true
        Fastpath dirty          : false
        Fastpath attached       : FASTPATH_ACTIVE
        Fastpath coordinator    : 3a965693-f569-472a-9402-0108fbd3ade2
        Fastpath replicas       : 1
        Fastpath replica property follows:
                Replica : 0
                        On Node         : c71fdb55-58e6-410e-b615-a324888cb0d3
                        Protocol        : FASTPATH_PROTO_ISCSI
                        Secure          : true
                        Exported        : true
                                Target  : iqn.2019-08.px.testdiscard:uuid.504f5258-0001-0002-08f0-45f6c32d6f5c
                                Source  : /dev/pwx0/644091672852787036
                                Type    : Block device
                        Imported        : true
                                Mapped local device: /dev/pxfp/pxd644091672852787036-node1
[root@ip-70-0-73-153 px-fuse]# ls -al /dev/pxfp/pxd644091672852787036-node1
lrwxrwxrwx 1 root root 6 Jan  8 12:03 /dev/pxfp/pxd644091672852787036-node1 -> ../sdh
[root@ip-70-0-73-153 px-fuse]# cd /sys/block/sdh/queue/
[root@ip-70-0-73-153 queue]# cat discard_granularity
0 <<<<<====== discard not supported on iscsi device.
[root@ip-70-0-73-153 queue]# cat write_same_max_bytes
33553920 
[root@ip-70-0-73-153 queue]# cat write_zeroes_max_bytes
33553920
[root@ip-70-0-73-153 queue]# cd /sys/block/pxd\!pxd644091672852787036/queue/
[root@ip-70-0-73-153 queue]# cat discard_granularity
4096 <<<<<====== discard supported on px device.
[root@ip-70-0-73-153 queue]# cat write_same_max_bytes
0
[root@ip-70-0-73-153 queue]# cat write_zeroes_max_bytes
0
[root@ip-70-0-73-153 queue]# blkid /dev/pxd/pxd644091672852787036
/dev/pxd/pxd644091672852787036: UUID="d11a68ac-6016-4295-ad71-5b0aebc03924" TYPE="ext4"
[root@ip-70-0-73-153 queue]# fio --direct=1 --bs=2M --size=1G --ioengine=libaio --rw=trim --iodepth=32 --name=/dev/pxd/pxd644091672852787036 --end_fsync=1
/dev/pxd/pxd644091672852787036: (g=0): rw=trim, bs=(R) 2048KiB-2048KiB, (W) 2048KiB-2048KiB, (T) 2048KiB-2048KiB, ioengine=libaio, iodepth=32
fio-3.7
Starting 1 process
Jobs: 1 (f=1): [D(1)][100.0%][r=0KiB/s,w=0KiB/s,t=102MiB/s][r=0,w=0,t=51 IOPS][eta 00m:00s]
/dev/pxd/pxd644091672852787036: (groupid=0, jobs=1): err= 0: pid=24291: Fri Jan  8 12:05:38 2021
   trim: IOPS=51, BW=102MiB/s (107MB/s)(1024MiB/10024msec)
    clat (nsec): min=592, max=35222, avg=1561.60, stdev=1832.13
     lat (usec): min=15961, max=42961, avg=19571.74, stdev=2688.28
    clat percentiles (nsec):
     |  1.00th=[  740],  5.00th=[  860], 10.00th=[  932], 20.00th=[ 1080],
     | 30.00th=[ 1176], 40.00th=[ 1256], 50.00th=[ 1352], 60.00th=[ 1448],
     | 70.00th=[ 1560], 80.00th=[ 1688], 90.00th=[ 1928], 95.00th=[ 2160],
     | 99.00th=[ 8096], 99.50th=[12480], 99.90th=[35072], 99.95th=[35072],
     | 99.99th=[35072]
   bw (  KiB/s): min=81920, max=114688, per=99.85%, avg=104448.00, stdev=6968.90, samples=20
   iops        : min=   40, max=   56, avg=51.00, stdev= 3.40, samples=20
  lat (nsec)   : 750=1.17%, 1000=11.52%
  lat (usec)   : 2=79.49%, 4=6.45%, 10=0.59%, 20=0.59%, 50=0.20%
  cpu          : usr=0.11%, sys=0.09%, ctx=809, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=0,0,512,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=32

Run status group 0 (all jobs):
   TRIM: bw=102MiB/s (107MB/s), 102MiB/s-102MiB/s (107MB/s-107MB/s), io=1024MiB (1074MB), run=10024-10024msec

Disk stats (read/write):
  pxd!pxd644091672852787036: ios=26/0, merge=0/0, ticks=22/18681, in_queue=18903, util=99.35%
[root@ip-70-0-73-153 queue]#

[root@ip-70-0-73-153 queue]# blkid /dev/pxd/pxd644091672852787036
[root@ip-70-0-73-153 queue]#
```




# dmesg with debug logs enabled #
```
[Fri Jan  8 11:58:44 2021] device 499894011720622109 called to disable IO
[Fri Jan  8 11:59:34 2021] Process px-storage pid 20261 parent pid 20134 IO_FLUSHER is set
[Fri Jan  8 12:00:05 2021] md127: detected capacity change from 0 to 411911061504
[Fri Jan  8 12:00:06 2021] XFS (dm-8): Mounting V5 Filesystem
[Fri Jan  8 12:00:06 2021] XFS (dm-8): Ending clean mount
[Fri Jan  8 12:00:07 2021] XFS (dm-8): Unmounting Filesystem
[Fri Jan  8 12:00:07 2021]  sdc:
[Fri Jan  8 12:00:12 2021]  sdc: sdc1
[Fri Jan  8 12:00:23 2021] XFS (dm-8): Mounting V5 Filesystem
[Fri Jan  8 12:00:23 2021] XFS (dm-8): Ending clean mount
[Fri Jan  8 12:00:27 2021] XFS (dm-8): Unmounting Filesystem
[Fri Jan  8 12:00:27 2021] XFS (dm-8): Mounting V5 Filesystem
[Fri Jan  8 12:00:27 2021] XFS (dm-8): Ending clean mount
[Fri Jan  8 12:00:39 2021] Rounding down aligned max_sectors from 4294967295 to 4294967288
[Fri Jan  8 12:00:39 2021] iscsi: registered transport (tcp)
[Fri Jan  8 12:00:45 2021] XFS (dm-8): Unmounting Filesystem
[Fri Jan  8 12:00:45 2021] XFS (dm-8): Mounting V5 Filesystem
[Fri Jan  8 12:00:45 2021] XFS (dm-8): Ending clean mount
[Fri Jan  8 12:00:47 2021] pxd_vm_open off 0 start 139982933049344 end 139982954024960
[Fri Jan  8 12:00:47 2021] pxd_vm_open off 0 start 139982933049344 end 139982954024960
[Fri Jan  8 12:00:47 2021] io_uring_vm_close
[Fri Jan  8 12:00:51 2021] read 0 write 0 sequence 8427
[Fri Jan  8 12:00:51 2021] read 0 write 0 sequence 8427
[Fri Jan  8 12:00:51 2021] device 499894011720622109 called to enable IO
[Fri Jan  8 12:00:51 2021] pxd_control_open: pxd-control-0(2) open OK
[Fri Jan  8 12:00:51 2021] pxd_vm_open 0 off 0 start 139982897385472 end 139982916263936
[Fri Jan  8 12:00:51 2021] pxd_read_init: pxd-control-0 init OK 1 devs version 11
[Fri Jan  8 12:00:51 2021] nfsd: last server has exited, flushing export cache
[Fri Jan  8 12:00:51 2021] NFSD: starting 90-second grace period (net f0000098)
[Fri Jan  8 12:02:56 2021] scsi host3: iSCSI Initiator over TCP/IP
[Fri Jan  8 12:02:56 2021] scsi 3:0:0:0: Direct-Access     LIO-ORG  IBLOCK           4.0  PQ: 0 ANSI: 5
[Fri Jan  8 12:02:56 2021] scsi 3:0:0:0: alua: supports implicit and explicit TPGS
[Fri Jan  8 12:02:56 2021] scsi 3:0:0:0: alua: device naa.6001405504f52580001000208f045f6c port group 0 rel port 1
[Fri Jan  8 12:02:56 2021] sd 3:0:0:0: Attached scsi generic sg7 type 0
[Fri Jan  8 12:02:56 2021] sd 3:0:0:0: [sdh] 20971520 512-byte logical blocks: (10.7 GB/10.0 GiB)
[Fri Jan  8 12:02:56 2021] sd 3:0:0:0: [sdh] Write Protect is off
[Fri Jan  8 12:02:56 2021] sd 3:0:0:0: [sdh] Mode Sense: 43 00 10 08
[Fri Jan  8 12:02:56 2021] sd 3:0:0:0: [sdh] Write cache: enabled, read cache: enabled, supports DPO and FUA
[Fri Jan  8 12:02:56 2021] sd 3:0:0:0: alua: transition timeout set to 60 seconds
[Fri Jan  8 12:02:56 2021] sd 3:0:0:0: alua: port group 00 state A non-preferred supports TOlUSNA
[Fri Jan  8 12:02:56 2021] sd 3:0:0:0: [sdh] Attached SCSI disk
[Fri Jan  8 12:02:56 2021] Device 644091672852787036 added ffff888234cfa000 with mode 0x40002 fastpath 1 npath 1
[Fri Jan  8 12:02:56 2021] device 644091672852787036 setting up fastpath target with mode 0x48002(LARW), paths 1
[Fri Jan  8 12:02:56 2021] For pxd device 644091672852787036 IO suspended
[Fri Jan  8 12:02:56 2021] For pxd device 644091672852787036 IO already suspended(2)
[Fri Jan  8 12:02:56 2021] device 644091672852787036:0, inode 31627588 mode 0x48002
[Fri Jan  8 12:02:56 2021] device[644091672852787036:0] is a block device - inode 31627588
[Fri Jan  8 12:02:56 2021] For pxd device 644091672852787036 IO still suspended(1)
[Fri Jan  8 12:02:56 2021] pxd_dev 644091672852787036 fastpath 1 mode 0x48002 setting up with 1 backing volumes, [ffff888104e1de00,0000000000000000,0000000000000000]
[Fri Jan  8 12:02:56 2021] For pxd device 644091672852787036 IO resumed
[Fri Jan  8 12:02:56 2021] dev644091672852787036 completed setting up 1 paths
[Fri Jan  8 12:02:56 2021] pxd device 644091672852787036: adjusting queue limits nfd 1
[Fri Jan  8 12:02:56 2021] pxd device 644091672852787036 queue limits adjusted with block dev 000000001e2e5238(sdh)
[Fri Jan  8 12:02:57 2021] For pxd device 644091672852787036 IO suspended
[Fri Jan  8 12:02:57 2021] For pxd device 644091672852787036 IO resumed
[Fri Jan  8 12:02:57 2021] sd 3:0:0:0: [sdh] Synchronizing SCSI cache
[Fri Jan  8 12:02:57 2021] scsi 3:0:0:0: alua: Detached
[Fri Jan  8 12:03:10 2021] scsi host3: iSCSI Initiator over TCP/IP
[Fri Jan  8 12:03:10 2021] scsi 3:0:0:0: Direct-Access     LIO-ORG  IBLOCK           4.0  PQ: 0 ANSI: 5
[Fri Jan  8 12:03:10 2021] scsi 3:0:0:0: alua: supports implicit and explicit TPGS
[Fri Jan  8 12:03:10 2021] scsi 3:0:0:0: alua: device naa.6001405504f52580001000208f045f6c port group 0 rel port 1
[Fri Jan  8 12:03:10 2021] sd 3:0:0:0: Attached scsi generic sg7 type 0
[Fri Jan  8 12:03:10 2021] sd 3:0:0:0: [sdh] 20971520 512-byte logical blocks: (10.7 GB/10.0 GiB)
[Fri Jan  8 12:03:10 2021] sd 3:0:0:0: [sdh] Write Protect is off
[Fri Jan  8 12:03:10 2021] sd 3:0:0:0: [sdh] Mode Sense: 43 00 10 08
[Fri Jan  8 12:03:10 2021] sd 3:0:0:0: [sdh] Write cache: enabled, read cache: enabled, supports DPO and FUA
[Fri Jan  8 12:03:10 2021] sd 3:0:0:0: alua: transition timeout set to 60 seconds
[Fri Jan  8 12:03:10 2021] sd 3:0:0:0: alua: port group 00 state A non-preferred supports TOlUSNA
[Fri Jan  8 12:03:10 2021] sd 3:0:0:0: [sdh] Attached SCSI disk
[Fri Jan  8 12:03:10 2021] Device 644091672852787036 added ffff888234cfa800 with mode 0x40002 fastpath 1 npath 1
[Fri Jan  8 12:03:10 2021] device 644091672852787036 setting up fastpath target with mode 0x48002(LARW), paths 1
[Fri Jan  8 12:03:10 2021] For pxd device 644091672852787036 IO suspended
[Fri Jan  8 12:03:10 2021] For pxd device 644091672852787036 IO already suspended(2)
[Fri Jan  8 12:03:10 2021] device 644091672852787036:0, inode 31627800 mode 0x48002
[Fri Jan  8 12:03:10 2021] device[644091672852787036:0] is a block device - inode 31627800
[Fri Jan  8 12:03:10 2021] For pxd device 644091672852787036 IO still suspended(1)
[Fri Jan  8 12:03:10 2021] pxd_dev 644091672852787036 fastpath 1 mode 0x48002 setting up with 1 backing volumes, [ffff88811e812f00,0000000000000000,0000000000000000]
[Fri Jan  8 12:03:10 2021] For pxd device 644091672852787036 IO resumed
[Fri Jan  8 12:03:10 2021] dev644091672852787036 completed setting up 1 paths
[Fri Jan  8 12:03:10 2021] pxd device 644091672852787036: adjusting queue limits nfd 1
[Fri Jan  8 12:03:10 2021] pxd device 644091672852787036 queue limits adjusted with block dev 00000000c7e96d68(sdh)
[Fri Jan  8 12:05:27 2021] fp_handle_special _writesame_ handle discard start 0, nsectors 2048
[Fri Jan  8 12:05:27 2021] fp_handle_special _writesame_ handle discard start 2048, nsectors 2048
[Fri Jan  8 12:05:27 2021] fp_handle_special _writesame_ handle discard start 4096, nsectors 2048
[Fri Jan  8 12:05:27 2021] fp_handle_special _writesame_ handle discard start 6144, nsectors 2048
[Fri Jan  8 12:05:27 2021] fp_handle_special _writesame_ handle discard start 8192, nsectors 2048
[Fri Jan  8 12:05:27 2021] fp_handle_special _writesame_ handle discard start 10240, nsectors 2048
[Fri Jan  8 12:05:27 2021] fp_handle_special _writesame_ handle discard start 12288, nsectors 2048
[Fri Jan  8 12:05:27 2021] fp_handle_special _writesame_ handle discard start 14336, nsectors 2048
[Fri Jan  8 12:05:27 2021] fp_handle_special _writesame_ handle discard start 16384, nsectors 2048
[Fri Jan  8 12:05:27 2021] fp_handle_special _writesame_ handle discard start 18432, nsectors 2048
[Fri Jan  8 12:05:27 2021] fp_handle_special _writesame_ handle discard start 20480, nsectors 2048
[Fri Jan  8 12:05:27 2021] fp_handle_special _writesame_ handle discard start 22528, nsectors 2048
[Fri Jan  8 12:05:27 2021] fp_handle_special _writesame_ handle discard start 24576, nsectors 2048
[Fri Jan  8 12:05:27 2021] fp_handle_special _writesame_ handle discard start 26624, nsectors 2048
...
[Fri Jan  8 12:05:37 2021] fp_handle_special _writesame_ handle discard start 2062336, nsectors 2048
[Fri Jan  8 12:05:37 2021] fp_handle_special _writesame_ handle discard start 2064384, nsectors 2048
[Fri Jan  8 12:05:37 2021] fp_handle_special _writesame_ handle discard start 2066432, nsectors 2048
[Fri Jan  8 12:05:37 2021] fp_handle_special _writesame_ handle discard start 2068480, nsectors 2048
[Fri Jan  8 12:05:37 2021] fp_handle_special _writesame_ handle discard start 2070528, nsectors 2048
[Fri Jan  8 12:05:37 2021] fp_handle_special _writesame_ handle discard start 2072576, nsectors 2048
[Fri Jan  8 12:05:37 2021] fp_handle_special _writesame_ handle discard start 2074624, nsectors 2048
[Fri Jan  8 12:05:37 2021] fp_handle_special _writesame_ handle discard start 2076672, nsectors 2048
[Fri Jan  8 12:05:37 2021] fp_handle_special _writesame_ handle discard start 2078720, nsectors 2048
[Fri Jan  8 12:05:37 2021] fp_handle_special _writesame_ handle discard start 2080768, nsectors 2048
[Fri Jan  8 12:05:37 2021] fp_handle_special _writesame_ handle discard start 2082816, nsectors 2048
[Fri Jan  8 12:05:37 2021] fp_handle_special _writesame_ handle discard start 2084864, nsectors 2048
[Fri Jan  8 12:05:37 2021] fp_handle_special _writesame_ handle discard start 2086912, nsectors 2048
[Fri Jan  8 12:05:37 2021] fp_handle_special _writesame_ handle discard start 2088960, nsectors 2048
[Fri Jan  8 12:05:37 2021] fp_handle_special _writesame_ handle discard start 2091008, nsectors 2048
[Fri Jan  8 12:05:37 2021] fp_handle_special _writesame_ handle discard start 2093056, nsectors 2048
[Fri Jan  8 12:05:37 2021] fp_handle_special _writesame_ handle discard start 2095104, nsectors 2048
```