### PR TITLE
fix io fail during device attach

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -834,12 +834,12 @@ static int fuse_notify(struct fuse_conn *fc, enum fuse_notify_code code,
 		return fuse_notify_suspend(fc, size, iter);
 	case PXD_RESUME:
 		return fuse_notify_resume(fc, size, iter);
-    case PXD_FAILOVER_TO_USERSPACE:
-        return fuse_notify_ioswitch_event(fc, size, iter, true);
-    case PXD_FALLBACK_TO_KERNEL:
-        return fuse_notify_ioswitch_event(fc, size, iter, false);
-    case PXD_EXPORT_DEV:
-        return fuse_notify_export(fc, size, iter);
+	case PXD_FAILOVER_TO_USERSPACE:
+		return fuse_notify_ioswitch_event(fc, size, iter, true);
+	case PXD_FALLBACK_TO_KERNEL:
+		return fuse_notify_ioswitch_event(fc, size, iter, false);
+	case PXD_EXPORT_DEV:
+		return fuse_notify_export(fc, size, iter);
 	default:
 		return -EINVAL;
 	}

--- a/dev.c
+++ b/dev.c
@@ -803,7 +803,6 @@ static int fuse_notify_ioswitch_event(struct fuse_conn *conn, unsigned int size,
 static int fuse_notify_export(struct fuse_conn *conn, unsigned int size,
 		struct iov_iter *iter)
 {
-	struct pxd_context *ctx = container_of(conn, struct pxd_context, fc);
 	uint64_t dev_id;
 	size_t len = sizeof(dev_id);
 

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -328,6 +328,7 @@ struct fuse_conn *fuse_conn_get(struct fuse_conn *fc);
 int fuse_restart_requests(struct fuse_conn *fc);
 
 ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add);
+ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id);
 ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove);
 ssize_t pxd_update_size(struct fuse_conn *fc, struct pxd_update_size *update_size);
 ssize_t pxd_ioc_update_size(struct fuse_conn *fc, struct pxd_update_size *update_size);

--- a/pxd.c
+++ b/pxd.c
@@ -1362,7 +1362,7 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 		} else {
 			disableFastPath(pxd_dev, false);
 		}
-		return pxd_dev->minor | (fastpath_active(pxd_dev) << MINORBITS);
+		return pxd_dev->minor;
 	}
 
 	/* pre-check to detect if prior instance is removed */
@@ -1461,7 +1461,7 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 	++ctx->num_devices;
 	spin_unlock(&ctx->lock);
 
-	return pxd_dev->minor | (fastpath_active(pxd_dev) << MINORBITS);
+	return pxd_dev->minor;
 
 out_disk:
 	pxd_free_disk(pxd_dev);

--- a/pxd.c
+++ b/pxd.c
@@ -1362,7 +1362,7 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 		} else {
 			disableFastPath(pxd_dev, false);
 		}
-		return pxd_dev->minor;
+		return pxd_dev->minor | (fastpath_active() << MINORBITS);
 	}
 
 	/* pre-check to detect if prior instance is removed */
@@ -1463,7 +1463,7 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 
 	add_disk(pxd_dev->disk);
 
-	return pxd_dev->minor;
+	return pxd_dev->minor | (fastpath_active() << MINORBITS);
 
 out_disk:
 	pxd_free_disk(pxd_dev);

--- a/pxd.c
+++ b/pxd.c
@@ -1461,8 +1461,6 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 	++ctx->num_devices;
 	spin_unlock(&ctx->lock);
 
-	add_disk(pxd_dev->disk);
-
 	return pxd_dev->minor | (fastpath_active(pxd_dev) << MINORBITS);
 
 out_disk:
@@ -1475,6 +1473,19 @@ out_module:
 	module_put(THIS_MODULE);
 out:
 	return err;
+}
+
+ssize_t pxd_export(struct fuse_conn *fc, struct pxd_add_ext_out *add)
+{
+	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
+	struct pxd_device *pxd_dev = find_pxd_device(ctx, add->dev_id);
+
+	if (pxd_dev) {
+		add_disk(pxd_dev->disk);
+		return 0;
+	}
+
+	return -ENOENT;
 }
 
 ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)

--- a/pxd.c
+++ b/pxd.c
@@ -1475,10 +1475,10 @@ out:
 	return err;
 }
 
-ssize_t pxd_export(struct fuse_conn *fc, struct pxd_add_ext_out *add)
+ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 {
 	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
-	struct pxd_device *pxd_dev = find_pxd_device(ctx, add->dev_id);
+	struct pxd_device *pxd_dev = find_pxd_device(ctx, dev_id);
 
 	if (pxd_dev) {
 		add_disk(pxd_dev->disk);

--- a/pxd.c
+++ b/pxd.c
@@ -1362,7 +1362,7 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 		} else {
 			disableFastPath(pxd_dev, false);
 		}
-		return pxd_dev->minor | (fastpath_active() << MINORBITS);
+		return pxd_dev->minor | (fastpath_active(pxd_dev) << MINORBITS);
 	}
 
 	/* pre-check to detect if prior instance is removed */
@@ -1463,7 +1463,7 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 
 	add_disk(pxd_dev->disk);
 
-	return pxd_dev->minor | (fastpath_active() << MINORBITS);
+	return pxd_dev->minor | (fastpath_active(pxd_dev) << MINORBITS);
 
 out_disk:
 	pxd_free_disk(pxd_dev);

--- a/pxd.h
+++ b/pxd.h
@@ -9,7 +9,6 @@
 #include <stdint.h>
 #include <sys/param.h>
 #include <string.h>
-
 #endif
 
 #include "fuse.h"

--- a/pxd.h
+++ b/pxd.h
@@ -10,10 +10,6 @@
 #include <sys/param.h>
 #include <string.h>
 
-// definitions needed by userspace
-#define MINORBITS   20
-#define MINORMASK   ((1U << MINORBITS) - 1)
-
 #endif
 
 #include "fuse.h"

--- a/pxd.h
+++ b/pxd.h
@@ -9,6 +9,11 @@
 #include <stdint.h>
 #include <sys/param.h>
 #include <string.h>
+
+// definitions needed by userspace
+#define MINORBITS   20
+#define MINORMASK   ((1U << MINORBITS) - 1)
+
 #endif
 
 #include "fuse.h"

--- a/pxd.h
+++ b/pxd.h
@@ -78,6 +78,7 @@ enum pxd_opcode {
 						  from kernel on a suspended device */
 	PXD_FALLBACK_TO_KERNEL,   /**< Fallback requests suspend IO and send in a marker req
 						  from kernel on a suspended device */
+	PXD_EXPORT_DEV,     /**< export the attached device to the kernel */
 	PXD_LAST,
 };
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

This address the IO fail during device attach.
device attach is split into two phases, first phase, setup everything except adding the disk to the kernel.
explicit export_device call exports the previous setup device.

```
[Mon Jul  5 14:16:59 2021] Device 953640569781256930 added with mode 0x0 fastpath 0 npath 0
[Mon Jul  5 14:16:59 2021] print_req_error: 14 callbacks suppressed
[Mon Jul  5 14:16:59 2021] blk_update_request: I/O error, dev pxd/pxd953640569781256930, sector 209715072 op 0x0:(READ) flags 0x80700 phys_seg 1 prio
[Mon Jul  5 14:16:59 2021] blk_update_request: I/O error, dev pxd/pxd953640569781256930, sector 209715072 op 0x0:(READ) flags 0x0 phys_seg 1 prio cla
[Mon Jul  5 14:16:59 2021] buffer_io_error: 2 callbacks suppressed
[Mon Jul  5 14:16:59 2021] Buffer I/O error on dev pxd/pxd953640569781256930, logical block 26214384, async page read
[Mon Jul  5 14:17:00 2021] Device 1134014523823128556 added with mode 0x0 fastpath 0 npath 0
[Mon Jul  5 14:17:00 2021] blk_update_request: I/O error, dev pxd/pxd1134014523823128556, sector 209715072 op 0x0:(READ) flags 0x80700 phys_seg 1 pri
[Mon Jul  5 14:17:00 2021] blk_update_request: I/O error, dev pxd/pxd1134014523823128556, sector 209715072 op 0x0:(READ) flags 0x0 phys_seg 1 prio cl
[Mon Jul  5 14:17:00 2021] Buffer I/O error on dev pxd/pxd1134014523823128556, logical block 26214384, async page read
[Mon Jul  5 14:17:00 2021] Device 177076861318275126 added with mode 0x0 fastpath 0 npath 0
[Mon Jul  5 14:17:00 2021] blk_update_request: I/O error, dev pxd/pxd177076861318275126, sector 209715072 op 0x0:(READ) flags 0x80700 phys_seg 1 prio
[Mon Jul  5 14:17:00 2021] blk_update_request: I/O error, dev pxd/pxd177076861318275126, sector 209715072 op 0x0:(READ) flags 0x0 phys_seg 1 prio cla
[Mon Jul  5 14:17:00 2021] Buffer I/O error on dev pxd/pxd177076861318275126, logical block 26214384, async page read
[Mon Jul  5 14:17:01 2021] Device 324207445964242906 added with mode 0x0 fastpath 0 npath 0
[Mon Jul  5 14:17:01 2021] blk_update_request: I/O error, dev pxd/pxd324207445964242906, sector 209715072 op 0x0:(READ) flags 0x80700 phys_seg 1 prio
[Mon Jul  5 14:17:01 2021] blk_update_request: I/O error, dev pxd/pxd324207445964242906, sector 209715072 op 0x0:(READ) flags 0x0 phys_seg 1 prio cla
[Mon Jul  5 14:17:01 2021] Buffer I/O error on dev pxd/pxd324207445964242906, logical block 26214384, async page read
```

**Which issue(s) this PR fixes** (optional)
Closes #
https://portworx.atlassian.net/browse/PWX-20967

**Special notes for your reviewer**:

