### PR TITLE
Unfreeze q after export

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -849,6 +849,10 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 	q->queuedata = pxd_dev;
 	pxd_dev->disk = disk;
 
+#if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
+	blk_mq_freeze_queue(q);
+#endif
+
 	return 0;
 out_disk:
 	put_disk(disk);
@@ -952,6 +956,9 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 	spin_unlock(&ctx->lock);
 
 	add_disk(pxd_dev->disk);
+#if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
+	blk_mq_unfreeze_queue(pxd_dev->disk->queue);
+#endif
 
 	return pxd_dev->minor;
 


### PR DESCRIPTION

**What this PR does / why we need it**:
Cherry-pick 45af3df8f5b67bbe7d1a945e82658a4dc011d430 from master.
Picking it in v2.9.0 so we can keep a porx 2.11 based release ready for https://portworx.atlassian.net/browse/CEE-409.

**Which issue(s) this PR fixes** (optional)
Closes # 

**Special notes for your reviewer**:
Test logs will be added in the porx PR.
