### PR TITLE
PWX-22186: LNS fix for SLES kernel 5.3.18-59 and others.  Implicit de…

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -9,6 +9,10 @@
 #include <linux/uio.h>
 #include <linux/pid_namespace.h>
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+#include <linux/part_stat.h>
+#endif
+
 #define CREATE_TRACE_POINTS
 #undef TRACE_INCLUDE_PATH
 #define TRACE_INCLUDE_PATH .


### PR DESCRIPTION
…clarations for part_stat functions.

Signed-off-by: Jose Rivera <jose@portworx.com>

**What this PR does / why we need it**:
PX fuse failed to build on SLES kernels 5.3.18-59 and others
**Which issue(s) this PR fixes** (optional)
Closes #  PWX-22186

**Special notes for your reviewer**:

