### PR TITLE
PWX-18937: px-fastpath driver cleanups

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -734,32 +734,6 @@ static int fuse_notify_update_size(struct fuse_conn *conn, unsigned int size,
 	return pxd_update_size(conn, &update_size);
 }
 
-static int fuse_notify_update_path(struct fuse_conn *conn, unsigned int size,
-		struct iov_iter *iter) {
-	struct pxd_update_path_out update_path;
-	size_t len = sizeof(update_path);
-
-	if (copy_from_iter(&update_path, len, iter) != len) {
-		printk(KERN_ERR "%s: can't copy arg\n", __func__);
-		return -EFAULT;
-	}
-
-	return pxd_update_path(conn, &update_path);
-}
-
-static int fuse_notify_set_fastpath(struct fuse_conn *conn, unsigned int size,
-		struct iov_iter *iter) {
-	struct pxd_fastpath_out fp;
-	size_t len = sizeof(fp);
-
-	if (copy_from_iter(&fp, len, iter) != len) {
-		printk(KERN_ERR "%s: can't copy arg\n", __func__);
-		return -EFAULT;
-	}
-
-	return pxd_set_fastpath(conn, &fp);
-}
-
 static int fuse_notify_get_features(struct fuse_conn *conn, unsigned int size,
 		struct iov_iter *iter) {
 	return pxd_supported_features();
@@ -842,10 +816,6 @@ static int fuse_notify(struct fuse_conn *fc, enum fuse_notify_code code,
 		return fuse_notify_update_size(fc, size, iter);
 	case PXD_ADD_EXT:
 		return fuse_notify_add_ext(fc, size, iter);
-	case PXD_UPDATE_PATH:
-		return fuse_notify_update_path(fc, size, iter);
-	case PXD_SET_FASTPATH:
-		return fuse_notify_set_fastpath(fc, size, iter);
 	case PXD_GET_FEATURES:
 		return fuse_notify_get_features(fc, size, iter);
 	case PXD_SUSPEND:

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -301,10 +301,6 @@ ssize_t pxd_update_size(struct fuse_conn *fc, struct pxd_update_size *update_siz
 ssize_t pxd_ioc_update_size(struct fuse_conn *fc, struct pxd_update_size *update_size);
 ssize_t pxd_read_init(struct fuse_conn *fc, struct iov_iter *iter);
 
-// fastpath extension
-ssize_t pxd_update_path(struct fuse_conn *fc, struct pxd_update_path_out *update_path);
-int pxd_set_fastpath(struct fuse_conn *fc, struct pxd_fastpath_out*);
-
 void fuse_request_init(struct fuse_req *req);
 
 void fuse_convert_zero_writes(struct fuse_req *req);

--- a/pxd.h
+++ b/pxd.h
@@ -61,8 +61,8 @@ enum pxd_opcode {
 	PXD_UPDATE_SIZE,	/**< update device size */
 	PXD_WRITE_SAME,		/**< write_same operation */
 	PXD_ADD_EXT,		/**< add device with extended info to kernel */
-	PXD_UPDATE_PATH,    /**< update backing file/device path for a volume */
-	PXD_SET_FASTPATH,   /**< enable/disable fastpath */
+	PXD_DEPRECATE_1,    /**< deprecated */
+	PXD_DEPRECATE_0,   /**< deprecated */
 	PXD_GET_FEATURES,   /**< get features */
 	PXD_COMPLETE,		/**< complete kernel operation */
 	PXD_SUSPEND,		/**< IO suspend */


### PR DESCRIPTION
px-fastpath specific cleanups:
1/ during failover from fastpath, open file handles are not closed (relies on disableFastPath() to perform the needed)
2/ io callbacks get scheduled from interrupt context during completion, need intr protection for handling failover.
3/ cleans up unused code.
https://portworx.atlassian.net/browse/PWX-18937

PASSED:
https://jenkins.portworx.dev/job/DEV/job/Porx-01-caching/435/ - btrfs smoke 3.10 kernel
https://jenkins.portworx.dev/job/DEV/job/Porx-01-caching/436 - dmthin smoke 4.18 kernel
https://jenkins.portworx.dev/job/DEV/job/Porx-01-caching/437 - dmthin smoke 5.7 kernel

