### PR TITLE
compilation fixes upto 5.10 kernel

### DIFF
--- a/io.c
+++ b/io.c
@@ -762,8 +762,13 @@ static int io_write(struct io_kiocb *req, const struct sqe_submit *s,
 	 * we return to userspace.
 	 */
 	if (S_ISREG(file_inode(file)->i_mode)) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
+		__sb_start_write(file_inode(file)->i_sb,
+			SB_FREEZE_WRITE);
+#else
 		__sb_start_write(file_inode(file)->i_sb,
 			SB_FREEZE_WRITE, true);
+#endif
 		__sb_writers_release(file_inode(file)->i_sb,
 			SB_FREEZE_WRITE);
 	}
@@ -1027,8 +1032,13 @@ static int io_switch(struct io_kiocb *req, const struct sqe_submit *s,
 		 * we return to userspace.
 		 */
 		if (S_ISREG(file_inode(file)->i_mode)) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
+			__sb_start_write(file_inode(file)->i_sb,
+				SB_FREEZE_WRITE);
+#else
 			__sb_start_write(file_inode(file)->i_sb,
 				SB_FREEZE_WRITE, true);
+#endif
 			__sb_writers_release(file_inode(file)->i_sb,
 				SB_FREEZE_WRITE);
 		}

--- a/io.c
+++ b/io.c
@@ -1567,8 +1567,12 @@ restart:
 #else
 				kthread_use_mm(cur_mm);
 #endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
+				old_fs = force_uaccess_begin();
+#else
 				old_fs = get_fs();
 				set_fs(USER_DS);
+#endif
 			}
 		}
 
@@ -1648,7 +1652,11 @@ restart:
 	}
 
 	if (cur_mm) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
+		force_uaccess_end(old_fs);
+#else
 		set_fs(old_fs);
+#endif
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,8,0)
 		unuse_mm(cur_mm);
 #else
@@ -1910,8 +1918,13 @@ static int io_sq_thread(void *data)
 	unsigned inflight;
 	unsigned long timeout;
 
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
+	old_fs = force_uaccess_begin();
+#else
 	old_fs = get_fs();
 	set_fs(USER_DS);
+#endif
 
 	timeout = inflight = 0;
 	while (!kthread_should_park()) {
@@ -2013,7 +2026,11 @@ static int io_sq_thread(void *data)
 		io_commit_sqring(ctx);
 	}
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
+	force_uaccess_end(old_fs);
+#else
 	set_fs(old_fs);
+#endif
 	if (cur_mm) {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,8,0)
 		unuse_mm(cur_mm);

--- a/pxd.c
+++ b/pxd.c
@@ -380,7 +380,7 @@ static const struct block_device_operations pxd_bd_ops = {
 	.open			= pxd_open,
 	.release		= pxd_release,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
-	.submit_io		= pxd_make_request_fastpath,
+	.submit_bio		= pxd_make_request_fastpath,
 #endif
 };
 
@@ -1452,8 +1452,12 @@ ssize_t pxd_ioc_update_size(struct fuse_conn *fc, struct pxd_update_size *update
 	set_capacity(pxd_dev->disk, update_size->size / SECTOR_SIZE);
 	spin_unlock(&pxd_dev->lock);
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
+	revalidate_disk_size(pxd_dev->disk, true);
+#else
 	err = revalidate_disk(pxd_dev->disk);
 	BUG_ON(err);
+#endif
 	put_device(&pxd_dev->dev);
 
 	return 0;

--- a/pxd.c
+++ b/pxd.c
@@ -597,7 +597,7 @@ int pxd_handle_device_limits(struct fuse_req *req, uint32_t *size, uint64_t *off
 		}
 
 		bio_chain(b, req->bio);
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(5,9,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,9,0)
 		generic_make_request(b);
 #else
 		submit_bio_noacct(b);

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -65,7 +65,7 @@
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
 #define BIO_ENDIO(bio, err) do {                \
-    bio->bi_status = err;                       \
+    (bio)->bi_status = err;                       \
     bio_endio(bio);                             \
 } while (0)
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -220,10 +220,10 @@ static int _pxd_bio_discard(struct pxd_device *pxd_dev, struct file *file, struc
 static int _pxd_write(uint64_t dev_id, struct file *file, struct bio_vec *bvec, loff_t *pos)
 {
 	ssize_t bw;
-	mm_segment_t old_fs = get_fs();
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
 	struct iov_iter i;
 #else
+	mm_segment_t old_fs = get_fs();
 	void *kaddr = kmap(bvec->bv_page) + bvec->bv_offset;
 #endif
 
@@ -233,7 +233,6 @@ static int _pxd_write(uint64_t dev_id, struct file *file, struct bio_vec *bvec, 
 	if (unlikely(bvec->bv_len != PXD_LBS)) {
 		printk(KERN_ERR"Unaligned block writes %d bytes\n", bvec->bv_len);
 	}
-	set_fs(KERNEL_DS);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,20,0)
 	iov_iter_bvec(&i, WRITE, bvec, 1, bvec->bv_len);
 	file_start_write(file);
@@ -250,10 +249,11 @@ static int _pxd_write(uint64_t dev_id, struct file *file, struct bio_vec *bvec, 
 	bw = vfs_iter_write(file, &i, pos);
 	file_end_write(file);
 #else
+	set_fs(KERNEL_DS);
 	bw = vfs_write(file, kaddr, bvec->bv_len, pos);
 	kunmap(bvec->bv_page);
-#endif
 	set_fs(old_fs);
+#endif
 
 	if (likely(bw == bvec->bv_len)) {
 		return 0;
@@ -1360,8 +1360,8 @@ out_file_failed:
 
 /* fast path make request function, io entry point */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
-blk_qc_t pxd_make_request_fastpath(struct bio *bio)
 #define BLK_QC_RETVAL BLK_QC_T_NONE
+blk_qc_t pxd_make_request_fastpath(struct bio *bio)
 {
 	struct request_queue *q = bio->bi_disk->queue;
 	struct pxd_device *pxd_dev = bio->bi_disk->private_data;

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -533,7 +533,7 @@ static void pxd_complete_io(struct bio* bio, int error)
 	// debug condition for force fail
 	if (pxd_dev->fp.force_fail) blkrc = -EIO;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,1)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
 	bio_end_io_acct(bio, iot->start);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0) || \
     (LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0) &&  \
@@ -1361,6 +1361,7 @@ out_file_failed:
 /* fast path make request function, io entry point */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
 blk_qc_t pxd_make_request_fastpath(struct bio *bio)
+#define BLK_QC_RETVAL BLK_QC_T_NONE
 {
 	struct request_queue *q = bio->bi_disk->queue;
 	struct pxd_device *pxd_dev = bio->bi_disk->private_data;
@@ -1492,7 +1493,7 @@ void pxd_make_request_fastpath(struct request_queue *q, struct bio *bio)
 		return BLK_QC_RETVAL;
 	}
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,1)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
 	head->start = bio_start_io_acct(bio);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0) || \
     (LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0) && \


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

https://portworx.atlassian.net/browse/PWX-18535

In the common IO path, few compilation fixes for 5.9/5.10 kernel. 
compilation passed in the following kernels. logs below.
```
[root@ip-70-0-39-218 ~]# ls !$
ls /usr/src/kernels/
4.14.186-146.268.amzn2.x86_64  4.18.0-193.23.1.el8_2.x86_64      4.18.0-80.1.2.el8_0.x86_64   5.7.0-1.el7.elrepo.x86_64  5.9.0-1.el7.elrepo.x86_64
4.18.0-147.20.1.el8_1.x86_64   4.18.0-193.24.1.el8_2.dt1.x86_64  5.10.0-1.el7.elrepo.x86_64   5.7.0-1.el8.elrepo.x86_64  5.9.0-1.el8.elrepo.x86_64
4.18.0-147.el8.x86_64          4.18.0-193.el8.x86_64             5.10.0-1.el8.elrepo.x86_64   5.8.0-1.el7.elrepo.x86_64
4.18.0-193.14.2.el8_2.x86_64   4.18.0-80.11.1.el8_0.x86_64       5.10.15-1.el7.elrepo.x86_64  5.8.0-1.el8.elrepo.x86_64
[root@ip-70-0-39-218 ~]#

```


```
[root@ip-70-0-39-218 wip]# sudo /usr/bin/docker run --rm --name px-dev-shell  -it --entrypoint=/bin/bash --net=host --privileged=true -v /run/docker/plugins:/run/docker/plugins -v /var/lib/osd:/var/lib/osd:shared -v /dev:/dev -v /etc/pwx:/etc/pwx -v /opt/pwx/bin:/export_bin:shared -v /var/run/docker.sock:/var/run/docker.sock -v /var/cores:/var/cores -v /usr/src:/usr/src -v /lib/modules:/lib/modules -v /root/Workspace/Dev/src/github.com/portworx/porx/wip:/home/wip docker.io/portworx/px-base-enterprise:2.7.0
root@ip-70-0-39-218:/# cd home/wip/
root@ip-70-0-39-218:/home/wip# FORCE_CONTAINER_CC=gcc-8 KERNELPATH=/usr/src/kernels/5.10.15-1.el7.elrepo.x86_64/ make clean all
Kernel version 5.10 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.10.15-1.el7.elrepo.x86_64 need minimum 3.10
make -C /usr/src/kernels/5.10.15-1.el7.elrepo.x86_64/  M=/home/wip clean
make[1]: Entering directory '/usr/src/kernels/5.10.15-1.el7.elrepo.x86_64'
Kernel version 5.10 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.10.15-1.el7.elrepo.x86_64 need minimum 3.10
make[1]: Leaving directory '/usr/src/kernels/5.10.15-1.el7.elrepo.x86_64'
make: git: Command not found
make: git: Command not found
echo "const char *gitversion = \":\";" > px_version.c
make CC=gcc-8 -C /usr/src/kernels/5.10.15-1.el7.elrepo.x86_64/  M=/home/wip modules
make[1]: Entering directory '/usr/src/kernels/5.10.15-1.el7.elrepo.x86_64'
Kernel version 5.10 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.10.15-1.el7.elrepo.x86_64 need minimum 3.10
  CC [M]  /home/wip/pxd.o
  CC [M]  /home/wip/dev.o
  CC [M]  /home/wip/iov_iter.o
  CC [M]  /home/wip/px_version.o
  CC [M]  /home/wip/io.o
  CC [M]  /home/wip/pxd_fastpath.o
  LD [M]  /home/wip/px.o
Kernel version 5.10 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.10.15-1.el7.elrepo.x86_64 need minimum 3.10
  MODPOST /home/wip/Module.symvers
  CC [M]  /home/wip/px.mod.o
  LD [M]  /home/wip/px.ko
make[1]: Leaving directory '/usr/src/kernels/5.10.15-1.el7.elrepo.x86_64'
root@ip-70-0-39-218:/home/wip# FORCE_CONTAINER_CC=gcc-8 KERNELPATH=/usr/src/kernels/5.10.15-1.el8.elrepo.x86_64/ make clean all
Makefile:28: *** Kernel path: /usr/src/kernels/5.10.15-1.el8.elrepo.x86_64/  directory does not exist..  Stop.
root@ip-70-0-39-218:/home/wip# FORCE_CONTAINER_CC=gcc-8 KERNELPATH=/usr/src/kernels/5.10.0-1.el8.elrepo.x86_64 make clean all
Kernel version 5.10 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.10.0-1.el8.elrepo.x86_64 need minimum 3.10
make -C /usr/src/kernels/5.10.0-1.el8.elrepo.x86_64  M=/home/wip clean
make[1]: Entering directory '/usr/src/kernels/5.10.0-1.el8.elrepo.x86_64'
Kernel version 5.10 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.10.0-1.el8.elrepo.x86_64 need minimum 3.10
  CLEAN   /home/wip/Module.symvers
make[1]: Leaving directory '/usr/src/kernels/5.10.0-1.el8.elrepo.x86_64'
make CC=gcc-8 -C /usr/src/kernels/5.10.0-1.el8.elrepo.x86_64  M=/home/wip modules
make[1]: Entering directory '/usr/src/kernels/5.10.0-1.el8.elrepo.x86_64'
Kernel version 5.10 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.10.0-1.el8.elrepo.x86_64 need minimum 3.10
  CC [M]  /home/wip/pxd.o
  CC [M]  /home/wip/dev.o
  CC [M]  /home/wip/iov_iter.o
  CC [M]  /home/wip/px_version.o
  CC [M]  /home/wip/io.o
  CC [M]  /home/wip/pxd_fastpath.o
  LD [M]  /home/wip/px.o
Kernel version 5.10 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.10.0-1.el8.elrepo.x86_64 need minimum 3.10
  MODPOST /home/wip/Module.symvers
  CC [M]  /home/wip/px.mod.o
  LD [M]  /home/wip/px.ko
make[1]: Leaving directory '/usr/src/kernels/5.10.0-1.el8.elrepo.x86_64'
root@ip-70-0-39-218:/home/wip# FORCE_CONTAINER_CC=gcc-8 KERNELPATH=/usr/src/kernels/5.10.0-1.el7.elrepo.x86_64 make clean all
Kernel version 5.10 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.10.0-1.el7.elrepo.x86_64 need minimum 3.10
make -C /usr/src/kernels/5.10.0-1.el7.elrepo.x86_64  M=/home/wip clean
make[1]: Entering directory '/usr/src/kernels/5.10.0-1.el7.elrepo.x86_64'
Kernel version 5.10 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.10.0-1.el7.elrepo.x86_64 need minimum 3.10
  CLEAN   /home/wip/Module.symvers
make[1]: Leaving directory '/usr/src/kernels/5.10.0-1.el7.elrepo.x86_64'
make CC=gcc-8 -C /usr/src/kernels/5.10.0-1.el7.elrepo.x86_64  M=/home/wip modules
make[1]: Entering directory '/usr/src/kernels/5.10.0-1.el7.elrepo.x86_64'
Kernel version 5.10 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.10.0-1.el7.elrepo.x86_64 need minimum 3.10
  CC [M]  /home/wip/pxd.o
  CC [M]  /home/wip/dev.o
  CC [M]  /home/wip/iov_iter.o
  CC [M]  /home/wip/px_version.o
  CC [M]  /home/wip/io.o
  CC [M]  /home/wip/pxd_fastpath.o
  LD [M]  /home/wip/px.o
Kernel version 5.10 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.10.0-1.el7.elrepo.x86_64 need minimum 3.10
  MODPOST /home/wip/Module.symvers
  CC [M]  /home/wip/px.mod.o
  LD [M]  /home/wip/px.ko
make[1]: Leaving directory '/usr/src/kernels/5.10.0-1.el7.elrepo.x86_64'
root@ip-70-0-39-218:/home/wip# FORCE_CONTAINER_CC=gcc-8 KERNELPATH=/usr/src/kernels/5.7.0-1.el7.elrepo.x86_64 make clean all
Kernel version 5.7 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.7.0-1.el7.elrepo.x86_64 need minimum 3.10
make -C /usr/src/kernels/5.7.0-1.el7.elrepo.x86_64  M=/home/wip clean
make[1]: Entering directory '/usr/src/kernels/5.7.0-1.el7.elrepo.x86_64'
Kernel version 5.7 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.7.0-1.el7.elrepo.x86_64 need minimum 3.10
  CLEAN   /home/wip/Module.symvers
make[1]: Leaving directory '/usr/src/kernels/5.7.0-1.el7.elrepo.x86_64'
make CC=gcc-8 -C /usr/src/kernels/5.7.0-1.el7.elrepo.x86_64  M=/home/wip modules
make[1]: Entering directory '/usr/src/kernels/5.7.0-1.el7.elrepo.x86_64'
Kernel version 5.7 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.7.0-1.el7.elrepo.x86_64 need minimum 3.10
  CC [M]  /home/wip/pxd.o
  CC [M]  /home/wip/dev.o
  CC [M]  /home/wip/iov_iter.o
  CC [M]  /home/wip/px_version.o
  CC [M]  /home/wip/io.o
  CC [M]  /home/wip/pxd_fastpath.o
  LD [M]  /home/wip/px.o
Kernel version 5.7 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.7.0-1.el7.elrepo.x86_64 need minimum 3.10
  MODPOST 1 modules
  CC [M]  /home/wip/px.mod.o
  LD [M]  /home/wip/px.ko
make[1]: Leaving directory '/usr/src/kernels/5.7.0-1.el7.elrepo.x86_64'
root@ip-70-0-39-218:/home/wip# FORCE_CONTAINER_CC=gcc-8 KERNELPATH=/usr/src/kernels/5.7.0-1.el8.elrepo.x86_64 make clean all
Kernel version 5.7 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.7.0-1.el8.elrepo.x86_64 need minimum 3.10
make -C /usr/src/kernels/5.7.0-1.el8.elrepo.x86_64  M=/home/wip clean
make[1]: Entering directory '/usr/src/kernels/5.7.0-1.el8.elrepo.x86_64'
Kernel version 5.7 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.7.0-1.el8.elrepo.x86_64 need minimum 3.10
  CLEAN   /home/wip/Module.symvers
make[1]: Leaving directory '/usr/src/kernels/5.7.0-1.el8.elrepo.x86_64'
make CC=gcc-8 -C /usr/src/kernels/5.7.0-1.el8.elrepo.x86_64  M=/home/wip modules
make[1]: Entering directory '/usr/src/kernels/5.7.0-1.el8.elrepo.x86_64'
Kernel version 5.7 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.7.0-1.el8.elrepo.x86_64 need minimum 3.10
  CC [M]  /home/wip/pxd.o
  CC [M]  /home/wip/dev.o
  CC [M]  /home/wip/iov_iter.o
  CC [M]  /home/wip/px_version.o
  CC [M]  /home/wip/io.o
  CC [M]  /home/wip/pxd_fastpath.o
  LD [M]  /home/wip/px.o
Kernel version 5.7 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.7.0-1.el8.elrepo.x86_64 need minimum 3.10
  MODPOST 1 modules
  CC [M]  /home/wip/px.mod.o
  LD [M]  /home/wip/px.ko
make[1]: Leaving directory '/usr/src/kernels/5.7.0-1.el8.elrepo.x86_64'
root@ip-70-0-39-218:/home/wip# FORCE_CONTAINER_CC=gcc-8 KERNELPATH=/usr/src/kernels/5.8.0-1.el7.elrepo.x86_64 make clean all
Kernel version 5.8 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.8.0-1.el7.elrepo.x86_64 need minimum 3.10
make -C /usr/src/kernels/5.8.0-1.el7.elrepo.x86_64  M=/home/wip clean
make[1]: Entering directory '/usr/src/kernels/5.8.0-1.el7.elrepo.x86_64'
Kernel version 5.8 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.8.0-1.el7.elrepo.x86_64 need minimum 3.10
  CLEAN   /home/wip/Module.symvers
make[1]: Leaving directory '/usr/src/kernels/5.8.0-1.el7.elrepo.x86_64'
make CC=gcc-8 -C /usr/src/kernels/5.8.0-1.el7.elrepo.x86_64  M=/home/wip modules
make[1]: Entering directory '/usr/src/kernels/5.8.0-1.el7.elrepo.x86_64'
Kernel version 5.8 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.8.0-1.el7.elrepo.x86_64 need minimum 3.10
  CC [M]  /home/wip/pxd.o
  CC [M]  /home/wip/dev.o
  CC [M]  /home/wip/iov_iter.o
  CC [M]  /home/wip/px_version.o
  CC [M]  /home/wip/io.o
  CC [M]  /home/wip/pxd_fastpath.o
  LD [M]  /home/wip/px.o
Kernel version 5.8 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.8.0-1.el7.elrepo.x86_64 need minimum 3.10
  MODPOST /home/wip/Module.symvers
  CC [M]  /home/wip/px.mod.o
  LD [M]  /home/wip/px.ko
make[1]: Leaving directory '/usr/src/kernels/5.8.0-1.el7.elrepo.x86_64'
root@ip-70-0-39-218:/home/wip# FORCE_CONTAINER_CC=gcc-8 KERNELPATH=/usr/src/kernels/5.8.0-1.el8.elrepo.x86_64 make clean all
Kernel version 5.8 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.8.0-1.el8.elrepo.x86_64 need minimum 3.10
make -C /usr/src/kernels/5.8.0-1.el8.elrepo.x86_64  M=/home/wip clean
make[1]: Entering directory '/usr/src/kernels/5.8.0-1.el8.elrepo.x86_64'
Kernel version 5.8 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.8.0-1.el8.elrepo.x86_64 need minimum 3.10
  CLEAN   /home/wip/Module.symvers
make[1]: Leaving directory '/usr/src/kernels/5.8.0-1.el8.elrepo.x86_64'
make CC=gcc-8 -C /usr/src/kernels/5.8.0-1.el8.elrepo.x86_64  M=/home/wip modules
make[1]: Entering directory '/usr/src/kernels/5.8.0-1.el8.elrepo.x86_64'
Kernel version 5.8 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.8.0-1.el8.elrepo.x86_64 need minimum 3.10
  CC [M]  /home/wip/pxd.o
  CC [M]  /home/wip/dev.o
  CC [M]  /home/wip/iov_iter.o
  CC [M]  /home/wip/px_version.o
  CC [M]  /home/wip/io.o
  CC [M]  /home/wip/pxd_fastpath.o
  LD [M]  /home/wip/px.o
Kernel version 5.8 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.8.0-1.el8.elrepo.x86_64 need minimum 3.10
  MODPOST /home/wip/Module.symvers
  CC [M]  /home/wip/px.mod.o
  LD [M]  /home/wip/px.ko
make[1]: Leaving directory '/usr/src/kernels/5.8.0-1.el8.elrepo.x86_64'
root@ip-70-0-39-218:/home/wip# FORCE_CONTAINER_CC=gcc-8 KERNELPATH=/usr/src/kernels/5.9.0-1.el7.elrepo.x86_64 make clean all
Kernel version 5.9 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.9.0-1.el7.elrepo.x86_64 need minimum 3.10
make -C /usr/src/kernels/5.9.0-1.el7.elrepo.x86_64  M=/home/wip clean
make[1]: Entering directory '/usr/src/kernels/5.9.0-1.el7.elrepo.x86_64'
Kernel version 5.9 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.9.0-1.el7.elrepo.x86_64 need minimum 3.10
  CLEAN   /home/wip/Module.symvers
make[1]: Leaving directory '/usr/src/kernels/5.9.0-1.el7.elrepo.x86_64'
make CC=gcc-8 -C /usr/src/kernels/5.9.0-1.el7.elrepo.x86_64  M=/home/wip modules
make[1]: Entering directory '/usr/src/kernels/5.9.0-1.el7.elrepo.x86_64'
Kernel version 5.9 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.9.0-1.el7.elrepo.x86_64 need minimum 3.10
  CC [M]  /home/wip/pxd.o
  CC [M]  /home/wip/dev.o
  CC [M]  /home/wip/iov_iter.o
  CC [M]  /home/wip/px_version.o
  CC [M]  /home/wip/io.o
  CC [M]  /home/wip/pxd_fastpath.o
  LD [M]  /home/wip/px.o
Kernel version 5.9 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.9.0-1.el7.elrepo.x86_64 need minimum 3.10
  MODPOST /home/wip/Module.symvers
  CC [M]  /home/wip/px.mod.o
  LD [M]  /home/wip/px.ko
make[1]: Leaving directory '/usr/src/kernels/5.9.0-1.el7.elrepo.x86_64'
root@ip-70-0-39-218:/home/wip# FORCE_CONTAINER_CC=gcc-8 KERNELPATH=/usr/src/kernels/5.9.0-1.el8.elrepo.x86_64 make clean all
Kernel version 5.9 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.9.0-1.el8.elrepo.x86_64 need minimum 3.10
make -C /usr/src/kernels/5.9.0-1.el8.elrepo.x86_64  M=/home/wip clean
make[1]: Entering directory '/usr/src/kernels/5.9.0-1.el8.elrepo.x86_64'
Kernel version 5.9 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.9.0-1.el8.elrepo.x86_64 need minimum 3.10
  CLEAN   /home/wip/Module.symvers
make[1]: Leaving directory '/usr/src/kernels/5.9.0-1.el8.elrepo.x86_64'
make CC=gcc-8 -C /usr/src/kernels/5.9.0-1.el8.elrepo.x86_64  M=/home/wip modules
make[1]: Entering directory '/usr/src/kernels/5.9.0-1.el8.elrepo.x86_64'
Kernel version 5.9 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.9.0-1.el8.elrepo.x86_64 need minimum 3.10
  CC [M]  /home/wip/pxd.o
  CC [M]  /home/wip/dev.o
  CC [M]  /home/wip/iov_iter.o
  CC [M]  /home/wip/px_version.o
  CC [M]  /home/wip/io.o
  CC [M]  /home/wip/pxd_fastpath.o
  LD [M]  /home/wip/px.o
Kernel version 5.9 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.9.0-1.el8.elrepo.x86_64 need minimum 3.10
  MODPOST /home/wip/Module.symvers
  CC [M]  /home/wip/px.mod.o
  LD [M]  /home/wip/px.ko
make[1]: Leaving directory '/usr/src/kernels/5.9.0-1.el8.elrepo.x86_64'
root@ip-70-0-39-218:/home/wip# FORCE_CONTAINER_CC=gcc-8 KERNELPATH=/usr/src/kernels/4.18.0-80.1.2.el8_0.x86_64 make clean all
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-80.1.2.el8_0.x86_64 need minimum 3.10
make -C /usr/src/kernels/4.18.0-80.1.2.el8_0.x86_64  M=/home/wip clean
make[1]: Entering directory '/usr/src/kernels/4.18.0-80.1.2.el8_0.x86_64'
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-80.1.2.el8_0.x86_64 need minimum 3.10
  CLEAN   /home/wip/Module.symvers
make[1]: Leaving directory '/usr/src/kernels/4.18.0-80.1.2.el8_0.x86_64'
make CC=gcc-8 -C /usr/src/kernels/4.18.0-80.1.2.el8_0.x86_64  M=/home/wip modules
make[1]: Entering directory '/usr/src/kernels/4.18.0-80.1.2.el8_0.x86_64'
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-80.1.2.el8_0.x86_64 need minimum 3.10
  CC [M]  /home/wip/pxd.o
  CC [M]  /home/wip/dev.o
  CC [M]  /home/wip/iov_iter.o
  CC [M]  /home/wip/px_version.o
  CC [M]  /home/wip/io.o
  CC [M]  /home/wip/pxd_fastpath.o
  LD [M]  /home/wip/px.o
  Building modules, stage 2.
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-80.1.2.el8_0.x86_64 need minimum 3.10
  MODPOST 1 modules
  CC      /home/wip/px.mod.o
  LD [M]  /home/wip/px.ko
make[1]: Leaving directory '/usr/src/kernels/4.18.0-80.1.2.el8_0.x86_64'
root@ip-70-0-39-218:/home/wip# FORCE_CONTAINER_CC=gcc-8 KERNELPATH=/usr/src/kernels/4.18.0-80.11.1.el8_0.x86_64 make clean all
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-80.11.1.el8_0.x86_64 need minimum 3.10
make -C /usr/src/kernels/4.18.0-80.11.1.el8_0.x86_64  M=/home/wip clean
make[1]: Entering directory '/usr/src/kernels/4.18.0-80.11.1.el8_0.x86_64'
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-80.11.1.el8_0.x86_64 need minimum 3.10
  CLEAN   /home/wip/.tmp_versions
  CLEAN   /home/wip/Module.symvers
make[1]: Leaving directory '/usr/src/kernels/4.18.0-80.11.1.el8_0.x86_64'
make CC=gcc-8 -C /usr/src/kernels/4.18.0-80.11.1.el8_0.x86_64  M=/home/wip modules
make[1]: Entering directory '/usr/src/kernels/4.18.0-80.11.1.el8_0.x86_64'
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-80.11.1.el8_0.x86_64 need minimum 3.10
  CC [M]  /home/wip/pxd.o
  CC [M]  /home/wip/dev.o
  CC [M]  /home/wip/iov_iter.o
  CC [M]  /home/wip/px_version.o
  CC [M]  /home/wip/io.o
  CC [M]  /home/wip/pxd_fastpath.o
  LD [M]  /home/wip/px.o
  Building modules, stage 2.
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-80.11.1.el8_0.x86_64 need minimum 3.10
  MODPOST 1 modules
  CC      /home/wip/px.mod.o
  LD [M]  /home/wip/px.ko
make[1]: Leaving directory '/usr/src/kernels/4.18.0-80.11.1.el8_0.x86_64'
root@ip-70-0-39-218:/home/wip# FORCE_CONTAINER_CC=gcc-8 KERNELPATH=/usr/src/kernels/4.18.0-193.el8.x86_64 make clean all
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-193.el8.x86_64 need minimum 3.10
make -C /usr/src/kernels/4.18.0-193.el8.x86_64  M=/home/wip clean
make[1]: Entering directory '/usr/src/kernels/4.18.0-193.el8.x86_64'
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-193.el8.x86_64 need minimum 3.10
  CLEAN   /home/wip/.tmp_versions
  CLEAN   /home/wip/Module.symvers
make[1]: Leaving directory '/usr/src/kernels/4.18.0-193.el8.x86_64'
make CC=gcc-8 -C /usr/src/kernels/4.18.0-193.el8.x86_64  M=/home/wip modules
make[1]: Entering directory '/usr/src/kernels/4.18.0-193.el8.x86_64'
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-193.el8.x86_64 need minimum 3.10
  CC [M]  /home/wip/pxd.o
  CC [M]  /home/wip/dev.o
  CC [M]  /home/wip/iov_iter.o
  CC [M]  /home/wip/px_version.o
  CC [M]  /home/wip/io.o
  CC [M]  /home/wip/pxd_fastpath.o
  LD [M]  /home/wip/px.o
  Building modules, stage 2.
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-193.el8.x86_64 need minimum 3.10
  MODPOST 1 modules
  CC      /home/wip/px.mod.o
  LD [M]  /home/wip/px.ko
make[1]: Leaving directory '/usr/src/kernels/4.18.0-193.el8.x86_64'
root@ip-70-0-39-218:/home/wip# FORCE_CONTAINER_CC=gcc-8 KERNELPATH=/usr/src/kernels/4.18.0-193.24.1.el8_2.dt1.x86_64 make clean all
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-193.24.1.el8_2.dt1.x86_64 need minimum 3.10
make -C /usr/src/kernels/4.18.0-193.24.1.el8_2.dt1.x86_64  M=/home/wip clean
make[1]: Entering directory '/usr/src/kernels/4.18.0-193.24.1.el8_2.dt1.x86_64'
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-193.24.1.el8_2.dt1.x86_64 need minimum 3.10
  CLEAN   /home/wip/.tmp_versions
  CLEAN   /home/wip/Module.symvers
make[1]: Leaving directory '/usr/src/kernels/4.18.0-193.24.1.el8_2.dt1.x86_64'
make CC=gcc-8 -C /usr/src/kernels/4.18.0-193.24.1.el8_2.dt1.x86_64  M=/home/wip modules
make[1]: Entering directory '/usr/src/kernels/4.18.0-193.24.1.el8_2.dt1.x86_64'
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-193.24.1.el8_2.dt1.x86_64 need minimum 3.10
  CC [M]  /home/wip/pxd.o
  CC [M]  /home/wip/dev.o
  CC [M]  /home/wip/iov_iter.o
  CC [M]  /home/wip/px_version.o
  CC [M]  /home/wip/io.o
  CC [M]  /home/wip/pxd_fastpath.o
  LD [M]  /home/wip/px.o
  Building modules, stage 2.
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-193.24.1.el8_2.dt1.x86_64 need minimum 3.10
  MODPOST 1 modules
  CC      /home/wip/px.mod.o
  LD [M]  /home/wip/px.ko
make[1]: Leaving directory '/usr/src/kernels/4.18.0-193.24.1.el8_2.dt1.x86_64'
root@ip-70-0-39-218:/home/wip# FORCE_CONTAINER_CC=gcc-8 KERNELPATH=/usr/src/kernels/4.18.0-193.23.1.el8_2.x86_64 make clean all  Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-193.23.1.el8_2.x86_64 need minimum 3.10
make -C /usr/src/kernels/4.18.0-193.23.1.el8_2.x86_64  M=/home/wip clean
make[1]: Entering directory '/usr/src/kernels/4.18.0-193.23.1.el8_2.x86_64'
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-193.23.1.el8_2.x86_64 need minimum 3.10
  CLEAN   /home/wip/.tmp_versions
  CLEAN   /home/wip/Module.symvers
make[1]: Leaving directory '/usr/src/kernels/4.18.0-193.23.1.el8_2.x86_64'
make CC=gcc-8 -C /usr/src/kernels/4.18.0-193.23.1.el8_2.x86_64  M=/home/wip modules
make[1]: Entering directory '/usr/src/kernels/4.18.0-193.23.1.el8_2.x86_64'
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-193.23.1.el8_2.x86_64 need minimum 3.10
  CC [M]  /home/wip/pxd.o
  CC [M]  /home/wip/dev.o
  CC [M]  /home/wip/iov_iter.o
  CC [M]  /home/wip/px_version.o
  CC [M]  /home/wip/io.o
  CC [M]  /home/wip/pxd_fastpath.o
  LD [M]  /home/wip/px.o
  Building modules, stage 2.
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-193.23.1.el8_2.x86_64 need minimum 3.10
  MODPOST 1 modules
  CC      /home/wip/px.mod.o
  LD [M]  /home/wip/px.ko
make[1]: Leaving directory '/usr/src/kernels/4.18.0-193.23.1.el8_2.x86_64'
root@ip-70-0-39-218:/home/wip# FORCE_CONTAINER_CC=gcc-8 KERNELPATH=/usr/src/kernels/4.18.0-193.14.2.el8_2.x86_64 make clean all
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-193.14.2.el8_2.x86_64 need minimum 3.10
make -C /usr/src/kernels/4.18.0-193.14.2.el8_2.x86_64  M=/home/wip clean
make[1]: Entering directory '/usr/src/kernels/4.18.0-193.14.2.el8_2.x86_64'
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-193.14.2.el8_2.x86_64 need minimum 3.10
  CLEAN   /home/wip/.tmp_versions
  CLEAN   /home/wip/Module.symvers
make[1]: Leaving directory '/usr/src/kernels/4.18.0-193.14.2.el8_2.x86_64'
make CC=gcc-8 -C /usr/src/kernels/4.18.0-193.14.2.el8_2.x86_64  M=/home/wip modules
make[1]: Entering directory '/usr/src/kernels/4.18.0-193.14.2.el8_2.x86_64'
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-193.14.2.el8_2.x86_64 need minimum 3.10
  CC [M]  /home/wip/pxd.o
  CC [M]  /home/wip/dev.o
  CC [M]  /home/wip/iov_iter.o
  CC [M]  /home/wip/px_version.o
  CC [M]  /home/wip/io.o
  CC [M]  /home/wip/pxd_fastpath.o
  LD [M]  /home/wip/px.o
  Building modules, stage 2.
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-193.14.2.el8_2.x86_64 need minimum 3.10
  MODPOST 1 modules
  CC      /home/wip/px.mod.o
  LD [M]  /home/wip/px.ko
make[1]: Leaving directory '/usr/src/kernels/4.18.0-193.14.2.el8_2.x86_64'
root@ip-70-0-39-218:/home/wip# FORCE_CONTAINER_CC=gcc-8 KERNELPATH=/usr/src/kernels/4.18.0-147.20.1.el8_1.x86_64 make clean all
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-147.20.1.el8_1.x86_64 need minimum 3.10
make -C /usr/src/kernels/4.18.0-147.20.1.el8_1.x86_64  M=/home/wip clean
make[1]: Entering directory '/usr/src/kernels/4.18.0-147.20.1.el8_1.x86_64'
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-147.20.1.el8_1.x86_64 need minimum 3.10
  CLEAN   /home/wip/.tmp_versions
  CLEAN   /home/wip/Module.symvers
make[1]: Leaving directory '/usr/src/kernels/4.18.0-147.20.1.el8_1.x86_64'
make CC=gcc-8 -C /usr/src/kernels/4.18.0-147.20.1.el8_1.x86_64  M=/home/wip modules
make[1]: Entering directory '/usr/src/kernels/4.18.0-147.20.1.el8_1.x86_64'
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-147.20.1.el8_1.x86_64 need minimum 3.10
  CC [M]  /home/wip/pxd.o
  CC [M]  /home/wip/dev.o
  CC [M]  /home/wip/iov_iter.o
  CC [M]  /home/wip/px_version.o
  CC [M]  /home/wip/io.o
  CC [M]  /home/wip/pxd_fastpath.o
  LD [M]  /home/wip/px.o
  Building modules, stage 2.
Kernel version 4.18 supports blkmq driver model.
Kernel fast path enabled, current kernel version 4.18.0-147.20.1.el8_1.x86_64 need minimum 3.10
  MODPOST 1 modules
  CC      /home/wip/px.mod.o
  LD [M]  /home/wip/px.ko
make[1]: Leaving directory '/usr/src/kernels/4.18.0-147.20.1.el8_1.x86_64'
root@ip-70-0-39-218:/home/wip# FORCE_CONTAINER_CC=gcc-8 KERNELPATH=/usr/src/kernels/4.14.186-146.268.amzn2.x86_64 make clean all
Kernel fast path enabled, current kernel version 4.14.186-146.268.amzn2.x86_64 need minimum 3.10
make -C /usr/src/kernels/4.14.186-146.268.amzn2.x86_64  M=/home/wip clean
make[1]: Entering directory '/usr/src/kernels/4.14.186-146.268.amzn2.x86_64'
Kernel fast path enabled, current kernel version 4.14.186-146.268.amzn2.x86_64 need minimum 3.10
  CLEAN   /home/wip/.tmp_versions
  CLEAN   /home/wip/Module.symvers
make[1]: Leaving directory '/usr/src/kernels/4.14.186-146.268.amzn2.x86_64'
make CC=gcc-8 -C /usr/src/kernels/4.14.186-146.268.amzn2.x86_64  M=/home/wip modules
make[1]: Entering directory '/usr/src/kernels/4.14.186-146.268.amzn2.x86_64'
Kernel fast path enabled, current kernel version 4.14.186-146.268.amzn2.x86_64 need minimum 3.10
  CC [M]  /home/wip/pxd.o
  CC [M]  /home/wip/dev.o
  CC [M]  /home/wip/iov_iter.o
  CC [M]  /home/wip/px_version.o
  CC [M]  /home/wip/io.o
  CC [M]  /home/wip/pxd_fastpath.o
  LD [M]  /home/wip/px.o
  Building modules, stage 2.
Kernel fast path enabled, current kernel version 4.14.186-146.268.amzn2.x86_64 need minimum 3.10
  MODPOST 1 modules
  CC      /home/wip/px.mod.o
  LD [M]  /home/wip/px.ko
make[1]: Leaving directory '/usr/src/kernels/4.14.186-146.268.amzn2.x86_64'
root@ip-70-0-39-218:/home/wip#
```