### PR TITLE
PWX-21175: handle kernel crash in fastpath + compilation fix

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -88,7 +88,7 @@ static int pxd_open(struct block_device *bdev, fmode_t mode)
 		err = -ENXIO;
 	} else {
 		spin_lock(&pxd_dev->lock);
-		if (atomic_read(&pxd_dev->removing))
+		if (pxd_dev->removing)
 			err = -EBUSY;
 		else
 			pxd_dev->open_count++;
@@ -1026,15 +1026,18 @@ static void pxd_rq_fn(struct request_queue *q)
 
 #ifdef __PX_FASTPATH__
 		if (pxd_dev->fp.fastpath) {
+#if 0
 			if (!pxd_dev->fp.wq || atomic_read(&pxd_dev->removing)) {
 				pr_info("EIO: pxd device %llu removing...\n", pxd_dev->dev_id);
 				__blk_end_request_all(rq, 0);
 				continue;
 			}
+#endif
 			// route through fastpath
 			// INIT_WORK(&fproot->work, fp_handle_io);
 			// queue_work(pxd_dev->fp.wq, &fproot->work);
-			schedule_work(&fproot->work);
+			// schedule_work(&fproot->work);
+			queue_work(fastpath_workqueue(), &fproot->work);
 			spin_lock_irq(&pxd_dev->qlock);
 			continue;
 		}
@@ -1088,11 +1091,6 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 	if (BLK_RQ_IS_PASSTHROUGH(rq) || !READ_ONCE(fc->allow_disconnected))
 		return BLK_STS_IOERR;
 
-	if (atomic_read(&pxd_dev->removing)) {
-		pr_info("EIO: pxd device %llu removing...\n", pxd_dev->dev_id);
-		return BLK_STS_IOERR;
-	}
-
 	pxd_printk("%s: dev m %d g %lld %s at %ld len %d bytes %d pages "
 		   "flags  %x\n", __func__,
 		pxd_dev->minor, pxd_dev->dev_id,
@@ -1111,16 +1109,19 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 
 #ifdef __PX_FASTPATH__
 	if (pxd_dev->fp.fastpath) {
+#if 0
 		if (!pxd_dev->fp.wq || atomic_read(&pxd_dev->removing)) {
 			pr_info("EIO: pxd device %llu removing...\n", pxd_dev->dev_id);
 			return BLK_STS_IOERR;
 		}
+#endif
 		// route through fastpath
 		// while in blkmq mode: cannot directly process IO from this thread... involves
 		// recursive BIO submission to the backing devices, causing deadlock.
 		// INIT_WORK(&fproot->work, fp_handle_io);
 		// queue_work(pxd_dev->fp.wq, &fproot->work);
-		schedule_work(&fproot->work);
+		// schedule_work(&fproot->work);
+		queue_work(fastpath_workqueue(), &fproot->work);
 		return BLK_STS_OK;
 	}
 #endif
@@ -1382,7 +1383,7 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 	pxd_mem_printk("device %llu allocated at %px\n", add->dev_id, pxd_dev);
 
 	pxd_dev->magic = PXD_DEV_MAGIC;
-	atomic_set(&pxd_dev->removing, 0u);
+	pxd_dev->removing = false;
 	spin_lock_init(&pxd_dev->lock);
 	spin_lock_init(&pxd_dev->qlock);
 
@@ -1512,7 +1513,7 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 		goto out;
 	}
 
-	atomic_set(&pxd_dev->removing, 1u);
+	pxd_dev->removing = true;
 	wmb();
 	pr_info("removing device %llu", pxd_dev->dev_id);
 
@@ -1557,7 +1558,7 @@ ssize_t pxd_ioc_update_size(struct fuse_conn *fc, struct pxd_update_size *update
 
 	spin_lock(&ctx->lock);
 	list_for_each_entry(pxd_dev, &ctx->list, node) {
-		if ((pxd_dev->dev_id == update_size->dev_id) && !atomic_read(&pxd_dev->removing)) {
+		if ((pxd_dev->dev_id == update_size->dev_id) && !pxd_dev->removing) {
 			spin_lock(&pxd_dev->lock);
 			found = true;
 			break;

--- a/pxd.c
+++ b/pxd.c
@@ -1024,6 +1024,7 @@ static void pxd_rq_fn(struct request_queue *q)
 		fproot = &req->fproot;
 		fp_root_context_init(fproot);
 
+#ifdef __PX_FASTPATH__
 		if (pxd_dev->fp.fastpath) {
 			// route through fastpath
 			INIT_WORK(&fproot->work, fp_handle_io);
@@ -1031,6 +1032,7 @@ static void pxd_rq_fn(struct request_queue *q)
 			spin_lock_irq(&pxd_dev->qlock);
 			continue;
 		}
+#endif
 		atomic_inc(&pxd_dev->fp.nslowPath);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) || defined(REQ_PREFLUSH)
 		if (pxd_request(req, blk_rq_bytes(rq), blk_rq_pos(rq) * SECTOR_SIZE,
@@ -1096,6 +1098,7 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 	req->pxd_dev = pxd_dev;
 	req->rq = rq;
 
+#ifdef __PX_FASTPATH__
 	if (pxd_dev->fp.fastpath) {
 		// route through fastpath
 		// while in blkmq mode: cannot directly process IO from this thread... involves
@@ -1104,6 +1107,7 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 		queue_work(pxd_dev->fp.wq, &fproot->work);
 		return BLK_STS_OK;
 	}
+#endif
 	atomic_inc(&pxd_dev->fp.nslowPath);
 
 	if (pxd_request(req, blk_rq_bytes(rq), blk_rq_pos(rq) * SECTOR_SIZE,
@@ -1638,6 +1642,30 @@ static int __pxd_update_path(struct pxd_device *pxd_dev, struct pxd_update_path_
 	return pxd_init_fastpath_target(pxd_dev, update_path);
 }
 
+static void _pxd_setup(struct pxd_device *pxd_dev, bool enable)
+{
+	if (!enable) {
+		printk(KERN_NOTICE "device %llu called to disable IO\n", pxd_dev->dev_id);
+		pxd_dev->connected = false;
+		pxd_abortfailQ(pxd_dev);
+	} else {
+		printk(KERN_NOTICE "device %llu called to enable IO\n", pxd_dev->dev_id);
+		pxd_dev->connected = true;
+	}
+}
+
+static void pxdctx_set_connected(struct pxd_context *ctx, bool enable)
+{
+	struct list_head *cur;
+	spin_lock(&ctx->lock);
+	list_for_each(cur, &ctx->list) {
+		struct pxd_device *pxd_dev = container_of(cur, struct pxd_device, node);
+
+		_pxd_setup(pxd_dev, enable);
+	}
+	spin_unlock(&ctx->lock);
+}
+
 static struct bus_type pxd_bus_type = {
 	.name		= "pxd",
 };
@@ -1926,6 +1954,7 @@ static ssize_t pxd_debug_store(struct device *dev,
 			struct device_attribute *attr,
 		        const char *buf, size_t count)
 {
+#ifdef __PX_FASTPATH__
 	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
 	switch (buf[0]) {
 	case 'Y': /* switch native path through IO failover */
@@ -1960,7 +1989,7 @@ static ssize_t pxd_debug_store(struct device *dev,
 		/* no action */
 		printk("dev:%llu - no action for %c\n", pxd_dev->dev_id, buf[0]);
 	}
-
+#endif
 	return count;
 }
 

--- a/pxd.c
+++ b/pxd.c
@@ -1506,7 +1506,6 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 
 	spin_unlock(&pxd_dev->lock);
 
-	pxd_fastpath_cleanup(pxd_dev);
 	device_unregister(&pxd_dev->dev);
 
 	module_put(THIS_MODULE);

--- a/pxd.c
+++ b/pxd.c
@@ -1507,7 +1507,6 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 
 		mutex_unlock(&pxd_dev->disk->queue->sysfs_lock);
 #else
-		blk_mq_freeze_queue(pxd_dev->disk->queue);
 		blk_set_queue_dying(pxd_dev->disk->queue);
 #endif
 	}

--- a/pxd_bio.h
+++ b/pxd_bio.h
@@ -47,7 +47,6 @@ static inline void fp_root_context_init(struct fp_root_context *fproot) {
   fproot->clones = NULL;
   atomic_set(&fproot->nactive, 0);
   INIT_LIST_HEAD(&fproot->wait);
-  // work struct should get initialized right before use
   INIT_WORK(&fproot->work, fp_handle_io);
 }
 

--- a/pxd_bio.h
+++ b/pxd_bio.h
@@ -26,6 +26,9 @@ void pxd_suspend_io(struct pxd_device *pxd_dev);
 void pxd_resume_io(struct pxd_device *pxd_dev);
 
 #ifdef __PXD_BIO_BLKMQ__
+// io entry point
+void fp_handle_io(struct work_struct *work);
+
 // structure is exported only so, it can be embedded within fuse_context.
 // Treat it as private outside fastpath
 struct fp_root_context {
@@ -45,10 +48,9 @@ static inline void fp_root_context_init(struct fp_root_context *fproot) {
   atomic_set(&fproot->nactive, 0);
   INIT_LIST_HEAD(&fproot->wait);
   // work struct should get initialized right before use
+  INIT_WORK(&fproot->work, fp_handle_io);
 }
 
-// io entry point
-void fp_handle_io(struct work_struct *work);
 #endif
 
 #endif /* _PXD_BIO_H_ */

--- a/pxd_bio.h
+++ b/pxd_bio.h
@@ -43,6 +43,7 @@ static inline void fp_root_context_init(struct fp_root_context *fproot) {
   fproot->bio = NULL;
   fproot->clones = NULL;
   atomic_set(&fproot->nactive, 0);
+  INIT_LIST_HEAD(&fproot->wait);
   // work struct should get initialized right before use
 }
 

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -281,10 +281,11 @@ static int prep_root_bio(struct fp_root_context *fproot) {
                    op_flags);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0) || defined(REQ_PREFLUSH)
-        if ((BIO_OP(rq->bio) != REQ_OP_FLUSH) &&
-            (BIO_OP(rq->bio) != REQ_OP_DISCARD)) {
+        if ((REQ_OP(rq) != REQ_OP_DISCARD) && (blk_rq_bytes(rq) != 0)) {
+            BUG_ON(BIO_OP(rq->bio) == REQ_OP_DISCARD);
 #else
-        if (!(BIO_OP(rq->bio) & (REQ_FLUSH | REQ_DISCARD))) {
+        if (!(REQ_OP(rq) & REQ_DISCARD) && (blk_rq_bytes(rq) != 0)) {
+            BUG_ON(BIO_OP(rq->bio) & REQ_DISCARD);
 #endif
                 rq_for_each_segment(bv, rq, rq_iter) {
                         unsigned len =

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -595,8 +595,8 @@ static void fp_handle_specialops(struct work_struct *work) {
         }
 #endif
 
-		printk("%s discard for device %llu, off %lu, sectors %d\n",
-				__func__, pxd_dev->dev_id, blk_rq_pos(rq), blk_rq_sectors(rq));
+		printk("%s discard for device %llu, off %llu, sectors %u\n",
+				__func__, pxd_dev->dev_id, (unsigned long long)blk_rq_pos(rq), blk_rq_sectors(rq));
 
         // submit discard to replica
         if (blk_queue_discard(q)) { // discard supported

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -245,11 +245,17 @@ static int prep_root_bio(struct fp_root_context *fproot) {
         BUG_ON(fproot->magic != FP_ROOT_MAGIC);
 
         // it is possible for sync request to carry no bio
-        if (!rq->bio)
+        if (!rq->bio) {
+				printk("%s:(none) rq->cmd_flags %#x req_op %#x bio_op %#x op_flags %#x\n",
+					__func__, rq->cmd_flags, req_op(rq), 0, op_flags);
                 return 0;
+		}
 
         // single bio request
         if (rq->bio == rq->biotail) {
+				printk("%s:(single) rq->cmd_flags %#x req_op %#x bio_op %#x op_flags %#x\n",
+                   __func__, rq->cmd_flags, req_op(rq), BIO_OP(rq->bio),
+                   op_flags);
                 fproot->bio = rq->bio;
                 BUG_ON(BIO_SECTOR(fproot->bio) != blk_rq_pos(rq));
                 BUG_ON(BIO_SIZE(fproot->bio) != blk_rq_bytes(rq));

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -1,6 +1,6 @@
 // enable this only if the px block device IO is
 // registered through blkmq
-#ifdef __PXD_BIO_BLKMQ__
+#if defined __PXD_BIO_BLKMQ__ && defined __PX_FASTPATH__
 
 #include <linux/delay.h>
 #include <linux/errno.h>

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -279,7 +279,7 @@ static int prep_root_bio(struct fp_root_context *fproot) {
         BIO_SET_OP_ATTRS(bio, BIO_OP(rq->bio), op_flags);
         bio->bi_private = fproot;
 
-        if (!specialops) {
+        if (!specialops && (blk_rq_bytes(rq) != 0)) {
                 rq_for_each_segment(bv, rq, rq_iter) {
                         unsigned len =
                             bio_add_page(bio, BVEC(bv).bv_page, BVEC(bv).bv_len,

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -485,14 +485,16 @@ clone_and_map(struct fp_root_context *fproot) {
                         if (rq_is_special(rq)) {
                                 INIT_WORK(&cc->work, fp_handle_specialops);
                                 // queue_work(pxd_dev->fp.wq, &cc->work);
-								schedule_work(&cc->work);
+								// schedule_work(&cc->work);
+								queue_work(fastpath_workqueue(), &cc->work);
                         } else {
                                 SUBMIT_BIO(clone);
                         }
                 } else {
                         INIT_WORK(&cc->work, pxd_process_fileio);
                         // queue_work(pxd_dev->fp.wq, &cc->work);
-						schedule_work(&cc->work);
+						// schedule_work(&cc->work);
+						queue_work(fastpath_workqueue(), &cc->work);
                 }
         }
 
@@ -560,7 +562,8 @@ static void pxd_failover_initiate(struct fp_root_context *fproot) {
 
         INIT_WORK(&fproot->work, pxd_io_failover);
         //queue_work(pxd_dev->fp.wq, &fproot->work);
-		schedule_work(&fproot->work);
+		// schedule_work(&fproot->work);
+		queue_work(fastpath_workqueue(), &fproot->work);
 }
 
 // io handling functions

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -484,13 +484,15 @@ clone_and_map(struct fp_root_context *fproot) {
                         atomic_inc(&pxd_dev->fp.nswitch);
                         if (rq_is_special(rq)) {
                                 INIT_WORK(&cc->work, fp_handle_specialops);
-                                queue_work(pxd_dev->fp.wq, &cc->work);
+                                // queue_work(pxd_dev->fp.wq, &cc->work);
+								schedule_work(&cc->work);
                         } else {
                                 SUBMIT_BIO(clone);
                         }
                 } else {
                         INIT_WORK(&cc->work, pxd_process_fileio);
-                        queue_work(pxd_dev->fp.wq, &cc->work);
+                        // queue_work(pxd_dev->fp.wq, &cc->work);
+						schedule_work(&cc->work);
                 }
         }
 
@@ -552,12 +554,13 @@ static void pxd_io_failover(struct work_struct *work) {
 }
 
 static void pxd_failover_initiate(struct fp_root_context *fproot) {
-        struct pxd_device *pxd_dev = fproot_to_pxd(fproot);
+        // struct pxd_device *pxd_dev = fproot_to_pxd(fproot);
 
         BUG_ON(fproot->magic != FP_ROOT_MAGIC);
 
         INIT_WORK(&fproot->work, pxd_io_failover);
-        queue_work(pxd_dev->fp.wq, &fproot->work);
+        //queue_work(pxd_dev->fp.wq, &fproot->work);
+		schedule_work(&fproot->work);
 }
 
 // io handling functions

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -276,7 +276,7 @@ static int prep_root_bio(struct fp_root_context *fproot) {
         BIO_SET_OP_ATTRS(bio, BIO_OP(rq->bio), op_flags);
         bio->bi_private = fproot;
 
-        pxd_printk("%s: rq->cmd_flags %#x req_op %#x bio_op %#x op_flags %#x\n",
+        printk("%s: rq->cmd_flags %#x req_op %#x bio_op %#x op_flags %#x\n",
                    __func__, rq->cmd_flags, req_op(rq), BIO_OP(rq->bio),
                    op_flags);
 
@@ -594,6 +594,9 @@ static void fp_handle_specialops(struct work_struct *work) {
                 BUG_ON("unexpected condition");
         }
 #endif
+
+		printk("%s discard for device %llu, off %lu, sectors %d\n",
+				__func__, pxd_dev->dev_id, blk_rq_pos(rq), blk_rq_sectors(rq));
 
         // submit discard to replica
         if (blk_queue_discard(q)) { // discard supported

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -279,12 +279,16 @@ static int prep_root_bio(struct fp_root_context *fproot) {
         BIO_SET_OP_ATTRS(bio, BIO_OP(rq->bio), op_flags);
         bio->bi_private = fproot;
 
-        if (!specialops && (blk_rq_bytes(rq) != 0)) {
-                rq_for_each_segment(bv, rq, rq_iter) {
-                        unsigned len =
-                            bio_add_page(bio, BVEC(bv).bv_page, BVEC(bv).bv_len,
+        if (specialops) {
+                BIO_SIZE(bio) = blk_rq_bytes(rq);
+        } else {
+                if (blk_rq_bytes(rq) != 0) {
+                        rq_for_each_segment(bv, rq, rq_iter) {
+                                unsigned len =
+                                    bio_add_page(bio, BVEC(bv).bv_page, BVEC(bv).bv_len,
                                          BVEC(bv).bv_offset);
-                        BUG_ON(len != BVEC(bv).bv_len);
+                                BUG_ON(len != BVEC(bv).bv_len);
+                        }
                 }
         }
 

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -246,15 +246,15 @@ static int prep_root_bio(struct fp_root_context *fproot) {
 
         // it is possible for sync request to carry no bio
         if (!rq->bio) {
-				printk("%s:(none) rq->cmd_flags %#x req_op %#x bio_op %#x op_flags %#x\n",
-					__func__, rq->cmd_flags, req_op(rq), 0, op_flags);
+				pxd_printk("%s:(none) %llu rq->cmd_flags %#x req_op %#x bio_op %#x op_flags %#x\n",
+					__func__, fproot_to_pxd(fproot)->dev_id, rq->cmd_flags, req_op(rq), 0, op_flags);
                 return 0;
 		}
 
         // single bio request
         if (rq->bio == rq->biotail) {
-				printk("%s:(single) rq->cmd_flags %#x req_op %#x bio_op %#x op_flags %#x\n",
-                   __func__, rq->cmd_flags, req_op(rq), BIO_OP(rq->bio),
+				pxd_printk("%s:(single) %llu rq->cmd_flags %#x req_op %#x bio_op %#x op_flags %#x\n",
+                   __func__, fproot_to_pxd(fproot)->dev_id, rq->cmd_flags, req_op(rq), BIO_OP(rq->bio),
                    op_flags);
                 fproot->bio = rq->bio;
                 BUG_ON(BIO_SECTOR(fproot->bio) != blk_rq_pos(rq));
@@ -282,8 +282,8 @@ static int prep_root_bio(struct fp_root_context *fproot) {
         BIO_SET_OP_ATTRS(bio, BIO_OP(rq->bio), op_flags);
         bio->bi_private = fproot;
 
-        printk("%s: rq->cmd_flags %#x req_op %#x bio_op %#x op_flags %#x\n",
-                   __func__, rq->cmd_flags, req_op(rq), BIO_OP(rq->bio),
+        pxd_printk("%s: %llu rq->cmd_flags %#x req_op %#x bio_op %#x op_flags %#x\n",
+                   __func__, fproot_to_pxd(fproot)->dev_id, rq->cmd_flags, req_op(rq), BIO_OP(rq->bio),
                    op_flags);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0) || defined(REQ_PREFLUSH)
@@ -601,8 +601,8 @@ static void fp_handle_specialops(struct work_struct *work) {
         }
 #endif
 
-		printk("%s discard for device %llu, off %llu, sectors %u\n",
-				__func__, pxd_dev->dev_id, (unsigned long long)blk_rq_pos(rq), blk_rq_sectors(rq));
+		pxd_printk("%s discard for device %llu, off %llu, sectors %u\n", __func__,
+				pxd_dev->dev_id, (unsigned long long)blk_rq_pos(rq), blk_rq_sectors(rq));
 
         // submit discard to replica
         if (blk_queue_discard(q)) { // discard supported

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -247,7 +247,7 @@ static int prep_root_bio(struct fp_root_context *fproot) {
 
         // it is possible for sync request to carry no bio
         if (!rq->bio)
-            return 0;
+                return 0;
 
         // single bio request
         if (rq->bio == rq->biotail) {
@@ -257,8 +257,8 @@ static int prep_root_bio(struct fp_root_context *fproot) {
                 return 0;
         }
 
-		if (!specialops)
-			rq_for_each_segment(bv, rq, rq_iter) nr_bvec++;
+        if (!specialops)
+                rq_for_each_segment(bv, rq, rq_iter) nr_bvec++;
 
         bio = bio_alloc_bioset(GFP_KERNEL, nr_bvec, get_fpbioset());
         if (!bio) {
@@ -574,7 +574,7 @@ static void fp_handle_specialops(struct work_struct *work) {
         bdev = get_bdev(file);
         q = bdev_get_queue(bdev);
 
-		BUG_ON(!rq_is_special(rq));
+        BUG_ON(!rq_is_special(rq));
         atomic_inc(&pxd_dev->fp.nio_discard);
 
         // submit discard to replica

--- a/pxd_bio_makereq.c
+++ b/pxd_bio_makereq.c
@@ -448,7 +448,8 @@ static void pxd_failover_initiate(struct pxd_device *pxd_dev,
                                   struct pxd_io_tracker *head) {
         INIT_WORK(&head->wi, pxd_io_failover);
         // queue_work(pxd_dev->fp.wq, &head->wi);
-		schedule_work(&head->wi);
+		// schedule_work(&head->wi);
+		queue_work(fastpath_workqueue(), &head->wi);
 }
 
 // special handling for discards
@@ -611,14 +612,16 @@ static void pxd_process_io(struct pxd_io_tracker *head) {
                                 if (special_op(BIO_OP(&curr->clone))) {
                                         INIT_WORK(&curr->wi, fp_handle_special);
                                         // queue_work(pxd_dev->fp.wq, &curr->wi);
-										schedule_work(&curr->wi);
+										// schedule_work(&curr->wi);
+										queue_work(fastpath_workqueue(), &curr->wi);
                                 } else {
                                         SUBMIT_BIO(&curr->clone);
                                 }
                                 atomic_inc(&pxd_dev->fp.nswitch);
                         } else {
-                                queue_work(pxd_dev->fp.wq, &curr->wi);
-								schedule_work(&curr->wi);
+                                // queue_work(pxd_dev->fp.wq, &curr->wi);
+								// schedule_work(&curr->wi);
+								queue_work(fastpath_workqueue(), &curr->wi);
                         }
                 }
         } else {
@@ -630,14 +633,16 @@ static void pxd_process_io(struct pxd_io_tracker *head) {
                 if (special_op(BIO_OP(&head->clone))) {
                         INIT_WORK(&head->wi, fp_handle_special);
                         // queue_work(pxd_dev->fp.wq, &head->wi);
-						schedule_work(&head->wi);
+						// schedule_work(&head->wi);
+						queue_work(fastpath_workqueue(), &head->wi);
                 } else {
                         SUBMIT_BIO(&head->clone);
                 }
                 atomic_inc(&pxd_dev->fp.nswitch);
         } else {
                 // queue_work(pxd_dev->fp.wq, &head->wi);
-				schedule_work(&head->wi);
+				// schedule_work(&head->wi);
+				queue_work(fastpath_workqueue(), &head->wi);
         }
 }
 

--- a/pxd_bio_makereq.c
+++ b/pxd_bio_makereq.c
@@ -447,7 +447,8 @@ static void pxd_io_failover(struct work_struct *ws) {
 static void pxd_failover_initiate(struct pxd_device *pxd_dev,
                                   struct pxd_io_tracker *head) {
         INIT_WORK(&head->wi, pxd_io_failover);
-        queue_work(pxd_dev->fp.wq, &head->wi);
+        // queue_work(pxd_dev->fp.wq, &head->wi);
+		schedule_work(&head->wi);
 }
 
 // special handling for discards
@@ -609,13 +610,15 @@ static void pxd_process_io(struct pxd_io_tracker *head) {
                         if (S_ISBLK(curr->file->f_inode->i_mode)) {
                                 if (special_op(BIO_OP(&curr->clone))) {
                                         INIT_WORK(&curr->wi, fp_handle_special);
-                                        queue_work(pxd_dev->fp.wq, &curr->wi);
+                                        // queue_work(pxd_dev->fp.wq, &curr->wi);
+										schedule_work(&curr->wi);
                                 } else {
                                         SUBMIT_BIO(&curr->clone);
                                 }
                                 atomic_inc(&pxd_dev->fp.nswitch);
                         } else {
                                 queue_work(pxd_dev->fp.wq, &curr->wi);
+								schedule_work(&curr->wi);
                         }
                 }
         } else {
@@ -626,13 +629,15 @@ static void pxd_process_io(struct pxd_io_tracker *head) {
         if (S_ISBLK(head->file->f_inode->i_mode)) {
                 if (special_op(BIO_OP(&head->clone))) {
                         INIT_WORK(&head->wi, fp_handle_special);
-                        queue_work(pxd_dev->fp.wq, &head->wi);
+                        // queue_work(pxd_dev->fp.wq, &head->wi);
+						schedule_work(&head->wi);
                 } else {
                         SUBMIT_BIO(&head->clone);
                 }
                 atomic_inc(&pxd_dev->fp.nswitch);
         } else {
-                queue_work(pxd_dev->fp.wq, &head->wi);
+                // queue_work(pxd_dev->fp.wq, &head->wi);
+				schedule_work(&head->wi);
         }
 }
 

--- a/pxd_bio_makereq.c
+++ b/pxd_bio_makereq.c
@@ -1,6 +1,10 @@
 // enable this only if the px block device IO is
 // registered through make_request() fn.
-#ifdef __PXD_BIO_MAKEREQ__
+#if defined __PXD_BIO_MAKEREQ__ && defined __PX_FASTPATH__
+
+#ifndef _PX_FASTPATH_
+#error "invalid compile option"
+#endif
 
 #include <linux/delay.h>
 #include <linux/genhd.h>

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -40,7 +40,7 @@ struct pxd_device {
 	spinlock_t qlock;
 	struct list_head node;
 	int open_count;
-	bool removing;
+	atomic_t removing;
 	struct pxd_fastpath_extension fp;
 	struct pxd_context *ctx;
 	bool connected;

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -40,7 +40,7 @@ struct pxd_device {
 	spinlock_t qlock;
 	struct list_head node;
 	int open_count;
-	atomic_t removing;
+	bool removing;
 	struct pxd_fastpath_extension fp;
 	struct pxd_context *ctx;
 	bool connected;

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -417,6 +417,7 @@ int pxd_fastpath_init(struct pxd_device *pxd_dev)
 
 void pxd_fastpath_cleanup(struct pxd_device *pxd_dev)
 {
+	printk("%s: entered for device %llu", __func__, pxd_dev->dev_id);
 	disableFastPath(pxd_dev, false);
 
 	if (pxd_dev->fp.wq) {

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -339,6 +339,10 @@ void disableFastPath(struct pxd_device *pxd_dev, bool skipsync)
 	pxd_dev->fp.can_failover = false;
 
 	pxd_resume_io(pxd_dev);
+
+	// ensure all pending workqueue items on this device gets finished.
+	if (pxd_dev->fp.wq)
+		flush_workqueue(pxd_dev->fp.wq);
 }
 
 int pxd_fastpath_init(struct pxd_device *pxd_dev)

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -131,7 +131,7 @@ int pxd_request_suspend_internal(struct pxd_device *pxd_dev,
 	atomic_set(&fp->sync_done, MAX_PXD_BACKING_DEVS);
 	reinit_completion(&fp->sync_complete);
 	for (i = 0; i < MAX_PXD_BACKING_DEVS; i++) {
-		queue_work(pxd_dev->fp.wq, &fp->syncwi[i].ws);
+		queue_work(fp->wq, &fp->syncwi[i].ws);
 	}
 
 #define SYNC_TIMEOUT (60000)
@@ -343,7 +343,6 @@ void disableFastPath(struct pxd_device *pxd_dev, bool skipsync)
 	pxd_dev->fp.can_failover = false;
 
 	pxd_resume_io(pxd_dev);
-
 }
 
 int pxd_fastpath_init(struct pxd_device *pxd_dev)

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -131,7 +131,8 @@ int pxd_request_suspend_internal(struct pxd_device *pxd_dev,
 	atomic_set(&fp->sync_done, MAX_PXD_BACKING_DEVS);
 	reinit_completion(&fp->sync_complete);
 	for (i = 0; i < MAX_PXD_BACKING_DEVS; i++) {
-		queue_work(fp->wq, &fp->syncwi[i].ws);
+		// queue_work(fp->wq, &fp->syncwi[i].ws);
+		schedule_work(&fp->syncwi[i].ws);
 	}
 
 #define SYNC_TIMEOUT (60000)

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -1,3 +1,4 @@
+#ifdef __PX_FASTPATH__
 #include <linux/version.h>
 #include <linux/types.h>
 #include <linux/delay.h>
@@ -32,30 +33,6 @@ void pxd_abortfailQ(struct pxd_device *pxd_dev)
 	spin_lock_irqsave(&pxd_dev->fp.fail_lock, flags);
 	__pxd_abortfailQ(pxd_dev);
 	spin_unlock_irqrestore(&pxd_dev->fp.fail_lock, flags);
-}
-
-static void _pxd_setup(struct pxd_device *pxd_dev, bool enable)
-{
-	if (!enable) {
-		printk(KERN_NOTICE "device %llu called to disable IO\n", pxd_dev->dev_id);
-		pxd_dev->connected = false;
-		pxd_abortfailQ(pxd_dev);
-	} else {
-		printk(KERN_NOTICE "device %llu called to enable IO\n", pxd_dev->dev_id);
-		pxd_dev->connected = true;
-	}
-}
-
-void pxdctx_set_connected(struct pxd_context *ctx, bool enable)
-{
-	struct list_head *cur;
-	spin_lock(&ctx->lock);
-	list_for_each(cur, &ctx->list) {
-		struct pxd_device *pxd_dev = container_of(cur, struct pxd_device, node);
-
-		_pxd_setup(pxd_dev, enable);
-	}
-	spin_unlock(&ctx->lock);
 }
 
 // background pxd syncer work function
@@ -556,3 +533,5 @@ int pxd_debug_switch_nativepath(struct pxd_device* pxd_dev)
 
 	return 0;
 }
+
+#endif /* __PX_FASTPATH__ */

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -73,8 +73,6 @@ struct pxd_fastpath_extension {
 int fastpath_init(void);
 void fastpath_cleanup(void);
 
-struct workqueue_struct *fastpath_workqueue(void);
-
 struct pxd_update_path_out;
 int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path);
 

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -65,6 +65,10 @@ struct pxd_fastpath_extension {
 	atomic_t nerror; // [global] total IO error
 };
 
+#ifndef __PX_FASTPATH__
+#include "pxd_fastpath_stub.h"
+#else
+
 // global initialization during module init for fastpath
 int fastpath_init(void);
 void fastpath_cleanup(void);
@@ -75,8 +79,6 @@ int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_
 // per device initialization for fastpath
 int pxd_fastpath_init(struct pxd_device *pxd_dev);
 void pxd_fastpath_cleanup(struct pxd_device *pxd_dev);
-
-void pxdctx_set_connected(struct pxd_context *ctx, bool enable);
 
 void enableFastPath(struct pxd_device *pxd_dev, bool force);
 void disableFastPath(struct pxd_device *pxd_dev, bool skipSync);
@@ -141,5 +143,6 @@ int remap_io_status(int status)
 
 	return -EIO;
 }
+#endif /* __PX_FASTPATH__ */
 
 #endif /* _PXD_FASTPATH_H_ */

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -106,6 +106,7 @@ int pxd_request_ioswitch(struct pxd_device *pxd_dev, int code);
 
 // handle IO reroutes and switch events
 void pxd_reissuefailQ(struct pxd_device *pxd_dev, struct list_head *ios, int status);
+void pxd_abortfailQ(struct pxd_device *pxd_dev);
 
 static inline
 struct block_device* get_bdev(struct file *fileh)

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -73,6 +73,8 @@ struct pxd_fastpath_extension {
 int fastpath_init(void);
 void fastpath_cleanup(void);
 
+struct workqueue_struct *fastpath_workqueue(void);
+
 struct pxd_update_path_out;
 int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path);
 

--- a/pxd_fastpath_stub.h
+++ b/pxd_fastpath_stub.h
@@ -1,0 +1,86 @@
+#ifndef _PX_FASTPATH_STUB_
+#define _PX_FASTPATH_STUB_
+#include <linux/kernel.h>
+#include <asm/bug.h>
+
+struct pxd_device;
+struct pxd_update_path_out;
+
+/// module global fastpath specific setup/cleanup
+static inline
+int fastpath_init(void) { return 0; }
+static inline
+void fastpath_cleanup(void) {}
+
+/// common failover/fallback code path
+static inline
+int pxd_request_suspend_internal(struct pxd_device *pxd_dev, bool skip_flush, bool coe)
+{
+	BUG_ON(!"unexpected");
+	return -EINVAL;
+}
+
+static inline
+int pxd_request_resume_internal(struct pxd_device *pxd_dev)
+{
+	BUG_ON(!"unexpected");
+	return -EINVAL;
+}
+
+/// ioctl calls from userspace
+static inline
+int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush, bool coe)
+{
+	BUG_ON(!"unexpected");
+	return -EINVAL;
+}
+
+static inline
+int pxd_request_resume(struct pxd_device *pxd_dev)
+{
+	BUG_ON(!"unexpected");
+	return -EINVAL;
+}
+
+static inline
+int pxd_request_ioswitch(struct pxd_device *pxd_dev, int code)
+{
+	BUG_ON(!"unexpected");
+	return -EINVAL;
+}
+
+/// node wipe callback
+static inline
+int pxd_fastpath_vol_cleanup(struct pxd_device *pxd_dev)
+{
+	return 0;
+}
+
+// restart code path
+static inline
+void pxd_abortfailQ(struct pxd_device *pxd_dev) {}
+static inline
+void disableFastPath(struct pxd_device *pxd_dev, bool skipSync) {}
+
+// common volume attach/detach path
+static inline
+int pxd_fastpath_init(struct pxd_device *pxd_dev) { return 0; }
+static inline
+void pxd_fastpath_cleanup(struct pxd_device *pxd_dev) {}
+/// per volume fastpath specific init
+static inline
+int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path)
+{
+	BUG_ON(!"unexpected");
+	return -EINVAL;
+}
+
+/// debug routines
+static inline
+int pxd_debug_switch_fastpath(struct pxd_device *pxd_dev) { return 0; }
+static inline
+int pxd_debug_switch_nativepath(struct pxd_device *pxd_dev) { return 0; }
+static inline
+int pxd_suspend_state(struct pxd_device *pxd_dev) { return 0; }
+
+#endif /* _PX_FASTPATH_STUB_ */


### PR DESCRIPTION
**What this PR does / why we need it**:

In 2.10.0 branch

**Which issue(s) this PR fixes** (optional)
Closes #
https://portworx.atlassian.net/browse/PWX-21201 - fix compilation issue
https://portworx.atlassian.net/browse/PWX-21175 - fix kernel crash

**Special notes for your reviewer**:
This change passes the automation test consistently.
Fixes two issues.
1/ kernel crash
2/ compilation issue.


PASSED last 6 consecutive runs in the automation test.