### PR TITLE
PWX-26675: 5.19 and 5.18 changes/build issues.

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -753,7 +753,9 @@ static int pxd_write_same_request(struct fuse_req *req, uint32_t size, uint64_t 
 {
 	int rc;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) || defined(REQ_PREFLUSH)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) 
+	rc = pxd_handle_device_limits(req, &size, &off, REQ_OP_WRITE_ZEROES);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) || defined(REQ_PREFLUSH)
 	rc = pxd_handle_device_limits(req, &size, &off, REQ_OP_WRITE_SAME);
 #else
 	rc = pxd_handle_device_limits(req, &size, &off, REQ_WRITE_SAME);
@@ -781,7 +783,11 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 	trace_pxd_request(req->in.h.unique, size, off, minor, flags);
 
 	switch (op) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
+	case REQ_OP_WRITE_ZEROES:
+#else
 	case REQ_OP_WRITE_SAME:
+#endif
 		rc = pxd_write_same_request(req, size, off, minor, flags);
 		break;
 	case REQ_OP_WRITE:
@@ -1286,8 +1292,10 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 	blk_queue_logical_block_size(q, PXD_LBS);
 	blk_queue_physical_block_size(q, PXD_LBS);
 
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(5,18,0)
 	/* Enable discard support. */
 	QUEUE_FLAG_SET(QUEUE_FLAG_DISCARD,q);
+#endif
 
     q->limits.discard_granularity = PXD_MAX_DISCARD_GRANULARITY;
     q->limits.discard_alignment = PXD_MAX_DISCARD_GRANULARITY;

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -601,7 +601,7 @@ static void fp_handle_specialops(struct work_struct *work) {
         atomic_inc(&pxd_dev->fp.nio_discard);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0)
-        if (bdev_max_discard_sectors(bdev)) {  // discard supported
+	if (bdev_max_discard_sectors(bdev)) {  // discard supported
           r = blkdev_issue_discard(bdev, blk_rq_pos(rq),
 				   blk_rq_sectors(rq), GFP_NOIO);
 	} else { // zero-out
@@ -617,8 +617,8 @@ static void fp_handle_specialops(struct work_struct *work) {
 				   blk_rq_sectors(rq), GFP_NOIO, 0);
 	}
 #else
-        // submit discard to replica
-        if (blk_queue_discard(q)) { // discard supported
+    // submit discard to replica
+    if (blk_queue_discard(q)) { // discard supported
 	  r = blkdev_issue_discard(bdev, blk_rq_pos(rq),
 				   blk_rq_sectors(rq), GFP_NOIO, 0);
 	} else if (bdev_write_same(bdev)) {
@@ -627,8 +627,7 @@ static void fp_handle_specialops(struct work_struct *work) {
                 // convert discard to write same
                 r = blkdev_issue_write_same(bdev, blk_rq_pos(rq),
 		blk_rq_sectors(rq), GFP_NOIO, pg);
-	}
-
+	} else {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0)
 	r = blkdev_issue_zeroout(bdev, blk_rq_pos(rq),
 				 blk_rq_sectors(rq), GFP_NOIO, 0);
@@ -636,10 +635,10 @@ static void fp_handle_specialops(struct work_struct *work) {
 	r = blkdev_issue_zeroout(bdev, blk_rq_pos(rq),
 				 blk_rq_sectors(rq), GFP_NOIO);
 #endif
+	}
 #endif
 
-
-        BIO_ENDIO(&cc->clone, r);
+	BIO_ENDIO(&cc->clone, r);
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 3, 0)

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -248,7 +248,9 @@ static int prep_root_bio(struct fp_root_context *fproot) {
         struct bio *bio;
         int nr_bvec = 0;
         bool specialops = rq_is_special(rq);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0) /// to sync up with the usage of newer bio_alloc_bioset.
         unsigned int op_flags = get_op_flags(rq->bio);
+#endif
 
         BUG_ON(fproot->magic != FP_ROOT_MAGIC);
 

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -285,10 +285,11 @@ static int prep_root_bio(struct fp_root_context *fproot) {
         bio->bi_size = 0;
 #endif
         bio->bi_end_io = stub_endio; // should never get called
-#if defined(bio_copy_dev)
-        BIO_COPY_DEV(bio, rq->bio);
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0) /// to sync up with the usage of newer bio_alloc_bioset.
+	BIO_COPY_DEV(bio, rq->bio);
+	BIO_SET_OP_ATTRS(bio, BIO_OP(rq->bio), op_flags);
 #endif
-        BIO_SET_OP_ATTRS(bio, BIO_OP(rq->bio), op_flags);
         bio->bi_private = fproot;
 
         if (specialops) {
@@ -567,7 +568,7 @@ static void pxd_failover_initiate(struct fp_root_context *fproot) {
         INIT_WORK(&fproot->work, pxd_io_failover);
         queue_work(fastpath_workqueue(), &fproot->work);
 }
- 
+
 // io handling functions
 // discard is special ops
 static void fp_handle_specialops(struct work_struct *work) {
@@ -597,13 +598,13 @@ static void fp_handle_specialops(struct work_struct *work) {
         BUG_ON(!rq_is_special(rq));
         atomic_inc(&pxd_dev->fp.nio_discard);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0)                                                                                                                                                                                                                                             
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0)
         if (bdev_max_discard_sectors(bdev)) {  // discard supported
           r = blkdev_issue_discard(bdev, blk_rq_pos(rq),
 				   blk_rq_sectors(rq), GFP_NOIO);
 	} else { // zero-out
 	  r = blkdev_issue_zeroout(bdev, blk_rq_pos(rq),
-				   blk_rq_sectors(rq), GFP_NOIO, 0);	  
+				   blk_rq_sectors(rq), GFP_NOIO, 0);
 	}
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
 	if (blk_queue_discard(q)) { // discard supported
@@ -611,7 +612,7 @@ static void fp_handle_specialops(struct work_struct *work) {
 				   blk_rq_sectors(rq), GFP_NOIO, 0);
 	} else { // zero-out
 	  r = blkdev_issue_zeroout(bdev, blk_rq_pos(rq),
-				   blk_rq_sectors(rq), GFP_NOIO, 0);	  
+				   blk_rq_sectors(rq), GFP_NOIO, 0);
 	}
 #else
         // submit discard to replica
@@ -625,14 +626,14 @@ static void fp_handle_specialops(struct work_struct *work) {
                 r = blkdev_issue_write_same(bdev, blk_rq_pos(rq),
 		blk_rq_sectors(rq), GFP_NOIO, pg);
 	}
-	
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0)
 	r = blkdev_issue_zeroout(bdev, blk_rq_pos(rq),
 				 blk_rq_sectors(rq), GFP_NOIO, 0);
 #else
 	r = blkdev_issue_zeroout(bdev, blk_rq_pos(rq),
 				 blk_rq_sectors(rq), GFP_NOIO);
-#endif	
+#endif
 #endif
 
 

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -137,7 +137,6 @@ static inline unsigned int get_op_flags(struct bio *bio)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
 #define BDEVNAME(bio, b)   bdevname(bio->bi_bdev, b)
-#define BIO_COPY_DEV(dst, src) bio_copy_data(dst, src)
 #else
 #define BDEVNAME(bio, b)   bio_devname(bio, b)
 #define BIO_COPY_DEV(dst, src) bio_copy_dev(dst, src)

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -135,8 +135,13 @@ static inline unsigned int get_op_flags(struct bio *bio)
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
+#define BDEVNAME(bio, b)   bdevname(bio->bi_bdev, b)
+#define BIO_COPY_DEV(dst, src) bio_copy_data(dst, src)
+#else
 #define BDEVNAME(bio, b)   bio_devname(bio, b)
 #define BIO_COPY_DEV(dst, src) bio_copy_dev(dst, src)
+#endif
 #else
 #define BDEVNAME(bio, b)   bdevname(bio->bi_bdev, b)
 #define BIO_COPY_DEV(dst, src) do {			\

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -2,7 +2,16 @@
 #include <linux/version.h>
 #include <linux/types.h>
 #include <linux/delay.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
+#include <linux/kdev_t.h>
+#include <linux/uuid.h>
+#include <linux/blk_types.h>
+#include <linux/device.h>
+#include <linux/xarray.h>
+#include <linux/printk.h>
+#else
 #include <linux/genhd.h>
+#endif
 #include <linux/workqueue.h>
 
 #include "pxd_bio.h"


### PR DESCRIPTION
Signed-off-by: root <root@ip-10-13-1-49.pwx.dev.purestorage.com>

**What this PR does / why we need it**:
Build issues with 5.18.x/5.19.x kernels.  5.18.x/5.19.x removed include <linux/genhd.h>,   api changes for discard, removal of "write same" , etc...
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-26675

**Special notes for your reviewer**
Waiting for dev jenkins to support these kernel so can run a full BVT tests.    

Note these changes:
REQ_OP_WRITE_ZEROES replaces REQ_OP_WRITE_SAME
pxd_bio_blkmq.c:fp_handle_specialops() changes dealing with "..write_same.."

BVTs:
BVT-MN-RESYNC-DMTHIN-FASTPATH Pass: https://jenkins.pwx.dev.purestorage.com/job/DMTHIN/view/DMTHIN-FASTPATH/job/DMTHIN-FASTPATH/job/BVT-MN-RESYNC-DMTHIN-FASTPATH-RELEASE/106/
Smoke 5.18 Pass: https://jenkins.pwx.dev.purestorage.com/job/Dev/job/Porx-08/199/
Smoke 5.19.1 Pass: https://jenkins.pwx.dev.purestorage.com/job/Dev/job/Porx-08/200/

FVT 5.19 running: https://jenkins.pwx.dev.purestorage.com/job/Dev/job/Porx-08/201/
FVT 5.18 running: https://jenkins.pwx.dev.purestorage.com/job/Dev/job/Porx-08/201/
