### PR TITLE
PWX-19006: Do not set pxd_bd_ops.submit_bio, 5.10 kernel uses this to…

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -379,9 +379,6 @@ static const struct block_device_operations pxd_bd_ops = {
 	.owner			= THIS_MODULE,
 	.open			= pxd_open,
 	.release		= pxd_release,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
-	.submit_bio		= pxd_make_request_fastpath,
-#endif
 };
 
 static void pxd_update_stats(struct fuse_req *req, int rw, unsigned int count)


### PR DESCRIPTION
… submit ios to pxd instead of the request queue.

On 5.10 kernel, the request queue is bypassed if submit_bio is set for the pxd block device. Our internal mmap request queue depends on request queue based processing. Even if we can reroute to slowpath it's an extra cost which can be avoided. 
It's not needed and compilation works fine on both 5.9 and 5.10. 