### PR TITLE
discard settings for dmthin

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1228,8 +1228,8 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 	/* Enable discard support. */
 	QUEUE_FLAG_SET(QUEUE_FLAG_DISCARD,q);
 
-    q->limits.discard_granularity = PXD_LBS;
-	q->limits.discard_alignment = PXD_LBS;
+    q->limits.discard_granularity = PXD_MAX_DISCARD_GRANULARITY;
+    q->limits.discard_alignment = PXD_MAX_DISCARD_GRANULARITY;
 	if (add->discard_size < SECTOR_SIZE)
 		q->limits.max_discard_sectors = SEGMENT_SIZE / SECTOR_SIZE;
 	else

--- a/pxd.h
+++ b/pxd.h
@@ -62,6 +62,8 @@ struct pxd_ioc_register_region {
 #define PXD_MAX_DEVICES	512			/**< maximum number of devices supported */
 #define PXD_MAX_IO		(1024*1024)	/**< maximum io size in bytes */
 #define PXD_MAX_QDEPTH  256			/**< maximum device queue depth */
+#define PXD_MIN_DISCARD_GRANULARITY		PXD_LBS
+#define PXD_MAX_DISCARD_GRANULARITY		(64 * 1024)
 
 // NOTE: nvme devices can go upto 1023 queue depth
 #define MAX_CONGESTION_THRESHOLD (1024)


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

**What this PR does / why we need it**:
Revising discard changes needed for virtual pxd device settings.
1/ fix discard granularity at 64K
2/ fix discard alignment at 64K

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

