### PR TITLE
PWX-26219: improve recovery for suspended fastpath volumes

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -215,7 +215,7 @@ static void fuse_conn_wakeup(struct fuse_conn *fc)
  * the 'end' callback is called if given, else the reference to the
  * request is released
  */
-static void request_end(struct fuse_conn *fc, struct fuse_req *req,
+void request_end(struct fuse_conn *fc, struct fuse_req *req,
 	int status)
 {
 	u64 uid = req->in.unique;
@@ -495,7 +495,7 @@ static int fuse_notify_add_ext(struct fuse_conn *conn, unsigned int size,
 
 
 /* Look up request on processing list by unique ID */
-static struct fuse_req *request_find(struct fuse_conn *fc, u64 unique)
+struct fuse_req *request_find(struct fuse_conn *fc, u64 unique)
 {
 	u32 index = unique & (FUSE_MAX_REQUEST_IDS - 1);
 	struct fuse_req *req = fc->request_map[index];

--- a/fuse_i.h
+++ b/fuse_i.h
@@ -337,5 +337,9 @@ void fuse_convert_zero_writes(struct fuse_req *req);
 void fuse_queue_init_cb(struct fuse_queue_cb *cb);
 
 struct fuse_req* request_find_in_ctx(unsigned ctx, u64 unique);
+
+// request lookups.
+struct fuse_req *request_find(struct fuse_conn *fc, u64 unique);
+void request_end(struct fuse_conn *fc, struct fuse_req *req, int status);
 #endif
 #endif /* _FS_FUSE_I_H */

--- a/pxd.c
+++ b/pxd.c
@@ -1674,7 +1674,7 @@ static void _pxd_setup(struct pxd_device *pxd_dev, bool enable)
 	if (!enable) {
 		printk(KERN_NOTICE "device %llu called to disable IO\n", pxd_dev->dev_id);
 		pxd_dev->connected = false;
-		pxd_abortfailQ(pxd_dev);
+		pxd_fastpath_reset_device(pxd_dev);
 	} else {
 		printk(KERN_NOTICE "device %llu called to enable IO\n", pxd_dev->dev_id);
 		pxd_dev->connected = true;

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -29,8 +29,8 @@ struct pxd_sync_ws {
 struct pxd_fastpath_extension {
 	// Extended information
 	atomic_t ioswitch_active; // failover or fallback active
-	atomic_t suspend;
-	atomic_t app_suspend; // userspace suspended IO
+	atomic_t suspend;     // [int] counter
+	atomic_t app_suspend; // [bool] userspace suspended IO
 #ifdef __PXD_BIO_BLKMQ__
 	atomic_t blkmq_frozen; // state indicating whether actually mq frozen
 #else
@@ -42,6 +42,8 @@ struct pxd_fastpath_extension {
 	struct pxd_sync_ws syncwi[MAX_PXD_BACKING_DEVS];
 	struct completion sync_complete;
 	atomic_t sync_done;
+
+	uint64_t switch_uid; // switch IO request unique id
 
 	// failover work item
 	spinlock_t  fail_lock;
@@ -108,6 +110,10 @@ int pxd_request_ioswitch(struct pxd_device *pxd_dev, int code);
 // handle IO reroutes and switch events
 void pxd_reissuefailQ(struct pxd_device *pxd_dev, struct list_head *ios, int status);
 void pxd_abortfailQ(struct pxd_device *pxd_dev);
+
+// reset device called during device cleanup actions from any internal state.
+// consider node wipe, device remove while suspended etc.
+void pxd_fastpath_reset_device(struct pxd_device *pxd_dev);
 
 static inline
 struct block_device* get_bdev(struct file *fileh)

--- a/pxd_fastpath_stub.h
+++ b/pxd_fastpath_stub.h
@@ -84,6 +84,9 @@ int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_
 	return -EINVAL;
 }
 
+static inline
+void pxd_fastpath_reset_device(struct pxd_device *pxd_dev) {}
+
 /// debug routines
 static inline
 int pxd_debug_switch_fastpath(struct pxd_device *pxd_dev) { return 0; }


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
handle recovering volume that are in suspended IO state.
During normal conditions this condition gets handled, but if for some unforeseen cases, if the block device in the kernel is frozen, and userspace does not complete in expected lines, it could leave both the block device hanging and IOs blocked forever.

This change addresses those scenarios, likely device is in suspend IO state,
1/ px restarts
2/ px stop and node wiped
3/ px up, but state inconsistent between kernel and userspace, and a device remove op gets submitted.

Test logs attached below, device suspended through debug interface.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-26219

**Special notes for your reviewer**:

**detach volume while volume IO suspended from within kernel**
```
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# pxctl status
Status: PX is operational
Telemetry: Disabled or Unhealthy
Metering: Disabled or Unhealthy
License: Trial (expires in 22 days)
Node ID: ce00a6d3-9574-454a-b681-704252a5eadf
        IP: 10.0.2.15
        Local Storage Pool: 2 pools
        POOL    IO_PRIORITY     RAID_LEVEL      USABLE  USED    STATUS  ZONE    REGION
        0       HIGH            raid0           9.0 GiB 66 MiB  Online  default default
        1       HIGH            raid0           8.3 GiB 33 MiB  Online  default default
        Local Storage Devices: 2 devices
        Device  Path            Media Type              Size            Last-Scan
        0:0     /dev/sdb        STORAGE_MEDIUM_SSD      10 GiB          11 Aug 22 19:15 IST
        1:0     /dev/sdc2       STORAGE_MEDIUM_SSD      9.3 GiB         11 Aug 22 19:15 IST
        total                   -                       19 GiB
        Cache Devices:
         * No cache devices
        Metadata Device:
        1       /dev/sdc1       STORAGE_MEDIUM_SSD      65 GiB
Cluster Summary
        Cluster ID: px-123
        Cluster UUID: 3ea1ef53-102f-4d41-88c5-0c022a8df106
        Scheduler: none
        Nodes: 1 node(s) with storage (1 online)
        IP              ID                                      SchedulerNodeName       Auth            StorageNode             Used    Capacity        Status  StorageStatus   Version         KernelOS
        10.0.2.15       ce00a6d3-9574-454a-b681-704252a5eadf    N/A                     Disabled        Yes(Px-store-v2)        99 MiB  17 GiB          Online  Up (This node)  3.0.0.0-af932e5 4.20.17-042017-generic        Ubuntu 18.04.4 LTS
        Warnings:
                 WARNING: Swap is enabled on this node.
Global Storage Pool
        Total Used      :  99 MiB
        Total Capacity  :  17 GiB
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# pxctl v i -e fpvol1
        Volume                   :  413210081426910700
        Name                     :  fpvol1
        Size                     :  1.0 GiB
        Format                   :  ext4
        HA                       :  1
        IO Priority              :  LOW
        Creation time            :  Aug 2 06:39:59 UTC 2022
        Shared                   :  no
        Status                   :  up
        State                    :  Attached: ce00a6d3-9574-454a-b681-704252a5eadf (10.0.2.15)
        Last Attached            :  Aug 11 13:34:52 UTC 2022
        Device Path              :  /dev/pxd/pxd413210081426910700
        Mount Options            :  discard
        ScanPolicy               :  none
        Reads                    :  0
        Reads MS                 :  0
        Bytes Read               :  0
        Writes                   :  0
        Writes MS                :  0
        Bytes Written            :  0
        Discards                 :  0
        Discards MS              :  0
        Bytes Discarded          :  0
        IOs in progress          :  0
        Bytes used               :  33 MiB
        Replica sets on nodes:
                Set 0
                  Node           : 10.0.2.15 (Pool d13c8380-99f6-4432-a1bd-7d6eb741a947 )
        Replication Status       :  Up

        Displaying extended volume state:
        Fastpath preferred      : true
        Fastpath promoted       : true
        Fastpath dirty          : false
        Fastpath attached       : FASTPATH_ACTIVE
        Fastpath coordinator    : ce00a6d3-9574-454a-b681-704252a5eadf
        Fastpath replicas       : 1
        Fastpath replica property follows:
                Replica : 0
                        On Node         : ce00a6d3-9574-454a-b681-704252a5eadf
                        Protocol        : FASTPATH_PROTO_LOCAL
                        Secure          : true
                        Exported        : true
                                Target  : /dev/pwx0/413210081426910700
                                Source  : /dev/pwx0/413210081426910700
                                Type    : Block device
                        Imported        : true
                                Mapped local device: /dev/pwx0/413210081426910700
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# cat /sys/devices/pxd/1/debug
nfd:1,suspend:0,fpenabled:1,fpactive:1,app_suspend:0
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# echo s > /sys/devices/pxd/1/debug
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# cat /sys/devices/pxd/1/debug
nfd:1,suspend:1,fpenabled:1,fpactive:1,app_suspend:0
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# pxctl host detach fpvol1
Volume successfully detached
```

**suspended from userspace, try detach again**
```
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# pxctl host attach fpvol1
Volume successfully attached at: /dev/pxd/pxd413210081426910700
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# pxctl v i -e fpvol1
        Volume                   :  413210081426910700
        Name                     :  fpvol1
        Size                     :  1.0 GiB
        Format                   :  ext4
        HA                       :  1
        IO Priority              :  LOW
        Creation time            :  Aug 2 06:39:59 UTC 2022
        Shared                   :  no
        Status                   :  up
        State                    :  Attached: ce00a6d3-9574-454a-b681-704252a5eadf (10.0.2.15)
        Last Attached            :  Aug 11 13:47:53 UTC 2022
        Device Path              :  /dev/pxd/pxd413210081426910700
        Mount Options            :  discard
        ScanPolicy               :  none
        Reads                    :  0
        Reads MS                 :  0
        Bytes Read               :  0
        Writes                   :  0
        Writes MS                :  0
        Bytes Written            :  0
        Discards                 :  0
        Discards MS              :  0
        Bytes Discarded          :  0
        IOs in progress          :  0
        Bytes used               :  33 MiB
        Replica sets on nodes:
                Set 0
                  Node           : 10.0.2.15 (Pool d13c8380-99f6-4432-a1bd-7d6eb741a947 )
        Replication Status       :  Up

        Displaying extended volume state:
        Fastpath preferred      : true
        Fastpath promoted       : true
        Fastpath dirty          : false
        Fastpath attached       : FASTPATH_ACTIVE
        Fastpath coordinator    : ce00a6d3-9574-454a-b681-704252a5eadf
        Fastpath replicas       : 1
        Fastpath replica property follows:
                Replica : 0
                        On Node         : ce00a6d3-9574-454a-b681-704252a5eadf
                        Protocol        : FASTPATH_PROTO_LOCAL
                        Secure          : true
                        Exported        : true
                                Target  : /dev/pwx0/413210081426910700
                                Source  : /dev/pwx0/413210081426910700
                                Type    : Block device
                        Imported        : true
                                Mapped local device: /dev/pwx0/413210081426910700
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# echo S > /sys/devices/pxd/1/debug
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# pxctl host detach fpvol1
Volume successfully detached
```

**suspend device from both kernel and userspace, detach it from userspace**
```
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# pxctl host attach fpvol1
Volume successfully attached at: /dev/pxd/pxd413210081426910700
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# pxctl v i -e fpvol1
        Volume                   :  413210081426910700
        Name                     :  fpvol1
        Size                     :  1.0 GiB
        Format                   :  ext4
        HA                       :  1
        IO Priority              :  LOW
        Creation time            :  Aug 2 06:39:59 UTC 2022
        Shared                   :  no
        Status                   :  up
        State                    :  Attached: ce00a6d3-9574-454a-b681-704252a5eadf (10.0.2.15)
        Last Attached            :  Aug 11 13:48:26 UTC 2022
        Device Path              :  /dev/pxd/pxd413210081426910700
        Mount Options            :  discard
        ScanPolicy               :  none
        Reads                    :  0
        Reads MS                 :  0
        Bytes Read               :  0
        Writes                   :  0
        Writes MS                :  0
        Bytes Written            :  0
        Discards                 :  0
        Discards MS              :  0
        Bytes Discarded          :  0
        IOs in progress          :  0
        Bytes used               :  33 MiB
        Replica sets on nodes:
                Set 0
                  Node           : 10.0.2.15 (Pool d13c8380-99f6-4432-a1bd-7d6eb741a947 )
        Replication Status       :  Up

        Displaying extended volume state:
        Fastpath preferred      : true
        Fastpath promoted       : true
        Fastpath dirty          : false
        Fastpath attached       : FASTPATH_ACTIVE
        Fastpath coordinator    : ce00a6d3-9574-454a-b681-704252a5eadf
        Fastpath replicas       : 1
        Fastpath replica property follows:
                Replica : 0
                        On Node         : ce00a6d3-9574-454a-b681-704252a5eadf
                        Protocol        : FASTPATH_PROTO_LOCAL
                        Secure          : true
                        Exported        : true
                                Target  : /dev/pwx0/413210081426910700
                                Source  : /dev/pwx0/413210081426910700
                                Type    : Block device
                        Imported        : true
                                Mapped local device: /dev/pwx0/413210081426910700
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# echo S > /sys/devices/pxd/1/debug
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# echo s > /sys/devices/pxd/1/debug
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# cat /sys/devices/pxd/1/debug
nfd:1,suspend:2,fpenabled:1,fpactive:1,app_suspend:1
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# pxctl host detach fpvol1
Volume successfully detached
```

**detach suspended device with active IO**
detach fails, IO continues to complete, volume remains in fastpath.

```
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# pxctl host attach fpvol1
Volume successfully attached at: /dev/pxd/pxd413210081426910700
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# dir=/dev/pxd/pxd413210081426910700; fio --blocksize=32k --filename=$dir --ioengine=libaio --readwrite=write --size=1G --name=test --verify=meta --do_verify=1 --verify_pattern=0xDeadBeef --direct=1 --gtod_reduce=1 --iodepth=2 --randrepeat=1 --disable_lat=0 --gtod_reduce=0 & pxctl v i -e fpvol1; echo s > /sys/devices/pxd/1/debug; echo S > /sys/devices/pxd/1/debug; cat /sys/devices/pxd/1/debug; pxctl host detach fpvol1;
[1] 5367
        Volume                   :  413210081426910700
        Name                     :  fpvol1
        Size                     :  1.0 GiB
        Format                   :  ext4
        HA                       :  1
        IO Priority              :  LOW
        Creation time            :  Aug 2 06:39:59 UTC 2022
        Shared                   :  no
        Status                   :  up
        State                    :  Attached: ce00a6d3-9574-454a-b681-704252a5eadf (10.0.2.15)
        Last Attached            :  Aug 11 13:49:31 UTC 2022
        Device Path              :  /dev/pxd/pxd413210081426910700
        Mount Options            :  discard
        ScanPolicy               :  none
        Reads                    :  0
        Reads MS                 :  0
        Bytes Read               :  0
        Writes                   :  0
        Writes MS                :  0
        Bytes Written            :  0
        Discards                 :  0
        Discards MS              :  0
        Bytes Discarded          :  0
        IOs in progress          :  0
        Bytes used               :  33 MiB
        Replica sets on nodes:
                Set 0
                  Node           : 10.0.2.15 (Pool d13c8380-99f6-4432-a1bd-7d6eb741a947 )
        Replication Status       :  Up

        Displaying extended volume state:
        Fastpath preferred      : true
        Fastpath promoted       : true
        Fastpath dirty          : false
        Fastpath attached       : FASTPATH_ACTIVE
        Fastpath coordinator    : ce00a6d3-9574-454a-b681-704252a5eadf
        Fastpath replicas       : 1
        Fastpath replica property follows:
                Replica : 0
                        On Node         : ce00a6d3-9574-454a-b681-704252a5eadf
                        Protocol        : FASTPATH_PROTO_LOCAL
                        Secure          : true
                        Exported        : true
                                Target  : /dev/pwx0/413210081426910700
                                Source  : /dev/pwx0/413210081426910700
                                Type    : Block device
                        Imported        : true
                                Mapped local device: /dev/pwx0/413210081426910700
nfd:1,suspend:2,fpenabled:1,fpactive:1,app_suspend:1
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# 
HostDetach: Failed to detach volume fpvol1: Volume is busy                                                                                                                    Jobs: 1 (f=1): [W(1)][-.pxctl host detach fpvol1Jobs: 1 (f=1): [W(1)][-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]KiB/s][r=0,w=0 IOPS][eta 00m:00s]

Jobs: 1 (f=1): [V(1)][89.2%][r=316MiB/s,w=0KiB/s][r=10.1k,w=0 IOPS][eta 00m:12s]    [r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
test: (groupid=0, jobs=1): err= 0: pid=5388: Thu Aug 11 19:23:17 2022
   read: IOPS=9911, BW=310MiB/s (325MB/s)(1024MiB/3306msec)
    slat (nsec): min=1640, max=8896.5k, avg=9148.88, stdev=49985.38
    clat (usec): min=10, max=8975, avg=189.08, stdev=134.68
     lat (usec): min=90, max=9089, avg=198.44, stdev=143.37
    clat percentiles (usec):
     |  1.00th=[  131],  5.00th=[  145], 10.00th=[  151], 20.00th=[  159],
     | 30.00th=[  163], 40.00th=[  167], 50.00th=[  172], 60.00th=[  176],
     | 70.00th=[  182], 80.00th=[  192], 90.00th=[  227], 95.00th=[  285],
     | 99.00th=[  453], 99.50th=[  660], 99.90th=[ 1631], 99.95th=[ 2114],
     | 99.99th=[ 6063]
   iops        : min= 3704, max=10450, avg=9050.00, stdev=2388.16, samples=7
  write: IOPS=342, BW=10.7MiB/s (11.2MB/s)(1024MiB/95805msec)
    slat (nsec): min=1681, max=93349M, avg=2856467.40, stdev=515684267.43
    clat (nsec): min=1081, max=14639k, avg=140651.57, stdev=202347.05
     lat (usec): min=77, max=93349k, avg=2997.30, stdev=515686.44
    clat percentiles (usec):
     |  1.00th=[   93],  5.00th=[  103], 10.00th=[  109], 20.00th=[  115],
     | 30.00th=[  120], 40.00th=[  125], 50.00th=[  130], 60.00th=[  135],
     | 70.00th=[  141], 80.00th=[  151], 90.00th=[  169], 95.00th=[  188],
     | 99.00th=[  243], 99.50th=[  285], 99.90th=[ 1188], 99.95th=[ 3228],
     | 99.99th=[ 9765]
   bw (  KiB/s): min=112896, max=448576, per=100.00%, avg=349525.33, stdev=139639.19, samples=6
   iops        : min= 3528, max=14018, avg=10922.67, stdev=4363.72, samples=6
  lat (usec)   : 2=0.01%, 20=0.02%, 50=0.02%, 100=1.67%, 250=93.90%
  lat (usec)   : 500=3.89%, 750=0.22%, 1000=0.07%
  lat (msec)   : 2=0.14%, 4=0.04%, 10=0.04%, 20=0.01%
  cpu          : usr=0.16%, sys=0.86%, ctx=48799, majf=0, minf=811
  IO depths    : 1=0.1%, 2=100.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=32768,32768,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=2

Run status group 0 (all jobs):
   READ: bw=310MiB/s (325MB/s), 310MiB/s-310MiB/s (325MB/s-325MB/s), io=1024MiB (1074MB), run=3306-3306msec
  WRITE: bw=10.7MiB/s (11.2MB/s), 10.7MiB/s-10.7MiB/s (11.2MB/s-11.2MB/s), io=1024MiB (1074MB), run=95805-95805msec

Disk stats (read/write):
  pxd!pxd413210081426910700: ios=30627/32768, merge=0/0, ticks=5422/4241, in_queue=9492, util=5.21%

[1]+  Done                    fio --blocksize=32k --filename=$dir --ioengine=libaio --readwrite=write --size=1G --name=test --verify=meta --do_verify=1 --verify_pattern=0xDeadBeef --direct=1 --gtod_reduce=1 --iodepth=2 --randrepeat=1 --disable_lat=0 --gtod_reduce=0

root@bionic:/home/lns/srcs/src/github.com/portworx/porx# pxctl v i -e fpvol1
        Volume                   :  413210081426910700
        Name                     :  fpvol1
        Size                     :  1.0 GiB
        Format                   :  ext4
        HA                       :  1
        IO Priority              :  LOW
        Creation time            :  Aug 2 06:39:59 UTC 2022
        Shared                   :  no
        Status                   :  up
        State                    :  Attached: ce00a6d3-9574-454a-b681-704252a5eadf (10.0.2.15)
        Last Attached            :  Aug 11 13:49:31 UTC 2022
        Device Path              :  /dev/pxd/pxd413210081426910700
        Mount Options            :  discard
        ScanPolicy               :  none
        Reads                    :  32768
        Reads MS                 :  5808
        Bytes Read               :  1073741824
        Writes                   :  32768
        Writes MS                :  4241
        Bytes Written            :  1073741824
        Discards                 :  0
        Discards MS              :  0
        Bytes Discarded          :  0
        IOs in progress          :  0
        Bytes used               :  1.0 GiB
        Replica sets on nodes:
                Set 0
                  Node           : 10.0.2.15 (Pool d13c8380-99f6-4432-a1bd-7d6eb741a947 )
        Replication Status       :  Up

        Displaying extended volume state:
        Fastpath preferred      : true
        Fastpath promoted       : true
        Fastpath dirty          : false
        Fastpath attached       : FASTPATH_ACTIVE
        Fastpath coordinator    : ce00a6d3-9574-454a-b681-704252a5eadf
        Fastpath replicas       : 1
        Fastpath replica property follows:
                Replica : 0
                        On Node         : ce00a6d3-9574-454a-b681-704252a5eadf
                        Protocol        : FASTPATH_PROTO_LOCAL
                        Secure          : true
                        Exported        : true
                                Target  : /dev/pwx0/413210081426910700
                                Source  : /dev/pwx0/413210081426910700
                                Type    : Block device
                        Imported        : true
                                Mapped local device: /dev/pwx0/413210081426910700
```

**suspend device and do node wipe**
```
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# systemctl stop portworx
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# echo s > /sys/devices/pxd/1/debug
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# echo S > /sys/devices/pxd/1/debug
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# pxctl sv nw -a
This is a disruptive operation.
It will delete all PX configuration files from this node. Data on the storage disks attached on this node will be irrevocably deleted.
Executing manual log rotation logs...
Request to wipe device: /dev/md126
  0 logical volume(s) in volume group "pwx1" now active
  WARNING: PV /dev/md126 is used by VG pwx1.
  WARNING: Wiping physical volume label from /dev/md126 of volume group "pwx1".
  Labels on physical volume "/dev/md126" successfully wiped.
Device /dev/md126 wiped successfully.
Request to wipe device: /dev/md127
  0 logical volume(s) in volume group "pwx0" now active
  WARNING: PV /dev/md127 is used by VG pwx0.
  WARNING: Wiping physical volume label from /dev/md127 of volume group "pwx0".
  Labels on physical volume "/dev/md127" successfully wiped.
Device /dev/md127 wiped successfully.
mdadm: stopped /dev/md127
Removed PX footprint from device pwx0.
mdadm: stopped /dev/md126
Removed PX footprint from device pwx1.
Removed MD footprint from device /dev/sdb.
Removed MD footprint from device /dev/sdc2.
Removed MD footprint from device /dev/mapper/pwx0-pxMetaFS.
Removed MD footprint from device /dev/mapper/pwx1-pxMetaFS.
Removed PX footprint from device /dev/sdc1.
Removed PX footprint from device /dev/sdb.
Removed PX footprint from device /dev/sdc2.
INFO[0000] Local license decommissioned successfully
Wiped node successfully.
root@bionic:/home/lns/srcs/src/github.com/portworx/porx# cat /sys/devices/pxd/1/debug
nfd:1,suspend:0,fpenabled:1,fpactive:0,app_suspend:0
root@bionic:/home/lns/srcs/src/github.com/portworx/porx#
```


**suspend device, with active failover, stop px, node wipe**
```
root@bionic:/home/lns/srcs/src/github.com/portworx/px-fuse# pxctl v c --fastpath fpvol1
Volume successfully created: 641770617308317130
root@bionic:/home/lns/srcs/src/github.com/portworx/px-fuse# pxctl host attach fpvol1
Volume successfully attached at: /dev/pxd/pxd641770617308317130
root@bionic:/home/lns/srcs/src/github.com/portworx/px-fuse# cat /sys/devices/pxd/1/debug
nfd:1,suspend:0,fpenabled:1,fpactive:1,app_suspend:0
root@bionic:/home/lns/srcs/src/github.com/portworx/px-fuse# systemctl stop portworx
Warning: Stopping portworx.service, but it can still be activated by:
  portworx.socket
root@bionic:/home/lns/srcs/src/github.com/portworx/px-fuse# echo X > /sys/devices/pxd/1/debug
root@bionic:/home/lns/srcs/src/github.com/portworx/px-fuse# cat /sys/devices/pxd/1/debug
nfd:1,suspend:0,fpenabled:1,fpactive:0,app_suspend:0
root@bionic:/home/lns/srcs/src/github.com/portworx/px-fuse# ~lns/scripts/pxetcd-cleanup.sh
This is a disruptive operation.
It will delete all PX configuration files from this node. Data on the storage disks attached on this node will be irrevocably deleted.
Executing manual log rotation logs...
Request to wipe device: /dev/md126
  0 logical volume(s) in volume group "pwx1" now active
  WARNING: PV /dev/md126 is used by VG pwx1.
  WARNING: Wiping physical volume label from /dev/md126 of volume group "pwx1".
  Labels on physical volume "/dev/md126" successfully wiped.
Device /dev/md126 wiped successfully.
Request to wipe device: /dev/md127
  0 logical volume(s) in volume group "pwx0" now active
  WARNING: PV /dev/md127 is used by VG pwx0.
  WARNING: Wiping physical volume label from /dev/md127 of volume group "pwx0".
  Labels on physical volume "/dev/md127" successfully wiped.
Device /dev/md127 wiped successfully.
mdadm: stopped /dev/md127
Removed PX footprint from device pwx0.
mdadm: stopped /dev/md126
Removed PX footprint from device pwx1.
Removed MD footprint from device /dev/sdb.
Removed MD footprint from device /dev/sdc2.
Removed MD footprint from device /dev/mapper/pwx0-pxMetaFS.
Removed MD footprint from device /dev/mapper/pwx1-pxMetaFS.
Removed MD footprint from device /dev/mapper/pwx1-641770617308317130.
Removed PX footprint from device /dev/sdc1.
Removed PX footprint from device /dev/sdb.
Removed PX footprint from device /dev/sdc2.
INFO[0000] Local license decommissioned successfully
Wiped node successfully.
root@bionic:/home/lns/srcs/src/github.com/portworx/px-fuse# cat /sys/devices/pxd/1/debug
nfd:1,suspend:0,fpenabled:1,fpactive:0,app_suspend:0

```