### PR TITLE
Unfreeze q after export

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1255,6 +1255,10 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 	q->queuedata = pxd_dev;
 	pxd_dev->disk = disk;
 
+#if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
+	blk_mq_freeze_queue(q);
+#endif
+
 	return 0;
 out_disk:
 	put_disk(disk);
@@ -1466,6 +1470,9 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 
 	if (pxd_dev) {
 		add_disk(pxd_dev->disk);
+#if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
+		blk_mq_unfreeze_queue(pxd_dev->disk->queue);
+#endif
 		return 0;
 	}
 


### PR DESCRIPTION

**What this PR does / why we need it**:
Pxd block device is exported out using add_disk(). It looks like in some cases while we are in the middle on this lsblk or systemd-udevd starts using the device. And the add_disk() gets stuck because device is in use.So to avoid that keep the device q frozen until after add_disk() returns so that add_disk always finishes. 

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Issue is not readily reproducible.
To test: 
1. Create a repl2 volumes on node1, node2.
2. Start 'watch -n 1 lsblk' on both nodes.
3. Start 'watch pxctl host attach' on both nodes.
Device attachment will flip-flop among the 2 nodes with lsblk continuously trying to read from device. No issue so far. 
