### PR TITLE
perf: ioring background processing fixes

### DIFF
--- a/fuse_i.h
+++ b/fuse_i.h
@@ -131,7 +131,7 @@ struct ____cacheline_aligned fuse_queue_writer {
 	uint32_t write;         /** cached write index */
 	uint32_t read;		/** cached read index */
 	spinlock_t lock;	/** writer lock */
-	uint32_t need_wake_up; /** if true reader needs wake up call */
+	uint32_t pad1; /** not used */
 	uint64_t sequence;        /** next request sequence number */
 	uint64_t pad[5];
 };
@@ -141,7 +141,7 @@ struct ____cacheline_aligned fuse_queue_reader {
 	uint32_t read;          /** read index updated by reader */
 	uint32_t write;		/** write index updated by writer */
 	uint32_t pad_0;
-	uint32_t pad;
+	atomic_t need_wake_up;
 	uint64_t pad_2[6];
 };
 
@@ -156,7 +156,7 @@ struct alignas(64) fuse_queue_writer {
 	uint32_t write;         	/** cached write index */
 	uint32_t read;			/** cached read index */
 	px::spinlock lock;		/** writer lock */
-	uint32_t need_wake_up;
+	uint32_t pad_3; /** not used */
 	uint64_t sequence;      /** next request sequence number */
 	uint32_t committed_;    /** last write index committed to reader */
 	bool in_runq;			/** a thread is processing the queue */
@@ -169,6 +169,7 @@ struct alignas(64) fuse_queue_reader {
 	std::atomic<uint32_t> read;	/** read index updated by reader */
 	std::atomic<uint32_t> write;	/** write index updated by writer */
 	px::spinlock lock;
+	std::atomic<uint32_t> need_wake_up;
 	uint64_t pad_2[6];
 };
 

--- a/io.c
+++ b/io.c
@@ -2041,10 +2041,6 @@ static int io_sq_thread(void *data)
 			atomic_dec(&ctx->requests_cb->r.need_wake_up);
 
 			if (kthread_should_stop()) {
-				if (cur_mm) {
-					io_sq_remove_user_mm(cur_mm, old_fs);
-					cur_mm = NULL;
-				}
 				break;
 			}
 			continue;

--- a/io.h
+++ b/io.h
@@ -49,6 +49,7 @@
 #include <linux/percpu-refcount.h>
 #include <linux/miscdevice.h>
 #include "fuse_i.h"
+#include "pxd_io_uring.h"
 
 struct async_list {
 	spinlock_t		lock;
@@ -87,7 +88,7 @@ struct io_ring_ctx {
 
 	/* IO offload */
 	struct workqueue_struct	*sqo_wq;
-#define NSLAVES (8)
+#define NSLAVES (8u)
 	struct task_struct	*sqo_thread[NSLAVES];	/* if using sq thread polling */
 	struct mm_struct	*sqo_mm;
 	wait_queue_head_t	sqo_wait;
@@ -174,6 +175,7 @@ struct io_kiocb {
 		struct io_poll_iocb	poll;
 	};
 
+	struct io_uring_sqe __attribute__((aligned(8))) cached_sqe; // cached orig req
 	struct sqe_submit	submit;
 
 	struct io_ring_ctx	*ctx;

--- a/io.h
+++ b/io.h
@@ -87,9 +87,11 @@ struct io_ring_ctx {
 
 	/* IO offload */
 	struct workqueue_struct	*sqo_wq;
-	struct task_struct	*sqo_thread;	/* if using sq thread polling */
+#define NSLAVES (8)
+	struct task_struct	*sqo_thread[NSLAVES];	/* if using sq thread polling */
 	struct mm_struct	*sqo_mm;
 	wait_queue_head_t	sqo_wait;
+	spinlock_t		io_lock;
 
 	struct {
 		/* CQ ring */

--- a/pxd.h
+++ b/pxd.h
@@ -38,6 +38,7 @@
 #define PXD_IOC_IO_FLUSHER		_IO(PXD_IOCTL_MAGIC, 10)	/* 0x50580a */
 #define PXD_IOC_INIT_IO         _IO(PXD_IOCTL_MAGIC, 11)    /* 0x50580b */
 #define PXD_IOC_WAKE_UP_SQO     _IO(PXD_IOCTL_MAGIC, 12)    /* 0x50580c */
+#define PXD_IOC_RUN_CMD     _IO(PXD_IOCTL_MAGIC, 13)    /* 0x50580d */
 
 #define PXD_MAX_DEVICES	512			/**< maximum number of devices supported */
 #define PXD_MAX_IO		(1024*1024)	/**< maximum io size in bytes */

--- a/pxd_io_uring.h
+++ b/pxd_io_uring.h
@@ -132,7 +132,8 @@ struct io_uring_params {
 	__u32 flags;
 	__u32 sq_thread_cpu;
 	__u32 sq_thread_idle;
-	__u32 resv[5];
+	__u32 sqo_threads; // ofload threads
+	__u32 resv[4];
 	struct io_sqring_offsets sq_off;
 	struct io_cqring_offsets cq_off;
 };


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This is my in a series of change to address perf gap between master and 2.8.
This focusses only on uring path changes.

1/ enables background processing of IOs submitted to uring. Currently they are run in the context of the 
submit user thread.

2/ below results confirm perf is better than master in all profiles.
3/ vs 2.8 still some work to do.

This goes with https://github.com/portworx/porx/pull/7913

**Which issue(s) this PR fixes** (optional)
Closes #
https://portworx.atlassian.net/browse/PWX-20970
**Special notes for your reviewer**:


                 | 2.8.0 default | master default | only uring changes |     
1vol          | KIOPS           | KIOPS               | KIOPS                      | % improvement vs 2.8 | % improvement vs master
seqwrite   | 172               | 115                   | 116                          | -32.55813953               | 0.869565217
seqread    | 246               | 246                   |  296                         | 20.32520325                | 20.32520325
randwrite | 87                 | 68                     | 71                            | -18.3908046                 | 4.411764706
randread  | 137               | 93                     | 270                          | 97.08029197                 | 190.3225806

40vol        
seqwrite   | 234               | 312                  | 357                           | 52.56410256                  | 14.42307692
seqread    | 420               | 184                 | 185                            | -55.95238095                 | 0.543478261
randwrite | 95                 | 81                    | 83                             | -12.63157895                 | 2.469135802
randread  | 62                | 73                     | 183                           | 195.1612903                   | 150.6849315



