### PR TITLE
PWX-22075 Compile fix for 4.18.0-348.2.1.el8_5.x86_64 kernel.

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1065,7 +1065,7 @@ ssize_t pxd_ioc_update_size(struct fuse_conn *fc, struct pxd_update_size *update
 	// set_capacity is sufficient for modifying disk size from 5.11 onwards
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0) || (defined(__EL8__) && defined(GD_READ_ONLY))
 	revalidate_disk_size(pxd_dev->disk, true);
 #else
 	err = revalidate_disk(pxd_dev->disk);


### PR DESCRIPTION
Signed-off-by: Jose Rivera <jose@portworx.com>

**What this PR does / why we need it**:
PX Fuse build fails on kernel 4.18.0-348.2.1.el8_5.x86_64.   This kernel backported changes from 5.10.  So add a define to handle that for this kernel.
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-22075
**Special notes for your reviewer**:

