### PR TITLE
pxd abort handler leaves fc->lock in locked state.

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1667,7 +1667,9 @@ static void pxd_abort_context(struct work_struct *work)
 	/* Let other threads see the value of allow_disconnected. */
 	synchronize_rcu();
 
+	spin_lock(&fc->lock);
 	fuse_end_queued_requests(fc);
+	spin_unlock(&fc->lock);
 	pxdctx_set_connected(ctx, false);
 }
 


### PR DESCRIPTION
noticed spin lock already locked in abort context and never freed, thereby stalling a px restart.

https://jenkins.portworx.dev/job/PX2-RELEASE/view/PX2-RELEASE-Cloudsnap/job/FVT-MN-ObjectStore-NEXT-PX2-RELEASE/

referenced to the original fuse 2.7.0 that regressed:
https://github.com/portworx/px-fuse/pull/199/files#r594439302

```
Mar 15 11:58:53 ip-70-0-41-103 portworx: 2021-03-15 11:58:53,540 INFO success: pxdaemon entered RUNNING state, process has stayed up for > than 5 seconds (startsecs)
Mar 15 11:59:09 ip-70-0-41-103 kernel: NMI watchdog: BUG: soft lockup - CPU#3 stuck for 24s! [systemd-udevd:2759]
Mar 15 11:59:09 ip-70-0-41-103 kernel: Modules linked in: intel_rapl(-) floppy(-) rpcsec_gss_krb5 nfsv4 dns_resolver nfs fscache af_packet_diag netlink_diag vsock_diag tcp_diag udp_diag inet_diag unix_diag btrfs raid6_pq xor raid0 px(OE) dm_cache_smq dm_cache dm_thin_pool dm_persistent_data dm_bio_prison dm_bufio nfsd auth_rpcgss nfs_acl lockd grace xt_nat veth xt_conntrack ipt_MASQUERADE nf_nat_masquerade_ipv4 nf_conntrack_netlink nfnetlink xt_addrtype iptable_filter iptable_nat nf_conntrack_ipv4 nf_defrag_ipv4 nf_nat_ipv4 nf_nat nf_conntrack br_netfilter bridge stp llc overlay(T) vmw_vsock_vmci_transport vsock sunrpc ext4 mbcache jbd2 iosf_mbi crc32_pclmul ppdev ghash_clmulni_intel aesni_intel vmw_balloon lrw gf128mul glue_helper ablk_helper cryptd joydev pcspkr sg vmw_vmci nfit i2c_piix4 libnvdimm parport_pc parport ip_tables
Mar 15 11:59:09 ip-70-0-41-103 kernel: xfs libcrc32c sd_mod crc_t10dif crct10dif_generic ata_generic pata_acpi vmwgfx drm_kms_helper syscopyarea sysfillrect sysimgblt fb_sys_fops ttm drm e1000 ata_piix crct10dif_pclmul crct10dif_common crc32c_intel mptspi serio_raw libata scsi_transport_spi mptscsih mptbase drm_panel_orientation_quirks dm_mirror dm_region_hash dm_log dm_mod fuse
Mar 15 11:59:09 ip-70-0-41-103 kernel: CPU: 3 PID: 2759 Comm: systemd-udevd Kdump: loaded Tainted: G           OE  ------------ T 3.10.0-1160.15.2.el7.x86_64 #1
Mar 15 11:59:09 ip-70-0-41-103 kernel: Hardware name: VMware, Inc. VMware Virtual Platform/440BX Desktop Reference Platform, BIOS 6.00 07/28/2017
Mar 15 11:59:09 ip-70-0-41-103 kernel: task: ffff98887b545280 ti: ffff98893d3a0000 task.ti: ffff98893d3a0000
Mar 15 11:59:09 ip-70-0-41-103 kernel: RIP: 0010:[<ffffffffbbf1770d>]  [<ffffffffbbf1770d>] native_queued_spin_lock_slowpath+0x1d/0x200
Mar 15 11:59:09 ip-70-0-41-103 kernel: RSP: 0018:ffff98893d3a3af0  EFLAGS: 00000293
Mar 15 11:59:09 ip-70-0-41-103 kernel: RAX: 0000000000000001 RBX: ffff98893d3a3b78 RCX: 0000000000000001
Mar 15 11:59:09 ip-70-0-41-103 kernel: RDX: 0000000000000001 RSI: 0000000000000001 RDI: ffff9888592e8020
Mar 15 11:59:09 ip-70-0-41-103 kernel: RBP: ffff98893d3a3af0 R08: 0000000000000002 R09: 0000000000000001
Mar 15 11:59:09 ip-70-0-41-103 kernel: R10: 0000000000000000 R11: 0000000000000015 R12: ffff98885915ed00
Mar 15 11:59:09 ip-70-0-41-103 kernel: R13: 0000000180100002 R14: 0000000000000202 R15: ffff98885915ed00
Mar 15 11:59:09 ip-70-0-41-103 kernel: FS:  00007fe56d7268c0(0000) GS:ffff9889ffd80000(0000) knlGS:0000000000000000
Mar 15 11:59:09 ip-70-0-41-103 kernel: CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
Mar 15 11:59:09 ip-70-0-41-103 kernel: CR2: 00007fe56d731000 CR3: 000000017d3a4000 CR4: 00000000007607e0
Mar 15 11:59:09 ip-70-0-41-103 kernel: DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
Mar 15 11:59:09 ip-70-0-41-103 kernel: DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
Mar 15 11:59:09 ip-70-0-41-103 kernel: PKRU: 55555554
Mar 15 11:59:09 ip-70-0-41-103 kernel: Call Trace:
Mar 15 11:59:09 ip-70-0-41-103 kernel: [<ffffffffbc57bff5>] queued_spin_lock_slowpath+0xb/0xf
Mar 15 11:59:09 ip-70-0-41-103 kernel: [<ffffffffbc58a700>] _raw_spin_lock+0x20/0x30
Mar 15 11:59:09 ip-70-0-41-103 kernel: [<ffffffffc071178f>] pxd_open+0x3f/0x110 [px]
Mar 15 11:59:09 ip-70-0-41-103 kernel: [<ffffffffbc08fc7c>] __blkdev_get+0x43c/0x4e0
Mar 15 11:59:09 ip-70-0-41-103 kernel: [<ffffffffbc08fefd>] blkdev_get+0x1dd/0x380
Mar 15 11:59:09 ip-70-0-41-103 kernel: [<ffffffffbc09014b>] blkdev_open+0x5b/0x80
Mar 15 11:59:09 ip-70-0-41-103 kernel: [<ffffffffbc04b452>] do_dentry_open+0x1e2/0x2d0
Mar 15 11:59:09 ip-70-0-41-103 kernel: [<ffffffffbc1089b2>] ? security_inode_permission+0x22/0x30
Mar 15 11:59:09 ip-70-0-41-103 kernel: [<ffffffffbc0900f0>] ? blkdev_get_by_dev+0x50/0x50
Mar 15 11:59:09 ip-70-0-41-103 kernel: [<ffffffffbc04b5da>] vfs_open+0x5a/0xb0
Mar 15 11:59:09 ip-70-0-41-103 kernel: [<ffffffffbc059d33>] ? may_open+0xa3/0x120
Mar 15 11:59:09 ip-70-0-41-103 kernel: [<ffffffffbc05dc16>] do_last+0x1f6/0x1340
Mar 15 11:59:09 ip-70-0-41-103 kernel: [<ffffffffbc05ee2d>] path_openat+0xcd/0x5a0
Mar 15 11:59:09 ip-70-0-41-103 kernel: [<ffffffffbc06107d>] do_filp_open+0x4d/0xb0
Mar 15 11:59:09 ip-70-0-41-103 kernel: [<ffffffffbc06f177>] ? __alloc_fd+0x47/0x170
Mar 15 11:59:09 ip-70-0-41-103 kernel: [<ffffffffbc04cbc4>] do_sys_open+0x124/0x220
Mar 15 11:59:09 ip-70-0-41-103 kernel: [<ffffffffbc04ccde>] SyS_open+0x1e/0x20
Mar 15 11:59:09 ip-70-0-41-103 kernel: [<ffffffffbc594f92>] system_call_fastpath+0x25/0x2a
```
