### PR TITLE
PWX-18756 fix race in restart and new req processing

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -239,7 +239,8 @@ void fuse_request_send_nowait(struct fuse_conn *fc, struct fuse_req *req)
 	 */
 	rcu_read_lock();
 
-	if (READ_ONCE(fc->connected) || READ_ONCE(fc->allow_disconnected)) {
+	// 'allow_disconnected' check subsumes 'connected' as well
+	if (READ_ONCE(fc->allow_disconnected)) {
 		queue_request(fc, req);
 		rcu_read_unlock();
 

--- a/dev.c
+++ b/dev.c
@@ -107,19 +107,20 @@ static u64 fuse_get_unique(struct fuse_conn *fc)
 	struct fuse_per_cpu_ids *my_ids;
 	u64 uid;
 	int num_alloc;
+	unsigned long flags;
 
 	int cpu = get_cpu();
 
 	my_ids = per_cpu_ptr(fc->per_cpu_ids, cpu);
 
 	if (unlikely(my_ids->num_free_ids == 0)) {
-		spin_lock(&fc->lock);
+		spin_lock_irqsave(&fc->lock, flags);
 		BUG_ON(fc->num_free_ids == 0);
 		num_alloc = min(fc->num_free_ids, (u32)FUSE_MAX_PER_CPU_IDS / 2);
 		memcpy(my_ids->free_ids, &fc->free_ids[fc->num_free_ids - num_alloc],
 			num_alloc * sizeof(u64));
 		fc->num_free_ids -= num_alloc;
-		spin_unlock(&fc->lock);
+		spin_unlock_irqrestore(&fc->lock, flags);
 
 		my_ids->num_free_ids = num_alloc;
 	}
@@ -142,18 +143,19 @@ static void fuse_put_unique(struct fuse_conn *fc, u64 uid)
 	struct fuse_per_cpu_ids *my_ids;
 	int num_free;
 	int cpu = get_cpu();
+	unsigned long flags;
 
 	my_ids = per_cpu_ptr(fc->per_cpu_ids, cpu);
 
 	if (unlikely(my_ids->num_free_ids == FUSE_MAX_PER_CPU_IDS)) {
 		num_free = FUSE_MAX_PER_CPU_IDS / 2;
-		spin_lock(&fc->lock);
+		spin_lock_irqsave(&fc->lock, flags);
 		BUG_ON(fc->num_free_ids + num_free > FUSE_MAX_REQUEST_IDS);
 		memcpy(&fc->free_ids[fc->num_free_ids],
 			&my_ids->free_ids[my_ids->num_free_ids - num_free],
 			num_free * sizeof(u64));
 		fc->num_free_ids += num_free;
-		spin_unlock(&fc->lock);
+		spin_unlock_irqrestore(&fc->lock, flags);
 
 		my_ids->num_free_ids -= num_free;
 	}
@@ -253,7 +255,7 @@ void fuse_request_send_nowait(struct fuse_conn *fc, struct fuse_req *req, bool f
 static bool request_pending(struct fuse_conn *fc)
 {
 	struct fuse_queue_cb *cb = &fc->queue->requests_cb;
-	return cb->r.read != cb->r.write;
+	return smp_load_acquire(&cb->r.read) != smp_load_acquire(&cb->r.write);
 }
 
 /* Wait until a request is available on the pending list */
@@ -384,7 +386,7 @@ static ssize_t fuse_dev_do_read(struct fuse_conn *fc, struct file *file,
 	}
 
 retry:
-	read = cb->r.read;
+	read = smp_load_acquire(&cb->r.read);
 	write = smp_load_acquire(&cb->r.write);
 
 	while (read != write && remain >= sizeof(struct rdwr_in)) {
@@ -1314,7 +1316,7 @@ int fuse_restart_requests(struct fuse_conn *fc)
 	struct fuse_req **resend_reqs;
 	struct fuse_queue_cb *cb = &fc->queue->requests_cb;
 
-	u32 read = cb->r.read;	/* ok to access read part since user space is
+	u32 read = smp_load_acquire(&cb->r.read);	/* ok to access read part since user space is
  				* inactive */
 	u32 write;
 	u64 sequence;
@@ -1368,7 +1370,7 @@ int fuse_restart_requests(struct fuse_conn *fc)
 		}
 	}
 	/* Update write index if it changed because of removing completion entries. */
-	cb->r.write = write;
+	smp_store_release(&cb->r.write, write);
 	cb->w.write = write;
 	spin_unlock(&cb->w.lock);
 
@@ -1400,7 +1402,7 @@ int fuse_restart_requests(struct fuse_conn *fc)
 	spin_lock(&cb->w.lock);
 	/* update the reader part */
 	cb->w.read = read;
-	cb->r.read = read;
+	smp_store_release(&cb->r.read, read);
 	spin_unlock(&cb->w.lock);
 
 	spin_lock(&fc->lock);

--- a/dev.c
+++ b/dev.c
@@ -141,7 +141,13 @@ static void fuse_put_unique(struct fuse_conn *fc, u64 uid)
 {
 	struct fuse_per_cpu_ids *my_ids;
 	int num_free;
-	int cpu = get_cpu();
+	int cpu;
+
+	if (uid == 0) {
+		return;
+	}
+
+	cpu = get_cpu();
 
 	my_ids = per_cpu_ptr(fc->per_cpu_ids, cpu);
 
@@ -175,6 +181,9 @@ static void queue_request(struct fuse_conn *fc, struct fuse_req *req)
 	u32 write;
 	struct rdwr_in *rdwr;
 	struct fuse_queue_cb *cb = &fc->queue->requests_cb;
+
+	req->in.unique = fuse_get_unique(fc);
+	fc->request_map[req->in.unique & (FUSE_MAX_REQUEST_IDS - 1)] = req;
 
 	spin_lock(&cb->w.lock);
 	write = cb->w.write;
@@ -222,21 +231,21 @@ static void request_end(struct fuse_conn *fc, struct fuse_req *req,
 	if (shouldfree) fuse_request_free(req);
 }
 
-void fuse_request_send_nowait(struct fuse_conn *fc, struct fuse_req *req, bool force)
+void fuse_request_send_nowait(struct fuse_conn *fc, struct fuse_req *req)
 {
-	req->in.unique = fuse_get_unique(fc);
-	fc->request_map[req->in.unique & (FUSE_MAX_REQUEST_IDS - 1)] = req;
+	/*
+	 * Ensures checking the value of allow_disconnected and adding request to
+	 * queue is done atomically.
+	 */
+	rcu_read_lock();
 
-	if (force) {
+	if (READ_ONCE(fc->connected) || READ_ONCE(fc->allow_disconnected)) {
 		queue_request(fc, req);
-		if (fc->connected || fc->allow_disconnected) {
-			fuse_conn_wakeup(fc);
-		}
-	} else if (fc->connected || fc->allow_disconnected) {
-		queue_request(fc, req);
+		rcu_read_unlock();
 
 		fuse_conn_wakeup(fc);
 	} else {
+		rcu_read_unlock();
 		request_end(fc, req, -ENOTCONN);
 	}
 }
@@ -1258,8 +1267,8 @@ struct fuse_conn *fuse_conn_get(struct fuse_conn *fc)
 void fuse_abort_conn(struct fuse_conn *fc)
 {
 	spin_lock(&fc->lock);
-	if (fc->connected) {
-		fc->connected = 0;
+	if (READ_ONCE(fc->connected)) {
+		WRITE_ONCE(fc->connected, 0);
 		fuse_end_queued_requests(fc);
 		wake_up_all(&fc->waitq);
 		kill_fasync(&fc->fasync, SIGIO, POLL_IN);
@@ -1272,7 +1281,7 @@ int fuse_dev_release(struct inode *inode, struct file *file)
 	struct fuse_conn *fc = fuse_get_conn(file);
 	if (fc) {
 		spin_lock(&fc->lock);
-		fc->connected = 0;
+		WRITE_ONCE(fc->connected, 0);
 		fuse_end_queued_requests(fc);
 		spin_unlock(&fc->lock);
 		fuse_conn_put(fc);

--- a/dev.c
+++ b/dev.c
@@ -227,25 +227,16 @@ void fuse_request_send_nowait(struct fuse_conn *fc, struct fuse_req *req, bool f
 	req->in.unique = fuse_get_unique(fc);
 	fc->request_map[req->in.unique & (FUSE_MAX_REQUEST_IDS - 1)] = req;
 
-	/*
-	 * Ensures checking the value of allow_disconnected and adding request to
-	 * queue is done atomically.
-	 */
-	rcu_read_lock();
-
 	if (force) {
 		queue_request(fc, req);
 		if (fc->connected || fc->allow_disconnected) {
 			fuse_conn_wakeup(fc);
 		}
-		rcu_read_unlock();
 	} else if (fc->connected || fc->allow_disconnected) {
 		queue_request(fc, req);
-		rcu_read_unlock();
 
 		fuse_conn_wakeup(fc);
 	} else {
-		rcu_read_unlock();
 		request_end(fc, req, -ENOTCONN);
 	}
 }

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -252,7 +252,7 @@ struct fuse_req *fuse_get_req_for_background(struct fuse_conn *fc);
 /**
  * Send a request in the background
  */
-void fuse_request_send_nowait(struct fuse_conn *fc, struct fuse_req *req, bool force);
+void fuse_request_send_nowait(struct fuse_conn *fc, struct fuse_req *req);
 
 /* Abort all requests */
 void fuse_abort_conn(struct fuse_conn *fc);

--- a/pxd.c
+++ b/pxd.c
@@ -2155,6 +2155,7 @@ static void pxd_abort_context(struct work_struct *work)
 		ctx->name, ctx->id);
 
 	fc->allow_disconnected = 0;
+	wmb();
 
 	/* Let other threads see the value of allow_disconnected. */
 	synchronize_rcu();

--- a/pxd.c
+++ b/pxd.c
@@ -2101,6 +2101,7 @@ static int pxd_control_open(struct inode *inode, struct file *file)
 	file->private_data = fc;
 
 	pxdctx_set_connected(ctx, true);
+	wmb();
 
 	++ctx->open_seq;
 
@@ -2124,6 +2125,7 @@ static int pxd_control_release(struct inode *inode, struct file *file)
 		pxd_printk("%s: not opened\n", __func__);
 	} else {
 		ctx->fc.connected = 0;
+		wmb();
 	}
 
 	schedule_delayed_work(&ctx->abort_work, pxd_timeout_secs * HZ);

--- a/pxd.c
+++ b/pxd.c
@@ -1040,8 +1040,10 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 	struct request *rq = bd->rq;
 	struct pxd_device *pxd_dev = rq->q->queuedata;
 	struct fuse_req *req = blk_mq_rq_to_pdu(rq);
+	struct fuse_conn *fc = &pxd_dev->ctx->fc;
 
-	if (BLK_RQ_IS_PASSTHROUGH(rq))
+	if (BLK_RQ_IS_PASSTHROUGH(rq) ||
+		(!fc->allow_disconnected && !fc->connected))
 		return BLK_STS_IOERR;
 
 	pxd_printk("%s: dev m %d g %lld %s at %ld len %d bytes %d pages "
@@ -1062,7 +1064,7 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 		return BLK_STS_IOERR;
 	}
 
-	fuse_request_send_nowait(&pxd_dev->ctx->fc, req, false);
+	fuse_request_send_nowait(fc, req, false);
 
 	return BLK_STS_OK;
 }

--- a/pxd.c
+++ b/pxd.c
@@ -233,7 +233,7 @@ static long pxd_ioctl_run_user_queue(struct file *file)
 
 	struct fuse_user_request *req;
 
-	uint32_t read = smp_load_acquire(&cb->r.read);
+	uint32_t read = cb->r.read;
 	uint32_t write = smp_load_acquire(&cb->r.write);
 
 	while (read != write) {
@@ -1040,10 +1040,8 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 	struct request *rq = bd->rq;
 	struct pxd_device *pxd_dev = rq->q->queuedata;
 	struct fuse_req *req = blk_mq_rq_to_pdu(rq);
-	struct fuse_conn *fc = &pxd_dev->ctx->fc;
 
-	if (BLK_RQ_IS_PASSTHROUGH(rq) ||
-		(!fc->allow_disconnected && !fc->connected)) 
+	if (BLK_RQ_IS_PASSTHROUGH(rq))
 		return BLK_STS_IOERR;
 
 	pxd_printk("%s: dev m %d g %lld %s at %ld len %d bytes %d pages "

--- a/pxd.c
+++ b/pxd.c
@@ -233,7 +233,7 @@ static long pxd_ioctl_run_user_queue(struct file *file)
 
 	struct fuse_user_request *req;
 
-	uint32_t read = cb->r.read;
+	uint32_t read = smp_load_acquire(&cb->r.read);
 	uint32_t write = smp_load_acquire(&cb->r.write);
 
 	while (read != write) {
@@ -1040,8 +1040,10 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 	struct request *rq = bd->rq;
 	struct pxd_device *pxd_dev = rq->q->queuedata;
 	struct fuse_req *req = blk_mq_rq_to_pdu(rq);
+	struct fuse_conn *fc = &pxd_dev->ctx->fc;
 
-	if (BLK_RQ_IS_PASSTHROUGH(rq))
+	if (BLK_RQ_IS_PASSTHROUGH(rq) ||
+		(!fc->allow_disconnected && !fc->connected)) 
 		return BLK_STS_IOERR;
 
 	pxd_printk("%s: dev m %d g %lld %s at %ld len %d bytes %d pages "

--- a/pxd.c
+++ b/pxd.c
@@ -1043,7 +1043,7 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 	struct fuse_req *req = blk_mq_rq_to_pdu(rq);
 	struct fuse_conn *fc = &pxd_dev->ctx->fc;
 
-	if (BLK_RQ_IS_PASSTHROUGH(rq) || !READ_ONCE(fc->allow_disconnected)) {
+	if (BLK_RQ_IS_PASSTHROUGH(rq) || !READ_ONCE(fc->allow_disconnected))
 		return BLK_STS_IOERR;
 
 	pxd_printk("%s: dev m %d g %lld %s at %ld len %d bytes %d pages "

--- a/pxd.c
+++ b/pxd.c
@@ -2155,10 +2155,8 @@ static void pxd_abort_context(struct work_struct *work)
 		ctx->name, ctx->id);
 
 	fc->allow_disconnected = 0;
-	wmb();
-
 	/* Let other threads see the value of allow_disconnected. */
-	synchronize_rcu();
+	wmb();
 
 	fuse_end_queued_requests(fc);
 	pxdctx_set_connected(ctx, false);

--- a/pxd.c
+++ b/pxd.c
@@ -1396,6 +1396,7 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 	}
 
 	pxd_dev->removing = true;
+	wmb();
 
 	/* Make sure the req_fn isn't called anymore even if the device hangs around */
 	if (pxd_dev->disk && pxd_dev->disk->queue){


### PR DESCRIPTION

Issue:
Stuck requests from block layer but fuse has none.
Assertion with invalid uid seen.

JIRA:
https://portworx.atlassian.net/browse/PWX-18756

Root cause:
1/ rcu usage incorrect, code accessing protected variables naked causing stale values to be read.
fc->connected and fc->allow_disconnected though protected with rcu read and sync calls (not all places),
were never protected against compiler optimization by accessing them WRITE_ONCE(), READ_ONCE() macros.
There are many places where updates to these happen, hence removed them altogether and switched to use memory barriers instead.

2/ when new requests get submitted in disconnected state, uids are still allocated, request initialized and freed again.
This can all be avoided by early return.


NOTES:
```
[root@ip-70-0-69-50 px-fuse]# pxctl status
Status: PX is operational
License: Trial (expires in 9 days)
Node ID: b3a7f832-6dea-4b42-aa9f-859540cc57aa
        IP: 70.0.69.50
        Local Storage Pool: 2 pools
        POOL    IO_PRIORITY     RAID_LEVEL      USABLE  USED    STATUS  ZONE   REGION
        0       HIGH            raid0           32 GiB  1.6 GiB Online  defaultdefault
        1       HIGH            raid0           381 GiB 25 GiB  Online  defaultdefault
        Local Storage Devices: 4 devices
        Device  Path            Media Type              Size            Last-Scan
        0:1     /dev/sdb        STORAGE_MEDIUM_SSD      32 GiB          24 Feb 21 11:58 UTC
        1:1     /dev/sde2       STORAGE_MEDIUM_SSD      125 GiB         24 Feb 21 11:58 UTC
        1:2     /dev/sdc        STORAGE_MEDIUM_SSD      128 GiB         24 Feb 21 11:58 UTC
        1:3     /dev/sdd        STORAGE_MEDIUM_SSD      128 GiB         24 Feb 21 11:58 UTC
        total                   -                       413 GiB
        Cache Devices:
         * No cache devices
        Journal Device:
        1       /dev/sde1       STORAGE_MEDIUM_SSD
Cluster Summary
        Cluster ID: MAN-PWX-18127-2.7.0
        Cluster UUID: 26c7b572-6f77-4977-94b4-1b82428209fc
        Scheduler: none
        Nodes: 3 node(s) with storage (3 online)
        IP              ID                                      SchedulerNodeName       StorageNode     Used    Capacity        Status  StorageStatus   VersionKernel                           OS
        70.0.69.50      b3a7f832-6dea-4b42-aa9f-859540cc57aa    N/A            Yes              26 GiB  413 GiB         Online  Up (This node)  2.7.0.0-83e99545.4.12-1.el7.elrepo.x86_64       CentOS Linux 7 (Core)
        70.0.41.41      aa7dc493-b77d-4a41-8eff-be1ee87a2308    N/A            Yes              27 GiB  413 GiB         Online  Up              2.7.0.0-83e99545.4.12-1.el7.elrepo.x86_64       CentOS Linux 7 (Core)
        70.0.84.111     5d76e438-ed30-409f-8319-c690bf62450b    N/A            Yes              27 GiB  413 GiB         Online  Up              2.7.0.0-83e99545.4.12-1.el7.elrepo.x86_64       CentOS Linux 7 (Core)
Global Storage Pool
        Total Used      :  80 GiB
        Total Capacity  :  1.2 TiB

[root@ip-70-0-69-50 px-fuse]# systemctl stop portworx
[root@ip-70-0-69-50 px-fuse]# rmmod px
[root@ip-70-0-69-50 px-fuse]# rm px_version.[co]
rm: remove regular file ‘px_version.c’? y
rm: remove regular file ‘px_version.o’? y
[root@ip-70-0-69-50 px-fuse]# git pull
remote: Enumerating objects: 4, done.
remote: Counting objects: 100% (4/4), done.
remote: Total 4 (delta 3), reused 4 (delta 3), pack-reused 0
Unpacking objects: 100% (4/4), done.
From github.com:portworx/px-fuse
   ea201f1..4b02f3e  ln/v2.7.0-patch -> origin/ln/v2.7.0-patch
Updating ea201f1..4b02f3e
Fast-forward
 dev.c | 9 ---------
 pxd.c | 6 ++++--
 2 files changed, 4 insertions(+), 11 deletions(-)
[root@ip-70-0-69-50 px-fuse]# make
Kernel version 5.4 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.4.12-1.el7.elrepo.x86_64 need minimum 3.10
echo "const char *gitversion = \"ln/v2.7.0-patch:4b02f3e620640de97351e69bfd9da78259402ffa\";" > px_version.c
make  -C /usr/src/kernels/5.4.12-1.el7.elrepo.x86_64  M=/root/srcs/src/github.com/portworx/px-fuse modules
make[1]: Entering directory `/usr/src/kernels/5.4.12-1.el7.elrepo.x86_64'
Kernel version 5.4 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.4.12-1.el7.elrepo.x86_64 need minimum 3.10
  CC [M]  /root/srcs/src/github.com/portworx/px-fuse/pxd.o
  CC [M]  /root/srcs/src/github.com/portworx/px-fuse/dev.o
  CC [M]  /root/srcs/src/github.com/portworx/px-fuse/px_version.o
  LD [M]  /root/srcs/src/github.com/portworx/px-fuse/px.o
Kernel version 5.4 supports blkmq driver model.
Kernel fast path enabled, current kernel version 5.4.12-1.el7.elrepo.x86_64 need minimum 3.10
  Building modules, stage 2.
  MODPOST 1 modules
  CC [M]  /root/srcs/src/github.com/portworx/px-fuse/px.mod.o
  LD [M]  /root/srcs/src/github.com/portworx/px-fuse/px.ko
make[1]: Leaving directory `/usr/src/kernels/5.4.12-1.el7.elrepo.x86_64'
[root@ip-70-0-69-50 px-fuse]#
[root@ip-70-0-69-50 px-fuse]#
[root@ip-70-0-69-50 px-fuse]# insmod ./px.ko
[root@ip-70-0-69-50 px-fuse]# systemctl restart portworx
[root@ip-70-0-69-50 px-fuse]# pxctl status
Status: PX is operational
License: Trial (expires in 9 days)
Node ID: b3a7f832-6dea-4b42-aa9f-859540cc57aa
        IP: 70.0.69.50
        Local Storage Pool: 2 pools
        POOL    IO_PRIORITY     RAID_LEVEL      USABLE  USED    STATUS  ZONE   REGION
        0       HIGH            raid0           32 GiB  1.6 GiB Online  defaultdefault
        1       HIGH            raid0           381 GiB 12 GiB  Online  defaultdefault
        Local Storage Devices: 4 devices
        Device  Path            Media Type              Size            Last-Scan
        0:1     /dev/sdb        STORAGE_MEDIUM_SSD      32 GiB          24 Feb 21 12:15 UTC
        1:1     /dev/sde2       STORAGE_MEDIUM_SSD      125 GiB         24 Feb 21 12:15 UTC
        1:2     /dev/sdc        STORAGE_MEDIUM_SSD      128 GiB         24 Feb 21 12:15 UTC
        1:3     /dev/sdd        STORAGE_MEDIUM_SSD      128 GiB         24 Feb 21 12:15 UTC
        total                   -                       413 GiB
        Cache Devices:
         * No cache devices
        Journal Device:
        1       /dev/sde1       STORAGE_MEDIUM_SSD
Cluster Summary
        Cluster ID: MAN-PWX-18127-2.7.0
        Cluster UUID: 26c7b572-6f77-4977-94b4-1b82428209fc
        Scheduler: none
        Nodes: 3 node(s) with storage (3 online)
        IP              ID                                      SchedulerNodeName       StorageNode     Used    Capacity        Status  StorageStatus   VersionKernel                           OS
        70.0.69.50      b3a7f832-6dea-4b42-aa9f-859540cc57aa    N/A            Yes              14 GiB  413 GiB         Online  Up (This node)  2.7.0.0-83e99545.4.12-1.el7.elrepo.x86_64       CentOS Linux 7 (Core)
        70.0.41.41      aa7dc493-b77d-4a41-8eff-be1ee87a2308    N/A            Yes              14 GiB  413 GiB         Online  Up              2.7.0.0-83e99545.4.12-1.el7.elrepo.x86_64       CentOS Linux 7 (Core)
        70.0.84.111     5d76e438-ed30-409f-8319-c690bf62450b    N/A            Yes              14 GiB  413 GiB         Online  Up              2.7.0.0-83e99545.4.12-1.el7.elrepo.x86_64       CentOS Linux 7 (Core)
Global Storage Pool
        Total Used      :  42 GiB
        Total Capacity  :  1.2 TiB
[root@ip-70-0-69-50 px-fuse]# pxctl status
Status: PX is operational
License: Trial (expires in 9 days)
Node ID: b3a7f832-6dea-4b42-aa9f-859540cc57aa
        IP: 70.0.69.50
        Local Storage Pool: 2 pools
        POOL    IO_PRIORITY     RAID_LEVEL      USABLE  USED    STATUS  ZONE   REGION
        0       HIGH            raid0           32 GiB  1.6 GiB Online  defaultdefault
        1       HIGH            raid0           381 GiB 12 GiB  Online  defaultdefault
        Local Storage Devices: 4 devices
        Device  Path            Media Type              Size            Last-Scan
        0:1     /dev/sdb        STORAGE_MEDIUM_SSD      32 GiB          24 Feb 21 12:15 UTC
        1:1     /dev/sde2       STORAGE_MEDIUM_SSD      125 GiB         24 Feb 21 12:15 UTC
        1:2     /dev/sdc        STORAGE_MEDIUM_SSD      128 GiB         24 Feb 21 12:15 UTC
        1:3     /dev/sdd        STORAGE_MEDIUM_SSD      128 GiB         24 Feb 21 12:15 UTC
        total                   -                       413 GiB
        Cache Devices:
         * No cache devices
        Journal Device:
        1       /dev/sde1       STORAGE_MEDIUM_SSD
Cluster Summary
        Cluster ID: MAN-PWX-18127-2.7.0
        Cluster UUID: 26c7b572-6f77-4977-94b4-1b82428209fc
        Scheduler: none
        Nodes: 3 node(s) with storage (3 online)
        IP              ID                                      SchedulerNodeName       StorageNode     Used    Capacity        Status  StorageStatus   VersionKernel                           OS
        70.0.69.50      b3a7f832-6dea-4b42-aa9f-859540cc57aa    N/A            Yes              14 GiB  413 GiB         Online  Up (This node)  2.7.0.0-83e99545.4.12-1.el7.elrepo.x86_64       CentOS Linux 7 (Core)
        70.0.41.41      aa7dc493-b77d-4a41-8eff-be1ee87a2308    N/A            Yes              14 GiB  413 GiB         Online  Up              2.7.0.0-83e99545.4.12-1.el7.elrepo.x86_64       CentOS Linux 7 (Core)
        70.0.84.111     5d76e438-ed30-409f-8319-c690bf62450b    N/A            Yes              14 GiB  413 GiB         Online  Up              2.7.0.0-83e99545.4.12-1.el7.elrepo.x86_64       CentOS Linux 7 (Core)
Global Storage Pool
        Total Used      :  42 GiB
        Total Capacity  :  1.2 TiB
(reverse-i-search)`start': systemctl re^Cart portworx
[root@ip-70-0-69-50 px-fuse]# pxctl v l
ID      NAME    SIZE    HA      SHARED  ENCRYPTED       PROXY-VOLUME    IO_PRIORITY     STATUS  SNAP-ENABLED
[root@ip-70-0-69-50 px-fuse]# screen -RD start-test
[detached from 6700.start-test]
## hit oom
[root@ip-70-0-69-50 px-fuse]# echo 30 > /sys/devices/pxd/1/timeout
[root@ip-70-0-69-50 px-fuse]# cat /sys/block/pxd\!pxd*/inflight
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
[root@ip-70-0-69-50 px-fuse]# screen -RD slow-diff-1
[screen is terminating]
[root@ip-70-0-69-50 px-fuse]# screen -RD slow-diff-2
[screen is terminating]
[root@ip-70-0-69-50 px-fuse]# screen -RD slow-diff-3
[screen is terminating]
[root@ip-70-0-69-50 px-fuse]#
[root@ip-70-0-69-50 px-fuse]#
[root@ip-70-0-69-50 px-fuse]# for vol in $(pxctl v l -j | jq .[].id | tr -d \");  do pxctl v d -f $vol; done
Volume 836919802202142390 successfully deleted.
Volume 612052366174175389 successfully deleted.
Volume 160666015937413773 successfully deleted.
Volume 842182307206036125 successfully deleted.
Volume 569312837180066461 successfully deleted.
Volume 527481524870771127 successfully deleted.
Volume 719934882592650322 successfully deleted.
Volume 597098631762899521 successfully deleted.
Volume 382788275924146125 successfully deleted.
Volume 381215105176489032 successfully deleted.
Volume 921560239242663031 successfully deleted.
Volume 534614494852012384 successfully deleted.
Volume 607503559611190288 successfully deleted.
Volume 630255754048847981 successfully deleted.
Volume 164376266147608086 successfully deleted.
Volume 344115851846402266 successfully deleted.
Volume 507184879209100122 successfully deleted.
Volume 253250678035732140 successfully deleted.
Volume 343171988103495087 successfully deleted.
Volume 197663608152700596 successfully deleted.
Volume 1066154862962147587 successfully deleted.
Volume 512053139621507649 successfully deleted.
Volume 379813018554287919 successfully deleted.
Volume 119844971981445962 successfully deleted.
Volume 152375959836060148 successfully deleted.
Volume 11309031015561148 successfully deleted.
Volume 281686904715745291 successfully deleted.
Volume 240984244162047593 successfully deleted.
[root@ip-70-0-69-50 px-fuse]#
[root@ip-70-0-69-50 px-fuse]# screen -RD start-test
[detached from 6700.start-test]
[root@ip-70-0-69-50 px-fuse]#
[root@ip-70-0-69-50 px-fuse]#
[root@ip-70-0-69-50 px-fuse]#
[root@ip-70-0-69-50 px-fuse]#
[root@ip-70-0-69-50 px-fuse]#
[root@ip-70-0-69-50 px-fuse]#
[root@ip-70-0-69-50 px-fuse]#
[root@ip-70-0-69-50 px-fuse]#
[root@ip-70-0-69-50 px-fuse]#
[root@ip-70-0-69-50 px-fuse]#
[root@ip-70-0-69-50 px-fuse]#
[root@ip-70-0-69-50 px-fuse]# cat /sys/block/pxd\!pxd*/inflight
       0      453
       0        0
       0        0
       0        0
       0      214
       0        0
       0        0
       0        0
       0        0
       0      129
       1      210
       1      387
       0        1
       2      114
       1      256
       0        0
       0      247
       0        0
       0      234
       0        0
       0      366
       1      116
       1      249
       0        0
       0        0
       0        0
       0        0
[root@ip-70-0-69-50 px-fuse]# ### hit oom
[root@ip-70-0-69-50 px-fuse]# echo 30 > /sys/devices/pxd/1/timeout
[root@ip-70-0-69-50 px-fuse]# cat /sys/block/pxd\!pxd*/inflight
       0      453
       0        0
       0        0
       0        0
       0      214
       0        0
       0        0
       0        0
       0        0
       0      129
       1      210
       1      387
       0        1
       2      114
       1      256
       0        0
       0      247
       0        0
       0      234
       0        0
       0      366
       1      116
       1      249
       0        0
       0        0
       0        0
       0        0
[root@ip-70-0-69-50 px-fuse]# cat /sys/block/pxd\!pxd*/inflight
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
[root@ip-70-0-69-50 px-fuse]# pxctl status
Status: PX is operational
License: Trial (expires in 9 days)
Node ID: b3a7f832-6dea-4b42-aa9f-859540cc57aa
        IP: 70.0.69.50
        Local Storage Pool: 2 pools
        POOL    IO_PRIORITY     RAID_LEVEL      USABLE  USED    STATUS  ZONE   REGION
        0       HIGH            raid0           32 GiB  1.6 GiB Online  defaultdefault
        1       HIGH            raid0           381 GiB 25 GiB  Online  defaultdefault
        Local Storage Devices: 4 devices
        Device  Path            Media Type              Size            Last-Scan
        0:1     /dev/sdb        STORAGE_MEDIUM_SSD      32 GiB          24 Feb 21 12:26 UTC
        1:1     /dev/sde2       STORAGE_MEDIUM_SSD      125 GiB         24 Feb 21 12:26 UTC
        1:2     /dev/sdc        STORAGE_MEDIUM_SSD      128 GiB         24 Feb 21 12:26 UTC
        1:3     /dev/sdd        STORAGE_MEDIUM_SSD      128 GiB         24 Feb 21 12:26 UTC
        total                   -                       413 GiB
        Cache Devices:
         * No cache devices
        Journal Device:
        1       /dev/sde1       STORAGE_MEDIUM_SSD
Cluster Summary
        Cluster ID: MAN-PWX-18127-2.7.0
        Cluster UUID: 26c7b572-6f77-4977-94b4-1b82428209fc
        Scheduler: none
        Nodes: 3 node(s) with storage (3 online)
        IP              ID                                      SchedulerNodeName       StorageNode     Used    Capacity        Status  StorageStatus   VersionKernel                           OS
        70.0.69.50      b3a7f832-6dea-4b42-aa9f-859540cc57aa    N/A            Yes              26 GiB  413 GiB         Online  Up (This node)  2.7.0.0-83e99545.4.12-1.el7.elrepo.x86_64       CentOS Linux 7 (Core)
        70.0.41.41      aa7dc493-b77d-4a41-8eff-be1ee87a2308    N/A            Yes              28 GiB  413 GiB         Online  Up              2.7.0.0-83e99545.4.12-1.el7.elrepo.x86_64       CentOS Linux 7 (Core)
        70.0.84.111     5d76e438-ed30-409f-8319-c690bf62450b    N/A            Yes              28 GiB  413 GiB         Online  Up              2.7.0.0-83e99545.4.12-1.el7.elrepo.x86_64       CentOS Linux 7 (Core)
Global Storage Pool
        Total Used      :  83 GiB
        Total Capacity  :  1.2 TiB
[root@ip-70-0-69-50 px-fuse]# for vol in $(pxctl v l -j | jq .[].id | tr -d \");  do pxctl v d -f $vol; done
Volume 726979413421413154 successfully deleted.
Volume 570183114289491655 successfully deleted.
Volume 1001386735240115466 successfully deleted.
Volume 717699345993048202 successfully deleted.
Volume 887350118426723865 successfully deleted.
Volume 10572479190523077 successfully deleted.
Volume 1100003808439970068 successfully deleted.
Volume 704222129097173422 successfully deleted.
Volume 389073853284753603 successfully deleted.
Volume 113700620084412077 successfully deleted.
Volume 1073245171020293431 successfully deleted.
Volume 1073842049839578457 successfully deleted.
Volume 438959497027756748 successfully deleted.
Volume 759106970884226289 successfully deleted.
Volume 379141997930397359 successfully deleted.
Volume 169040391886579294 successfully deleted.
Volume 992644456314424250 successfully deleted.
Volume 517402392385723517 successfully deleted.
Volume 378911811916215535 successfully deleted.
Volume 753231858340370824 successfully deleted.
Volume 43117892067809681 successfully deleted.
Volume 865561370061464026 successfully deleted.
Volume 204161804573499944 successfully deleted.
Volume 570910950504955106 successfully deleted.
Volume 1135775733155949850 successfully deleted.
Volume 886769252060010227 successfully deleted.
Volume 423951072590475298 successfully deleted.
Volume 239242823161104052 successfully deleted.
Volume 501643584749479454 successfully deleted.
[root@ip-70-0-69-50 px-fuse]# screen -RD slow-diff-1                            [screen is terminating]
[root@ip-70-0-69-50 px-fuse]# screen -RD slow-diff-2
[screen is terminating]
[root@ip-70-0-69-50 px-fuse]# screen -RD slow-diff-3
[screen is terminating]
[root@ip-70-0-69-50 px-fuse]# pxctl v l
ID      NAME    SIZE    HA      SHARED  ENCRYPTED       PROXY-VOLUME    IO_PRIORITY     STATUS  SNAP-ENABLED
[root@ip-70-0-69-50 px-fuse]# screen -RD start-test
[detached from 6700.start-test]
[root@ip-70-0-69-50 px-fuse]# pxctl status
Status: PX is operational
License: Trial (expires in 9 days)
Node ID: b3a7f832-6dea-4b42-aa9f-859540cc57aa
        IP: 70.0.69.50
        Local Storage Pool: 2 pools
        POOL    IO_PRIORITY     RAID_LEVEL      USABLE  USED    STATUS  ZONE   REGION
        0       HIGH            raid0           32 GiB  1.6 GiB Online  defaultdefault
        1       HIGH            raid0           381 GiB 13 GiB  Online  defaultdefault
        Local Storage Devices: 4 devices
        Device  Path            Media Type              Size            Last-Scan
        0:1     /dev/sdb        STORAGE_MEDIUM_SSD      32 GiB          24 Feb 21 12:26 UTC
        1:1     /dev/sde2       STORAGE_MEDIUM_SSD      125 GiB         24 Feb 21 12:26 UTC
        1:2     /dev/sdc        STORAGE_MEDIUM_SSD      128 GiB         24 Feb 21 12:26 UTC
        1:3     /dev/sdd        STORAGE_MEDIUM_SSD      128 GiB         24 Feb 21 12:26 UTC
        total                   -                       413 GiB
        Cache Devices:
         * No cache devices
        Journal Device:
        1       /dev/sde1       STORAGE_MEDIUM_SSD
Cluster Summary
        Cluster ID: MAN-PWX-18127-2.7.0
        Cluster UUID: 26c7b572-6f77-4977-94b4-1b82428209fc
        Scheduler: none
        Nodes: 3 node(s) with storage (3 online)
        IP              ID                                      SchedulerNodeName       StorageNode     Used    Capacity        Status  StorageStatus   VersionKernel                           OS
        70.0.69.50      b3a7f832-6dea-4b42-aa9f-859540cc57aa    N/A            Yes              15 GiB  413 GiB         Online  Up (This node)  2.7.0.0-83e99545.4.12-1.el7.elrepo.x86_64       CentOS Linux 7 (Core)
        70.0.41.41      aa7dc493-b77d-4a41-8eff-be1ee87a2308    N/A            Yes              16 GiB  413 GiB         Online  Up              2.7.0.0-83e99545.4.12-1.el7.elrepo.x86_64       CentOS Linux 7 (Core)
        70.0.84.111     5d76e438-ed30-409f-8319-c690bf62450b    N/A            Yes              16 GiB  413 GiB         Online  Up              2.7.0.0-83e99545.4.12-1.el7.elrepo.x86_64       CentOS Linux 7 (Core)
Global Storage Pool
        Total Used      :  47 GiB
        Total Capacity  :  1.2 TiB
[root@ip-70-0-69-50 px-fuse]#
[root@ip-70-0-69-50 px-fuse]# ## hit oom
[root@ip-70-0-69-50 px-fuse]# echo 30 > /sys/devices/pxd/1/timeout
[root@ip-70-0-69-50 px-fuse]# cat /sys/block/pxd\!pxd*/inflight
       1      220
       1        0
       0        0
       0        0
       0      309
       2      130
       0        0
       0        0
       2      105
       1      252
       0      193
       1      151
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0      121
       0        0
       0        0
       0      241
       0      390
       0        0
       0        0
[root@ip-70-0-69-50 px-fuse]# cat /sys/block/pxd\!pxd*/inflight
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
       0        0
[root@ip-70-0-69-50 px-fuse]# pxctl status
Status: PX is operational
License: Trial (expires in 9 days)
Node ID: b3a7f832-6dea-4b42-aa9f-859540cc57aa
        IP: 70.0.69.50
        Local Storage Pool: 2 pools
        POOL    IO_PRIORITY     RAID_LEVEL      USABLE  USED    STATUS  ZONE   REGION
        0       HIGH            raid0           32 GiB  1.6 GiB Online  defaultdefault
        1       HIGH            raid0           381 GiB 25 GiB  Online  defaultdefault
        Local Storage Devices: 4 devices
        Device  Path            Media Type              Size            Last-Scan
        0:1     /dev/sdb        STORAGE_MEDIUM_SSD      32 GiB          24 Feb 21 12:31 UTC
        1:1     /dev/sde2       STORAGE_MEDIUM_SSD      125 GiB         24 Feb 21 12:31 UTC
        1:2     /dev/sdc        STORAGE_MEDIUM_SSD      128 GiB         24 Feb 21 12:31 UTC
        1:3     /dev/sdd        STORAGE_MEDIUM_SSD      128 GiB         24 Feb 21 12:31 UTC
        total                   -                       413 GiB
        Cache Devices:
         * No cache devices
        Journal Device:
        1       /dev/sde1       STORAGE_MEDIUM_SSD
Cluster Summary
        Cluster ID: MAN-PWX-18127-2.7.0
        Cluster UUID: 26c7b572-6f77-4977-94b4-1b82428209fc
        Scheduler: none
        Nodes: 3 node(s) with storage (3 online)
        IP              ID                                      SchedulerNodeName       StorageNode     Used    Capacity        Status  StorageStatus   VersionKernel                           OS
        70.0.69.50      b3a7f832-6dea-4b42-aa9f-859540cc57aa    N/A            Yes              27 GiB  413 GiB         Online  Up (This node)  2.7.0.0-83e99545.4.12-1.el7.elrepo.x86_64       CentOS Linux 7 (Core)
        70.0.41.41      aa7dc493-b77d-4a41-8eff-be1ee87a2308    N/A            Yes              27 GiB  413 GiB         Online  Up              2.7.0.0-83e99545.4.12-1.el7.elrepo.x86_64       CentOS Linux 7 (Core)
        70.0.84.111     5d76e438-ed30-409f-8319-c690bf62450b    N/A            Yes              27 GiB  413 GiB         Online  Up              2.7.0.0-83e99545.4.12-1.el7.elrepo.x86_64       CentOS Linux 7 (Core)
Global Storage Pool
        Total Used      :  81 GiB
        Total Capacity  :  1.2 TiB
[root@ip-70-0-69-50 px-fuse]# screen -RD slow-diff-1
[screen is terminating]
[root@ip-70-0-69-50 px-fuse]# screen -RD slow-diff-2
[screen is terminating]
[root@ip-70-0-69-50 px-fuse]# screen -RD slow-diff-3
[screen is terminating]
[root@ip-70-0-69-50 px-fuse]# screen -RD start-test
[detached from 6700.start-test]
[root@ip-70-0-69-50 px-fuse]#

```