### PR TITLE
fix compilation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -2,9 +2,6 @@ px-objs = pxd.o dev.o iov_iter.o px_version.o io.o kiolib.o pxd_bio_makereq.o px
 obj-m = px.o
 
 KBUILD_CPPFLAGS := -D__KERNEL__
-#PXDEFINES := -D__PXKERNEL__ -D__PX_FASTPATH__ -D__PXD_BIO_MAKEREQ__
-PXDEFINES := -D__PXKERNEL__ -D__PX_FASTPATH__ -D__PXD_BIO_BLKMQ__
-
 KVERSION=$(shell uname -r)
 
 ifndef KERNELPATH
@@ -46,11 +43,20 @@ minver_minor=$(call minorfn, ${MINKVER})
 blkmq_major=$(call majorfn, ${BLKMQ_MINKVER})
 blkmq_minor=$(call minorfn, ${BLKMQ_MINKVER})
 
+kmajor=$(call majorfn, ${KERNELVER})
+kminor=$(call minorfn, ${KERNELVER})
+
+#makereq interface supports fastpath in all version (not recommended)
+#PXDEFINES := -D__PXKERNEL__ -D__PXD_BIO_MAKEREQ__
+#FPATH_MINKVER=${kmajor}.${kminor}
+
+#blkmq mode has version check for fastpath (default, enabled)
+PXDEFINES := -D__PXKERNEL__ -D__PXD_BIO_BLKMQ__
+FPATH_MINKVER=4.12
+
 fp_major=$(call majorfn, ${FPATH_MINKVER})
 fp_minor=$(call minorfn, ${FPATH_MINKVER})
 
-kmajor=$(call majorfn, ${KERNELVER})
-kminor=$(call minorfn, ${KERNELVER})
 
 ## min kernel version checks
 ifeq ($(call verlater,${minver_major},${kmajor}),0)
@@ -59,6 +65,19 @@ else
 ifeq ($(call versame,${minver_major},${kmajor}),0)
 ifeq ($(call verlater,${minver_minor},${kminor}),0)
 $(error Kernel version error: Build kernel version must be >= $(MINKVER).)
+endif
+endif
+endif
+
+## fastpath checks
+ifeq ($(call verlater,${kmajor},${fp_major}),0)
+PXDEFINES += -D__PX_FASTPATH__
+$(info Kernel version ${KERNELVER} supports fastpath.)
+else
+ifeq ($(call versame,${kmajor},${fp_major}),0)
+ifeq ($(call versameorlater,${kminor},${fp_minor}),0)
+PXDEFINES += -D__PX_FASTPATH__
+$(info Kernel version ${KERNELVER} supports fastpath.)
 endif
 endif
 endif

--- a/io.c
+++ b/io.c
@@ -1126,7 +1126,7 @@ static int io_discard(struct io_kiocb *req, const struct sqe_submit *s,
 
 	inode = req->file->f_inode;
 	if (S_ISBLK(inode->i_mode)) {
-		struct block_device *bdev = inode->i_bdev;
+		struct block_device *bdev = I_BDEV(inode);
 		struct address_space *mapping = bdev->bd_inode->i_mapping;
 		truncate_inode_pages_range(mapping, off, off + bytes - 1);
 		ret = blkdev_issue_discard(bdev, off / SECTOR_SIZE,

--- a/io.c
+++ b/io.c
@@ -1176,8 +1176,10 @@ static int io_syncfs(struct io_kiocb *req, const struct sqe_submit *s,
 		struct block_device *bdev = I_BDEV(inode);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,8,0) &&  !defined(QUEUE_FLAG_NOWAIT)
 		ret = blkdev_issue_flush(bdev, GFP_KERNEL, NULL);
-#else
+#elif LINUX_VERSION_CODE <= KERNEL_VERSION(5,11,0)
 		ret = blkdev_issue_flush(bdev, GFP_KERNEL);
+#else
+		ret = blkdev_issue_flush(bdev);
 #endif
 	}
 


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Fix compilation issue.
a) revalidate_disk_size failure (not needed from 5.11)
b) stats interface changes -- this path is now no longer supported in master (having switched to blkmq fastpath)
c) blk_freeze_queue_start -- only available from 4.12 (used in fastpath) unless distros backported changes.

```
[lns@clone8 px-fuse]$ git checkout -b master origin/master
Branch 'master' set up to track remote branch 'master' from 'origin'.
Switched to a new branch 'master'
[lns@clone8 px-fuse]$ make
Kernel version 5.11 supports blkmq driver model.
make  -C /usr/src/kernels/5.11.3-1.el8.elrepo.x86_64  M=/home/lns/srcs/src/github.com/portworx/px-fuse modules
make[1]: Entering directory '/usr/src/kernels/5.11.3-1.el8.elrepo.x86_64'
Kernel version 5.11 supports blkmq driver model.
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/pxd.o
/home/lns/srcs/src/github.com/portworx/px-fuse/pxd.c: In function ‘pxd_ioc_update_size’:
/home/lns/srcs/src/github.com/portworx/px-fuse/pxd.c:1507:2: error: implicit declaration of function ‘revalidate_disk_size’; did you mean ‘blk_revalidate_disk_zones’? [-Werror=implicit-function-declaration]
  revalidate_disk_size(pxd_dev->disk, true);
  ^~~~~~~~~~~~~~~~~~~~
  blk_revalidate_disk_zones
cc1: all warnings being treated as errors
make[2]: *** [scripts/Makefile.build:279: /home/lns/srcs/src/github.com/portworx/px-fuse/pxd.o] Error 1
make[1]: *** [Makefile:1800: /home/lns/srcs/src/github.com/portworx/px-fuse] Error 2
make[1]: Leaving directory '/usr/src/kernels/5.11.3-1.el8.elrepo.x86_64'
make: *** [Makefile:116: all] Error 2
[lns@clone8 px-fuse]$

```

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-20267

**Special notes for your reviewer**:
```
[lns@clone8 px-fuse]$ uname -r
5.11.3-1.el8.elrepo.x86_64
[lns@clone8 px-fuse]$ make clean all
Kernel version 5.11 supports blkmq driver model.
make -C /usr/src/kernels/5.11.3-1.el8.elrepo.x86_64  M=/home/lns/srcs/src/github.com/portworx/px-fuse clean
make[1]: Entering directory '/usr/src/kernels/5.11.3-1.el8.elrepo.x86_64'
Kernel version 5.11 supports blkmq driver model.
  CLEAN   /home/lns/srcs/src/github.com/portworx/px-fuse/Module.symvers
make[1]: Leaving directory '/usr/src/kernels/5.11.3-1.el8.elrepo.x86_64'
make  -C /usr/src/kernels/5.11.3-1.el8.elrepo.x86_64  M=/home/lns/srcs/src/github.com/portworx/px-fuse modules
make[1]: Entering directory '/usr/src/kernels/5.11.3-1.el8.elrepo.x86_64'
Kernel version 5.11 supports blkmq driver model.
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/pxd.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/dev.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/iov_iter.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/px_version.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/io.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/kiolib.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/pxd_bio_makereq.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/pxd_bio_blkmq.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/pxd_fastpath.o
  LD [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/px.o
Kernel version 5.11 supports blkmq driver model.
  MODPOST /home/lns/srcs/src/github.com/portworx/px-fuse/Module.symvers
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/px.mod.o
  LD [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/px.ko
make[1]: Leaving directory '/usr/src/kernels/5.11.3-1.el8.elrepo.x86_64'
[lns@clone8 px-fuse]$ 
```

# test logs on 5.12 #
```
[root@init500-f20 porx]# pxctl status
Status: PX is operational
Telemetry: Disabled or Unhealthy
License: Trial (expires in 31 days)
Node ID: a39581b4-7117-4cd1-b1bf-fbab6ac52844
        IP: 10.13.17.5
        Local Storage Pool: 1 pool
        POOL    IO_PRIORITY     RAID_LEVEL      USABLE  USED    STATUS  ZONE    REGION
        0       HIGH            raid0           14 TiB  10 GiB  Online  default default
        Local Storage Devices: 4 devices
        Device  Path            Media Type              Size            Last-Scan
        0:1     /dev/nvme4n1    STORAGE_MEDIUM_NVME     3.5 TiB         24 Jun 21 23:35 MDT
        0:2     /dev/nvme1n1    STORAGE_MEDIUM_NVME     3.5 TiB         24 Jun 21 23:35 MDT
        0:3     /dev/nvme2n1    STORAGE_MEDIUM_NVME     3.5 TiB         24 Jun 21 23:35 MDT
        0:4     /dev/nvme3n1    STORAGE_MEDIUM_NVME     3.5 TiB         24 Jun 21 23:35 MDT
        total                   -                       14 TiB
        Cache Devices:
         * No cache devices
Cluster Summary
        Cluster ID: px-lns4-PWX20267
        Cluster UUID: ae137813-c2d1-4abb-9e30-a5cc96cccf55
        Scheduler: none
        Nodes: 1 node(s) with storage (1 online)
        IP              ID                                      SchedulerNodeName       Auth            StorageNode     Used    Capacity        Status  StorageStatus   VersionKernel                          OS
        10.13.17.5      a39581b4-7117-4cd1-b1bf-fbab6ac52844    N/A                     Disabled        Yes             10 GiB  14 TiB          Online  Up (This node)  3.0.0.0-038d58b        5.12.13-1.el7.elrepo.x86_64     CentOS Linux 7 (Core)
        Warnings:
                 WARNING: Swap is enabled on this node.
                 WARNING: Persistent journald logging is not enabled on this node.
Global Storage Pool
        Total Used      :  10 GiB
        Total Capacity  :  14 TiB
[root@init500-f20 porx]# uname -r
5.12.13-1.el7.elrepo.x86_64
[root@init500-f20 porx]# pxctl v c -s 10 vol1
Volume successfully created: 820825397080589372
[root@init500-f20 porx]# pxctl host attach vol1
Volume successfully attached at: /dev/pxd/pxd820825397080589372
[root@init500-f20 porx]# pxctl v update -s 20 vol1
Update Volume: Volume update successful for volume vol1
[root@init500-f20 porx]# lsblk -o name,size /dev/pxd/pxd820825397080589372
NAME                      SIZE
pxd!pxd820825397080589372  20G
[root@init500-f20 porx]# runc exec -t portworx bash
root@init500-f20:/# ls -alh /var/.px/0/820825397080589372/pxdev
-rw------- 1 root root 20G Jun 25 05:38 /var/.px/0/820825397080589372/pxdev
root@init500-f20:/# exit
[root@init500-f20 porx]# pxctl v i vol1
        Volume                   :  820825397080589372
        Name                     :  vol1
        Size                     :  20 GiB
        Format                   :  ext4
        HA                       :  1
        IO Priority              :  HIGH
        Creation time            :  Jun 25 05:35:44 UTC 2021
        Shared                   :  no
        Status                   :  up
        State                    :  Attached: a39581b4-7117-4cd1-b1bf-fbab6ac52844 (10.13.17.5)
        Last Attached            :  Jun 25 05:35:50 UTC 2021
        Device Path              :  /dev/pxd/pxd820825397080589372
        Mount Options            :  discard
        ScanPolicy               :  repair_on_mount
        Reads                    :  200
        Reads MS                 :  189
        Bytes Read               :  5304320
        Writes                   :  5338126
        Writes MS                :  9656532
        Bytes Written            :  21864964096
        Discards                 :  0
        Discards MS              :  0
        Bytes Discarded          :  0
        IOs in progress          :  128
        Bytes used               :  10 GiB
        Replica sets on nodes:
                Set 0
                  Node           : 10.13.17.5 (Pool 761da9ce-58a3-48fc-9a20-1c370b048b72 )
        Replication Status       :  Up
[root@init500-f20 porx]#
```

# dmesg logs during resize #
```
[Thu Jun 24 23:35:19 2021] read 0 write 0 sequence 1
[Thu Jun 24 23:35:19 2021] pxd_control_open: pxd-control-0(1) open OK
[Thu Jun 24 23:35:19 2021] pxd_vm_open 0 off 0 start 140296857788416 end 140296876666880
[Thu Jun 24 23:35:19 2021] pxd_read_init: pxd-control-0 init OK 0 devs version 12
[Thu Jun 24 23:35:19 2021] nfsd: last server has exited, flushing export cache
[Thu Jun 24 23:35:21 2021] NFSD: Using UMH upcall client tracking operations.
[Thu Jun 24 23:35:21 2021] NFSD: starting 90-second grace period (net f00000d8)
[Thu Jun 24 23:35:42 2021] Device 820825397080589372 added ffff91e4be2ea000 with mode 0x48002 fastpath 0 npath 0
[Thu Jun 24 23:35:49 2021] Device 820825397080589372 added ffff91e4be2e9000 with mode 0x48002 fastpath 0 npath 0
[Thu Jun 24 23:37:18 2021] pxd/pxd820825397080589372: detected capacity change from 20971520 to 41943040

```