### PR TITLE
io profiling: high level io density map support

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -607,8 +607,10 @@ static void pxd_req_misc(struct fuse_req *req, uint32_t size, uint64_t off,
 		switch (req->in.opcode) {
 		case PXD_READ:
 			req->pxd_dev->io_map[0][idx]++;
+			break;
 		case PXD_WRITE:
 			req->pxd_dev->io_map[1][idx]++;
+			break;
 		case PXD_DISCARD:
 			req->pxd_dev->io_map[2][idx]++;
 			break;

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -62,6 +62,9 @@ struct pxd_device {
 #if defined(__PXD_BIO_BLKMQ__) && defined(__PX_BLKMQ__)
         struct blk_mq_tag_set tag_set;
 #endif
+	// to capture io pattern map for each supported blocksize
+	// separate for read/write and discard.
+	uint64_t io_map[3][256];
 };
 
 // how pxd_device got registered with the kernel during device add.


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
a simple io profiler per volume at driver to identify frequent request sizes.
helps plot out a density map of requests on size for read/write and discard.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

