### PR TITLE
address recursive fc->lock path

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -2145,9 +2145,7 @@ static void pxd_abort_context(struct work_struct *work)
 	/* Let other threads see the value of allow_disconnected. */
 	synchronize_rcu();
 
-	spin_lock(&fc->lock);
 	fuse_end_queued_requests(fc);
-	spin_unlock(&fc->lock);
 	pxdctx_set_connected(ctx, false);
 }
 


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

Active IO to px device, px goes down and stays down, abort handler gets run.
In which case, it is possible for a recursive fc->lock to be taken.
pxd_abort_context(fc->lock)->fuse_end_queued_requests->request_end->fuse_put_unique(fc->lock)

fc->lock need not be taken while running pxd_abort_context, micro operations that work on 'fc' takes the lock appropriately.
if px were to come back again, there is a cancel_delayed_work_sync first up that ensures abort handler is not running.
And new requests that are received while px is disconnected are like wise handled with fc->lock taken for each micro ops.
No need to take this lock globally while running abort handler.

PWX BUG: https://portworx.atlassian.net/browse/PWX-18262

```
Jan 18 07:49:19 localhost kernel: queued_spin_lock_slowpath+0xb/0x13
Jan 18 07:49:19 localhost kernel: _raw_spin_lock+0x23/0x30
Jan 18 07:49:19 localhost kernel: request_end+0x97/0x110 [px]
Jan 18 07:49:19 localhost kernel: fuse_end_queued_requests+0x2c/0x90 [px]
Jan 18 07:49:19 localhost kernel: pxd_abort_context+0x57/0x80 [px]
Jan 18 07:49:19 localhost kernel: process_one_work+0x179/0x390
Jan 18 07:49:19 localhost kernel: worker_thread+0x4f/0x3e0
Jan 18 07:49:19 localhost kernel: kthread+0x105/0x140
Jan 18 07:49:19 localhost kernel: ? max_active_store+0x80/0x80
Jan 18 07:49:19 localhost kernel: ? kthread_bind+0x20/0x20
Jan 18 07:49:19 localhost kernel: ret_from_fork+0x35/0x40
Jan 18 07:49:20 localhost kernel: EXT4-fs warning: 15 callbacks suppressed
```