### PR TITLE
PWX-22163: Compile fixes for 5.15.0-1.el7.

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1130,6 +1130,10 @@ static const struct blk_mq_ops pxd_mq_ops = {
 #endif /* __PX_BLKMQ__ */
 #endif /* __PXD_BIO_BLKMQ__ */
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0)
+static struct lock_class_key pxd_init_lkclass;
+#endif
+ 
 static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add)
 {
 	struct gendisk *disk;
@@ -1140,7 +1144,11 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 		return -EINVAL;
 
 	/* Create gendisk info. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0)
+	disk = __alloc_disk_node(q, NUMA_NO_NODE, &pxd_init_lkclass);
+#else
 	disk = alloc_disk(1);
+#endif
 	if (!disk)
 		return -ENOMEM;
 
@@ -1266,7 +1274,11 @@ static void pxd_free_disk(struct pxd_device *pxd_dev)
 
 	pxd_fastpath_cleanup(pxd_dev);
 	pxd_dev->disk = NULL;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0)
+	if (disk_live(disk)) {
+#else	
 	if (disk->flags & GENHD_FL_UP) {
+#endif
 		del_gendisk(disk);
 		if (disk->queue)
 			blk_cleanup_queue(disk->queue);


### PR DESCRIPTION
Signed-off-by: Jose Rivera <jose@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
PX fuse fails to compile on 5.15.0-1.el7.   implicit declaration of function ‘alloc_disk’  & error: ‘GENHD_FL_UP’ undeclared .  Use '__alloc_disk_node(...)'  & 'disk_live()' instead.
**Which issue(s) this PR fixes** (optional)
Closes #: PWX-22163

**Special notes for your reviewer**:

