### PR TITLE
cleanup device remove/export path for race conditions

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -94,7 +94,6 @@ struct pxd_context* find_context(unsigned ctx)
 static int pxd_open(struct block_device *bdev, fmode_t mode)
 {
 	struct pxd_device *pxd_dev;
-	struct fuse_conn *fc;
 	int err = 0;
 
 	err = mutex_lock_killable(&pxd_ctl_mutex);
@@ -106,23 +105,20 @@ static int pxd_open(struct block_device *bdev, fmode_t mode)
 		mutex_unlock(&pxd_ctl_mutex);
 		return -ENXIO;
 	}
-	fc = &pxd_dev->ctx->fc;
 
-	spin_lock(&fc->lock);
-	if (!READ_ONCE(fc->connected)) {
+	spin_lock(&pxd_dev->lock);
+	if (!pxd_dev->connected) {
 		err = -ENXIO;
 	} else {
-		spin_lock(&pxd_dev->lock);
 		if (pxd_dev->removing)
 			err = -EBUSY;
 		else
 			pxd_dev->open_count++;
-		spin_unlock(&pxd_dev->lock);
 
 		if (!err)
 			(void)get_device(&pxd_dev->dev);
 	}
-	spin_unlock(&fc->lock);
+	spin_unlock(&pxd_dev->lock);
 	mutex_unlock(&pxd_ctl_mutex);
 	trace_pxd_open(pxd_dev->dev_id, pxd_dev->major, pxd_dev->minor, mode, err);
 	return err;
@@ -130,10 +126,15 @@ static int pxd_open(struct block_device *bdev, fmode_t mode)
 
 static void pxd_release(struct gendisk *disk, fmode_t mode)
 {
-	struct pxd_device *pxd_dev = disk->private_data;
+	struct pxd_device *pxd_dev;
 
-	if (!pxd_dev)
+	mutex_lock(&pxd_ctl_mutex);
+
+	pxd_dev = disk->private_data;
+	if (!pxd_dev) {
+		mutex_unlock(&pxd_ctl_mutex);
 		return;
+	}
 
 	spin_lock(&pxd_dev->lock);
 	BUG_ON(pxd_dev->magic != PXD_DEV_MAGIC);
@@ -142,7 +143,10 @@ static void pxd_release(struct gendisk *disk, fmode_t mode)
 
 	trace_pxd_release(pxd_dev->dev_id, pxd_dev->major, pxd_dev->minor, mode);
 	put_device(&pxd_dev->dev);
+
+	mutex_unlock(&pxd_ctl_mutex);
 }
+
 
 static long pxd_ioctl_dump_fc_info(void)
 {
@@ -1755,11 +1759,15 @@ static void _pxd_setup(struct pxd_device *pxd_dev, bool enable)
 {
 	if (!enable) {
 		printk(KERN_NOTICE "device %llu called to disable IO\n", pxd_dev->dev_id);
+		spin_lock(&pxd_dev->lock);
 		pxd_dev->connected = false;
+		spin_unlock(&pxd_dev->lock);
 		pxd_fastpath_reset_device(pxd_dev);
 	} else {
 		printk(KERN_NOTICE "device %llu called to enable IO\n", pxd_dev->dev_id);
+		spin_lock(&pxd_dev->lock);
 		pxd_dev->connected = true;
+		spin_unlock(&pxd_dev->lock);
 	}
 }
 

--- a/pxd.c
+++ b/pxd.c
@@ -63,6 +63,11 @@ extern const char *gitversion;
 static dev_t pxd_major;
 static DEFINE_IDA(pxd_minor_ida);
 
+static DEFINE_MUTEX(pxd_ctl_mutex);
+
+#define MINOR_GET()  ida_simple_get(&pxd_minor_ida, 1, 1 << MINORBITS, GFP_KERNEL)
+#define MINOR_PUT(m) ida_simple_remove(&pxd_minor_ida, m)
+
 struct pxd_context *pxd_contexts;
 uint32_t pxd_num_contexts = PXD_NUM_CONTEXTS;
 uint32_t pxd_num_contexts_exported = PXD_NUM_CONTEXT_EXPORTED;
@@ -88,9 +93,20 @@ struct pxd_context* find_context(unsigned ctx)
 
 static int pxd_open(struct block_device *bdev, fmode_t mode)
 {
-	struct pxd_device *pxd_dev = bdev->bd_disk->private_data;
-	struct fuse_conn *fc = &pxd_dev->ctx->fc;
+	struct pxd_device *pxd_dev;
+	struct fuse_conn *fc;
 	int err = 0;
+
+	err = mutex_lock_killable(&pxd_ctl_mutex);
+	if (err)
+		return err;
+
+	pxd_dev = bdev->bd_disk->private_data;
+	if (!pxd_dev) {
+		mutex_unlock(&pxd_ctl_mutex);
+		return -ENXIO;
+	}
+	fc = &pxd_dev->ctx->fc;
 
 	spin_lock(&fc->lock);
 	if (!READ_ONCE(fc->connected)) {
@@ -107,6 +123,7 @@ static int pxd_open(struct block_device *bdev, fmode_t mode)
 			(void)get_device(&pxd_dev->dev);
 	}
 	spin_unlock(&fc->lock);
+	mutex_unlock(&pxd_ctl_mutex);
 	trace_pxd_open(pxd_dev->dev_id, pxd_dev->major, pxd_dev->minor, mode, err);
 	return err;
 }
@@ -114,6 +131,9 @@ static int pxd_open(struct block_device *bdev, fmode_t mode)
 static void pxd_release(struct gendisk *disk, fmode_t mode)
 {
 	struct pxd_device *pxd_dev = disk->private_data;
+
+	if (!pxd_dev)
+		return;
 
 	spin_lock(&pxd_dev->lock);
 	BUG_ON(pxd_dev->magic != PXD_DEV_MAGIC);
@@ -1267,16 +1287,27 @@ static void pxd_free_disk(struct pxd_device *pxd_dev)
 		return;
 
 	pxd_fastpath_cleanup(pxd_dev);
-	pxd_dev->disk = NULL;
 	if (disk->flags & GENHD_FL_UP) {
 		del_gendisk(disk);
-		if (disk->queue)
+
+	    disk->private_data = NULL;
+	    pxd_dev->disk = NULL;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,13,0)
+		if (disk->queue) {
+			blk_cleanup_disk(disk);
+		}
+#else
+		if (disk->queue) {
 			blk_cleanup_queue(disk->queue);
+		}
+		put_disk(disk);
+#endif
+	}
+
 #if defined(__PXD_BIO_BLKMQ__) && defined(__PX_BLKMQ__)
 		blk_mq_free_tag_set(&pxd_dev->tag_set);
 #endif
-	}
-	put_disk(disk);
 }
 
 struct pxd_device* find_pxd_device(struct pxd_context *ctx, uint64_t dev_id)
@@ -1565,8 +1596,12 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 
 		mutex_unlock(&pxd_dev->disk->queue->sysfs_lock);
 #else
-		blk_mq_freeze_queue(pxd_dev->disk->queue);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,13,0)
+		// Do not mark queue dead, del_gendisk will try to
+		// submit all outstanding IOs on this device
+#else
 		blk_set_queue_dying(pxd_dev->disk->queue);
+#endif
 #endif
 	}
 
@@ -1575,9 +1610,13 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 	spin_unlock(&pxd_dev->lock);
 
 	if (cleanup) {
+
 		pxd_fastpath_reset_device(pxd_dev);
+
+		mutex_lock(&pxd_ctl_mutex);
 		pxd_free_disk(pxd_dev);
 		device_unregister(&pxd_dev->dev);
+		mutex_unlock(&pxd_ctl_mutex);
 
 		module_put(THIS_MODULE);
 	}

--- a/pxd.c
+++ b/pxd.c
@@ -1565,6 +1565,7 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 
 		mutex_unlock(&pxd_dev->disk->queue->sysfs_lock);
 #else
+		blk_mq_freeze_queue(pxd_dev->disk->queue);
 		blk_set_queue_dying(pxd_dev->disk->queue);
 #endif
 	}
@@ -1575,6 +1576,7 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 
 	if (cleanup) {
 		pxd_fastpath_reset_device(pxd_dev);
+		pxd_free_disk(pxd_dev);
 		device_unregister(&pxd_dev->dev);
 
 		module_put(THIS_MODULE);

--- a/pxd.c
+++ b/pxd.c
@@ -1294,7 +1294,6 @@ static void pxd_free_disk(struct pxd_device *pxd_dev)
 	if (disk->flags & GENHD_FL_UP) {
 		del_gendisk(disk);
 
-	    disk->private_data = NULL;
 	    pxd_dev->disk = NULL;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,13,0)

--- a/pxd.c
+++ b/pxd.c
@@ -133,6 +133,7 @@ static void pxd_release(struct gendisk *disk, fmode_t mode)
 	pxd_dev = disk->private_data;
 	if (!pxd_dev) {
 		mutex_unlock(&pxd_ctl_mutex);
+		printk(KERN_WARNING"pxd empty device context\n");
 		return;
 	}
 

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -152,8 +152,8 @@ void pxd_suspend_io(struct pxd_device *pxd_dev) {
                         // inline suspend while IOs are active, blocks until IO
                         // completes. This stalls px-storage too. So just
                         // initiate freeze, to stop new IOs.
-                        // blk_mq_freeze_queue(pxd_dev->disk->queue);
-                        blk_freeze_queue_start(pxd_dev->disk->queue);
+                        blk_mq_freeze_queue(pxd_dev->disk->queue);
+                        blk_mq_quiesce_queue(pxd_dev->disk->queue);
                         atomic_set(&fp->blkmq_frozen, 1);
                 }
                 printk("For pxd device %llu IO suspended\n", pxd_dev->dev_id);
@@ -171,6 +171,7 @@ void pxd_resume_io(struct pxd_device *pxd_dev) {
         wakeup = (curr == 0);
         if (wakeup) {
                 if (atomic_read(&fp->blkmq_frozen)) {
+                        blk_mq_unquiesce_queue(pxd_dev->disk->queue);
                         blk_mq_unfreeze_queue(pxd_dev->disk->queue);
                         atomic_set(&fp->blkmq_frozen, 0);
                 }

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -149,9 +149,6 @@ void pxd_suspend_io(struct pxd_device *pxd_dev) {
                 // it is possible to call suspend during initial creation with
                 // no disk, ignore as in any case, no IO can flow through.
                 if (pxd_dev->disk && pxd_dev->disk->queue) {
-                        // inline suspend while IOs are active, blocks until IO
-                        // completes. This stalls px-storage too. So just
-                        // initiate freeze, to stop new IOs.
                         blk_mq_freeze_queue(pxd_dev->disk->queue);
                         blk_mq_quiesce_queue(pxd_dev->disk->queue);
                         atomic_set(&fp->blkmq_frozen, 1);
@@ -170,7 +167,7 @@ void pxd_resume_io(struct pxd_device *pxd_dev) {
 
         wakeup = (curr == 0);
         if (wakeup) {
-                if (atomic_read(&fp->blkmq_frozen)) {
+                if (atomic_read(&fp->blkmq_frozen) && pxd_dev->disk && pxd_dev->disk->queue) {
                         blk_mq_unquiesce_queue(pxd_dev->disk->queue);
                         blk_mq_unfreeze_queue(pxd_dev->disk->queue);
                         atomic_set(&fp->blkmq_frozen, 0);

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -49,12 +49,15 @@ struct pxd_device {
 	bool connected;
 	mode_t mode;
 	bool fastpath; // this is persistent, how the block device registered with kernel
+	unsigned int queue_depth; // sysfs attribute bdev io queue depth
+	unsigned int discard_size;
 
 #define PXD_ACTIVE(pxd_dev)  (atomic_read(&pxd_dev->ncount))
 	// congestion handling
 	atomic_t ncount; // [global] total active requests, always modify with pxd_dev.lock
-	unsigned int qdepth;
+	unsigned int qdepth; // congestion control
 	atomic_t congested;
+	bool exported; //  [pxd_dev->lock protected] whether pxd_device exported to kernel
 	unsigned int nr_congestion_on;
 	unsigned int nr_congestion_off;
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
1/ pxd_remove has a race where it leaves block device queue context hanging while context are deleted.
This allows new IOs to take a long on an invalid/freed up context and this locks up the system.

2/ pxd_add - revised to only update metadata in the driver. No kernel side exposure gets made.

3/ pxd_export - revised to only export to kernel with the corresponding pxd device info.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

