### PR TITLE
PWX-21201: compilation fix

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1107,7 +1107,6 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 	struct pxd_device *pxd_dev = rq->q->queuedata;
 	struct fuse_req *req = blk_mq_rq_to_pdu(rq);
 	struct fuse_conn *fc = &pxd_dev->ctx->fc;
-	struct fp_root_context *fproot;
 
 	if (BLK_RQ_IS_PASSTHROUGH(rq) || !READ_ONCE(fc->allow_disconnected))
 		return BLK_STS_IOERR;
@@ -1127,7 +1126,8 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 	req->rq = rq;
 
 #ifdef __PX_FASTPATH__
-	fproot = &req->fproot;
+{
+	struct fp_root_context *fproot = &req->fproot;
 	fp_root_context_init(fproot);
 	if (pxd_dev->fp.fastpath) {
 		// route through fastpath
@@ -1136,6 +1136,7 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 		queue_work(fastpath_workqueue(), &fproot->work);
 		return BLK_STS_OK;
 	}
+}
 #endif
 	atomic_inc(&pxd_dev->fp.nslowPath);
 

--- a/pxd_bio.h
+++ b/pxd_bio.h
@@ -22,7 +22,6 @@ void pxd_bio_make_request_entryfn(struct request_queue *q, struct bio *bio);
 #endif
 
 void __pxd_abortfailQ(struct pxd_device *pxd_dev);
-void pxd_reissuefailQ(struct pxd_device *pxd_dev, struct list_head *ios, int status);
 
 void pxd_suspend_io(struct pxd_device *pxd_dev);
 void pxd_resume_io(struct pxd_device *pxd_dev);


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->
PWX-21201: part of compilation fixes for the fuse driver

**What this PR does / why we need it**:
While compiling in 3.10 kernel where fastpath is not supported, runs into a compilation failure.
This PR fixes it.

The issue is seen here: https://jenkins.portworx.dev/job/DEV/job/Porx-02/812/console
This above is in 2.10.0 branch, where this change needs to be cherry picked.

```
11:04:26    CC [M]  /home/carson/jenkins/jenkins.portworx.dev/workspace/DEV/Porx-02/src/github.com/portworx/porx/src/gdfs/px_fuse/pxd.o
11:04:27  /home/carson/jenkins/jenkins.portworx.dev/workspace/DEV/Porx-02/src/github.com/portworx/porx/src/gdfs/px_fuse/pxd.c: In function 'pxd_process_ioswitch_complete':
11:04:27  /home/carson/jenkins/jenkins.portworx.dev/workspace/DEV/Porx-02/src/github.com/portworx/porx/src/gdfs/px_fuse/pxd.c:844:2: error: implicit declaration of function 'pxd_reissuefailQ' [-Werror=implicit-function-declaration]
11:04:27    pxd_reissuefailQ(pxd_dev, &ios, status);
11:04:27    ^
11:04:27  cc1: all warnings being treated as errors
```


**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

