### PR TITLE
Set pxd minors to 1, pxd disk can't be partitioned

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1261,7 +1261,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 	snprintf(disk->disk_name, sizeof(disk->disk_name),
 		 PXD_DEV"%llu", pxd_dev->dev_id);
 	disk->major = pxd_dev->major;
-	disk->minors = 256;
+	disk->minors = 1;
 	disk->first_minor = pxd_dev->minor;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0)

--- a/pxd.c
+++ b/pxd.c
@@ -1230,6 +1230,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 		return PTR_ERR(disk);
 	  }
 	  q = disk->queue;
+	  disk->minors = 1;
 #else
 	  /* Create gendisk info. */
 	  disk = alloc_disk(1);
@@ -1261,7 +1262,6 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 	snprintf(disk->disk_name, sizeof(disk->disk_name),
 		 PXD_DEV"%llu", pxd_dev->dev_id);
 	disk->major = pxd_dev->major;
-	disk->minors = 1;
 	disk->first_minor = pxd_dev->minor;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0)

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -149,8 +149,7 @@ void pxd_suspend_io(struct pxd_device *pxd_dev) {
                 // it is possible to call suspend during initial creation with
                 // no disk, ignore as in any case, no IO can flow through.
                 if (pxd_dev->disk && pxd_dev->disk->queue) {
-                        blk_mq_freeze_queue(pxd_dev->disk->queue);
-                        blk_mq_quiesce_queue(pxd_dev->disk->queue);
+                        blk_freeze_queue_start(pxd_dev->disk->queue);
                         atomic_set(&fp->blkmq_frozen, 1);
                 }
                 printk("For pxd device %llu IO suspended\n", pxd_dev->dev_id);
@@ -167,9 +166,10 @@ void pxd_resume_io(struct pxd_device *pxd_dev) {
 
         wakeup = (curr == 0);
         if (wakeup) {
-                if (atomic_read(&fp->blkmq_frozen) && pxd_dev->disk && pxd_dev->disk->queue) {
-                        blk_mq_unquiesce_queue(pxd_dev->disk->queue);
-                        blk_mq_unfreeze_queue(pxd_dev->disk->queue);
+                if (atomic_read(&fp->blkmq_frozen)) {
+                        if (pxd_dev->disk && pxd_dev->disk->queue) {
+                                blk_mq_unfreeze_queue(pxd_dev->disk->queue);
+                        }
                         atomic_set(&fp->blkmq_frozen, 0);
                 }
                 printk("For pxd device %llu IO resumed\n", pxd_dev->dev_id);
@@ -282,9 +282,9 @@ static int prep_root_bio(struct fp_root_context *fproot) {
         } else {
                 if (blk_rq_bytes(rq) != 0) {
                         rq_for_each_segment(bv, rq, rq_iter) {
-                                unsigned len =
-                                    bio_add_page(bio, BVEC(bv).bv_page, BVEC(bv).bv_len,
-                                         BVEC(bv).bv_offset);
+                                unsigned len = bio_add_page(
+                                    bio, BVEC(bv).bv_page, BVEC(bv).bv_len,
+                                    BVEC(bv).bv_offset);
                                 BUG_ON(len != BVEC(bv).bv_len);
                         }
                 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
It's incorrect to set minors to 256 since alloc_disk() was called with minors==1.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

