### PR TITLE
Compilation fix for 4.15.0-141-generic.

### DIFF
--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -89,7 +89,7 @@
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0) || \
     (LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0) && \
-     defined(blk_queue_fua))
+     defined(bvec_iter_sectors))
 #define QUEUE_FLAG_SET(flag,q) blk_queue_flag_set(flag, q);
 #else
 #define QUEUE_FLAG_SET(flag,q) queue_flag_set_unlocked(flag, q);


### PR DESCRIPTION
Fix compilation issue with 4.15.0-141-generic kernel.

**Which issue(s) this PR fixes** (optional)
PWX-19639

**Special notes for your reviewer**:
This should not be merged in yet... Need to check this change against Suse 4.12.x kernel builds.
