### PR TITLE
PWX-23492 add force_async handling for read requests

### DIFF
--- a/io.c
+++ b/io.c
@@ -706,6 +706,10 @@ static int io_read(struct io_kiocb *req, const struct sqe_submit *s,
 	int ret;
 	ssize_t ret2;
 
+	if (force_nonblock && (s->sqe->flags & IOSQE_FORCE_ASYNC)) {
+		return -EAGAIN;
+	}
+
 	ret = io_prep_rw(req, s, force_nonblock);
 	if (ret)
 		return ret;


### PR DESCRIPTION
Add force async processing for read requests as well. Btrfs reads are
too slow to be done in a single thread.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

