### PR TITLE
fix compilation in ubuntu 4.15

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1315,6 +1315,18 @@ struct pxd_device* find_pxd_device(struct pxd_context *ctx, uint64_t dev_id)
 	return pxd_dev;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
+typedef struct block_device* (*lookup_bdev_wrapper_fn)(char *dev, int mask);
+// This hack is needed because in ubuntu lookup_bdev is defined with 2 arg.
+// ubuntu commit id 6bdf7d686366556020b6ed044fa9eadd090d3984
+// struct block_device *lookup_bdev(const char *pathname, int mask)
+// mask = 0, no perm checks are done
+// So this module shall always push 2 args into stack, but the kernel function
+// decides whether it uses both or only 1.
+// This satisfies the compilation.
+static lookup_bdev_wrapper_fn lookup_bdev_wrapper = (lookup_bdev_wrapper_fn)lookup_bdev;
+#endif
+
 static int __pxd_update_path(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path);
 ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 {
@@ -1356,7 +1368,7 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 	/* pre-check to detect if prior instance is removed */
 	sprintf(devfile, "/dev/pxd/pxd%llu", add->dev_id);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
-	bdev = lookup_bdev(devfile);
+	bdev = lookup_bdev_wrapper(devfile, 0);
 	if (!IS_ERR(bdev)) {
 		bdput(bdev);
 		pr_err("stale bdev %s still alive", devfile);


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
compilation fix for lookup_bdev.

In ubuntu alone this function has been extended with one additional arg to check for permission.
To address this, px-fuse module will always push with 2 args while calling lookup_bdev, while the actual kernel function can decide whether to use one or both args. This though is a hackish way, is clean and should work always.

Introduced part of https://github.com/portworx/px-fuse/pull/218

Ubuntu kernel commit for reference:
```
commit 6bdf7d686366556020b6ed044fa9eadd090d3984
Author: Seth Forshee <seth.forshee@canonical.com>
Date:   Fri Jul 31 12:58:34 2015 -0500

    UBUNTU: SAUCE: (namespace) block_dev: Support checking inode permissions in lookup_bdev()

    When looking up a block device by path no permission check is
    done to verify that the user has access to the block device inode
    at the specified path. In some cases it may be necessary to
    check permissions towards the inode, such as allowing
    unprivileged users to mount block devices in user namespaces.

    Add an argument to lookup_bdev() to optionally perform this
    permission check. A value of 0 skips the permission check and
    behaves the same as before. A non-zero value specifies the mask
    of access rights required towards the inode at the specified
    path. The check is always skipped if the user has CAP_SYS_ADMIN.

    All callers of lookup_bdev() currently pass a mask of 0, so this
    patch results in no functional change. Subsequent patches will
    add permission checks where appropriate.

    Acked-by: Serge Hallyn <serge.hallyn@canonical.com>
    Signed-off-by: Seth Forshee <seth.forshee@canonical.com>

```
**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-20602



**Special notes for your reviewer**:

