### PR TITLE
cleanup device remove/export path for race conditions

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -132,6 +132,7 @@ static void pxd_release(struct gendisk *disk, fmode_t mode)
 
 	pxd_dev = disk->private_data;
 	if (!pxd_dev) {
+		printk(KERN_WARNING"pxd empty device context\n");
 		mutex_unlock(&pxd_ctl_mutex);
 		return;
 	}

--- a/pxd.c
+++ b/pxd.c
@@ -65,6 +65,7 @@
 extern const char *gitversion;
 static dev_t pxd_major;
 static DEFINE_IDA(pxd_minor_ida);
+static DEFINE_MUTEX(pxd_ctl_mutex);
 
 struct pxd_context *pxd_contexts;
 uint32_t pxd_num_contexts = PXD_NUM_CONTEXTS;
@@ -91,32 +92,49 @@ struct pxd_context* find_context(unsigned ctx)
 
 static int pxd_open(struct block_device *bdev, fmode_t mode)
 {
-	struct pxd_device *pxd_dev = bdev->bd_disk->private_data;
-	struct fuse_conn *fc = &pxd_dev->ctx->fc;
+	struct pxd_device *pxd_dev;
 	int err = 0;
 
-	spin_lock(&fc->lock);
-	if (!READ_ONCE(fc->connected)) {
+	err = mutex_lock_killable(&pxd_ctl_mutex);
+	if (err)
+		return err;
+
+	pxd_dev = bdev->bd_disk->private_data;
+	if (!pxd_dev) {
+		mutex_unlock(&pxd_ctl_mutex);
+		return -ENXIO;
+	}
+
+	spin_lock(&pxd_dev->lock);
+	if (!pxd_dev->connected) {
 		err = -ENXIO;
 	} else {
-		spin_lock(&pxd_dev->lock);
 		if (pxd_dev->removing)
 			err = -EBUSY;
 		else
 			pxd_dev->open_count++;
-		spin_unlock(&pxd_dev->lock);
 
 		if (!err)
 			(void)get_device(&pxd_dev->dev);
 	}
-	spin_unlock(&fc->lock);
+	spin_unlock(&pxd_dev->lock);
+	mutex_unlock(&pxd_ctl_mutex);
+
 	trace_pxd_open(pxd_dev->dev_id, pxd_dev->major, pxd_dev->minor, mode, err);
 	return err;
 }
 
 static void pxd_release(struct gendisk *disk, fmode_t mode)
 {
-	struct pxd_device *pxd_dev = disk->private_data;
+	struct pxd_device *pxd_dev;
+
+	mutex_lock(&pxd_ctl_mutex);
+
+	pxd_dev = disk->private_data;
+	if (!pxd_dev) {
+		mutex_unlock(&pxd_ctl_mutex);
+		return;
+	}
 
 	spin_lock(&pxd_dev->lock);
 	BUG_ON(pxd_dev->magic != PXD_DEV_MAGIC);
@@ -125,6 +143,8 @@ static void pxd_release(struct gendisk *disk, fmode_t mode)
 
 	trace_pxd_release(pxd_dev->dev_id, pxd_dev->major, pxd_dev->minor, mode);
 	put_device(&pxd_dev->dev);
+
+	mutex_unlock(&pxd_ctl_mutex);
 }
 
 static long pxd_ioctl_dump_fc_info(void)
@@ -1586,11 +1606,13 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 
 	spin_unlock(&pxd_dev->lock);
 
+	mutex_lock(&pxd_ctl_mutex);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,13,0)
 	pxd_free_disk(pxd_dev);
 #endif
 	disableFastPath(pxd_dev, false);
 	device_unregister(&pxd_dev->dev);
+	mutex_unlock(&pxd_ctl_mutex);
 
 	module_put(THIS_MODULE);
 
@@ -1726,11 +1748,15 @@ static void _pxd_setup(struct pxd_device *pxd_dev, bool enable)
 {
 	if (!enable) {
 		printk(KERN_NOTICE "device %llu called to disable IO\n", pxd_dev->dev_id);
+		spin_lock(&pxd_dev->lock);
 		pxd_dev->connected = false;
+		spin_unlock(&pxd_dev->lock);
 		pxd_abortfailQ(pxd_dev);
 	} else {
 		printk(KERN_NOTICE "device %llu called to enable IO\n", pxd_dev->dev_id);
+		spin_lock(&pxd_dev->lock);
 		pxd_dev->connected = true;
+		spin_unlock(&pxd_dev->lock);
 	}
 }
 

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -149,11 +149,8 @@ void pxd_suspend_io(struct pxd_device *pxd_dev) {
                 // it is possible to call suspend during initial creation with
                 // no disk, ignore as in any case, no IO can flow through.
                 if (pxd_dev->disk && pxd_dev->disk->queue) {
-                        // inline suspend while IOs are active, blocks until IO
-                        // completes. This stalls px-storage too. So just
-                        // initiate freeze, to stop new IOs.
-                        // blk_mq_freeze_queue(pxd_dev->disk->queue);
-                        blk_freeze_queue_start(pxd_dev->disk->queue);
+                        blk_mq_freeze_queue(pxd_dev->disk->queue);
+                        blk_mq_quiesce_queue(pxd_dev->disk->queue);
                         atomic_set(&fp->blkmq_frozen, 1);
                 }
                 printk("For pxd device %llu IO suspended\n", pxd_dev->dev_id);
@@ -170,7 +167,8 @@ void pxd_resume_io(struct pxd_device *pxd_dev) {
 
         wakeup = (curr == 0);
         if (wakeup) {
-                if (atomic_read(&fp->blkmq_frozen)) {
+                if (atomic_read(&fp->blkmq_frozen) && pxd_dev->disk && pxd_dev->disk->queue) {
+                        blk_mq_unquiesce_queue(pxd_dev->disk->queue);
                         blk_mq_unfreeze_queue(pxd_dev->disk->queue);
                         atomic_set(&fp->blkmq_frozen, 0);
                 }

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -354,6 +354,7 @@ void disableFastPath(struct pxd_device *pxd_dev, bool skipsync)
 			fp->file[i] = NULL;
 		}
 	}
+	fp->nfd = 0;
 	pxd_dev->fp.fastpath = false;
 	pxd_dev->fp.can_failover = false;
 


### PR DESCRIPTION
1/ pxd_remove has a race where it leaves block device queue context hanging while context are deleted.
This allows new IOs to take a long on an invalid/freed up context and this locks up the system.

2/ pxd_add - revised to only update metadata in the driver. No kernel side exposure gets made.

3/ pxd_export - revised to only export to kernel with the corresponding pxd device info.

Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

