### PR TITLE
Centos 8 Stream 4.18.0-257 contains kernel 5.x backports and added ne…

### DIFF
--- a/io.c
+++ b/io.c
@@ -1138,7 +1138,7 @@ static int io_syncfs(struct io_kiocb *req, const struct sqe_submit *s,
 		up_read(&sb->s_umount);
 	} else if (S_ISBLK(inode->i_mode)) {
 		struct block_device *bdev = I_BDEV(inode);
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,8,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,8,0) &&  !defined(QUEUE_FLAG_NOWAIT)
 		ret = blkdev_issue_flush(bdev, GFP_KERNEL, NULL);
 #else
 		ret = blkdev_issue_flush(bdev, GFP_KERNEL);


### PR DESCRIPTION
…w interface blk_alloc_queue_rh. Add explicit check for this api for now.

Note:  The new api which is added/changed  is called `blk_alloc_queue_rh()`.  Previously it was blk_alloc_queue().  Since this API does not exist in any mainline kernel  tree I assume it was added only by Redhat/Centos.  The `QUEUE_FLAG_NOWAIT` define was added in 5.10 and does not exist in any 4.18.0 version except -257 and above.   So I am doing explicit check for this (ie.  Ver == 4.18.0 & EL8 & QUEUE_FLAG_NOWAIT) assume this Redhat/Centos 4.18.0-257 and above.