### PR TITLE
PWX-20602: pre-check stale devices before add

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1354,14 +1354,16 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 	err = vfs_stat(devfile, &pxdev_stat);
 	if (err == 0) {
 		pr_err("stale device(%s) found, attach fail", devfile);
-		return -EEXIST;
+		err = -EEXIST;
+		goto out_module;
 	}
 
 	sprintf(devfile, "/sys/devices/virtual/block/pxd!pxd%llu", add->dev_id);
 	err = vfs_stat(devfile, &pxdev_stat);
 	if (err == 0) {
 		pr_err("stale device(%s) found, attach fail", devfile);
-		return -EEXIST;
+		err = -EEXIST;
+		goto out_module;
 	}
 
 	pxd_dev = kzalloc(sizeof(*pxd_dev), GFP_KERNEL);


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

**What this PR does / why we need it**:
Adds stale device checks before adding new device to kernel.
checks for both actual block device and its sysfs device existence.
if they are present, during a device attach, then device attach will crash in add disk path inside the kernel.
This window may open up if forced detach gets used.

**Which issue(s) this PR fixes** (optional)
Closes #
part of https://portworx.atlassian.net/browse/PWX-20602
**Special notes for your reviewer**:

