### PR TITLE
PWX20756: iouring increase file limit

### DIFF
--- a/io.c
+++ b/io.c
@@ -2131,19 +2131,15 @@ static int io_sqe_register_file(struct io_ring_ctx *ctx, int fd)
 	}
 
 	err = -ENFILE;
-	if (i == ctx->nr_user_files) {
-		pr_err("iouring: max user file limit");
+	if (i == ctx->nr_user_files)
 		goto out;
-	}
 
 	err = -EBADF;
 	ctx->user_files[i] = fget(fd);
 	if (!ctx->user_files[i])
-		pr_err("iouring: bad file descriptor");
 		goto out;
 
 	if (ctx->user_files[i]->f_op == &fuse_dev_operations) {
-		pr_err("iouring: got control fd");
 		fput(ctx->user_files[i]);
 		ctx->user_files[i] = NULL;
 		goto out;
@@ -2153,6 +2149,7 @@ static int io_sqe_register_file(struct io_ring_ctx *ctx, int fd)
 	return i;
 
 out:
+	pr_err("iouring: register file failed with %d", err);
 	mutex_unlock(&ctx->uring_lock);
 	return err;
 }


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
https://portworx.atlassian.net/browse/PWX-20756

hit register file exception as below
```
#0  0x00007f387a1a418b in raise () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007f387a183859 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00007f387a183729 in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#3  0x00007f387a194f36 in __assert_fail () from /lib/x86_64-linux-gnu/libc.so.6
#4  0x000056005d0a63ee in px::ioring::Context::register_file (
    this=<optimized out>, fd=<optimized out>) at gdsd/pxd_io.cc:144
#5  0x000056005d0e2c79 in px::target::FileHandle::FileHandle (
```

The number of replica targets is 521 on that node.
Px in master, opens each file in two modes this doubles the count.
In px-fuse driver for iouring, there is a max limit of only 1024 file handles. This breaches the limit failing the px startup code.
The px-fuse limit for file descr limit has to be increased.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-20756

**Special notes for your reviewer**:

