### PR TITLE
compile fix

### DIFF
--- a/io.c
+++ b/io.c
@@ -85,6 +85,10 @@
 #define IORING_MAX_ENTRIES	4096
 #define IORING_MAX_FIXED_FILES	4096
 
+#ifndef SZ_4G
+#define SZ_4G (1ULL << 32)
+#endif
+
 struct io_uring {
 	u32 head ____cacheline_aligned_in_smp;
 	u32 tail ____cacheline_aligned_in_smp;


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lsundararajan@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
```
/root/go/src/github.com/portworx/porx/src/gdfs/px_fuse/io.c:2263:12: error: 'SZ_4G' undeclared (first use in this function)
  if (len > SZ_4G) {
```
above failure in : 4.15.0-20

some kernel versions have not defined the macro.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

