### PR TITLE
5.13 compile fixes: implicit declaration of function 'blk_mq_alloc_di…

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1223,7 +1223,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 		return err;
 	  }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,13,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
 	  disk = blk_mq_alloc_disk(&pxd_dev->tag_set, pxd_dev);
 	  if (IS_ERR(disk)) {
 		blk_mq_free_tag_set(&pxd_dev->tag_set);
@@ -1331,7 +1331,7 @@ static void pxd_free_disk(struct pxd_device *pxd_dev)
 	if (disk) {
 		del_gendisk(disk);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,13,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
 		if (disk->queue) {
 			blk_cleanup_disk(disk);
 		}


### PR DESCRIPTION
…sk' & 'blk_cleanup_disk'.

Signed-off-by: Jose Rivera <jose@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Fix compilation issues with 5.13.x kernels:   implicit declaration of function 'blk_mq_alloc_disk' & 'blk_cleanup_disk'.
**Which issue(s) this PR fixes** (optional)
Closes #  PWX-27516

**Special notes for your reviewer**:
TestBVTSuite: https://jenkins.pwx.dev.purestorage.com/job/Dev/job/Porx-09/175/ - Pass
TestSmokeSuite: https://jenkins.pwx.dev.purestorage.com/job/Dev/job/Porx-09/174/ -Pass
TestFVTSuite: https://jenkins.pwx.dev.purestorage.com/job/Dev/job/Porx-10/87/ - Pass
TestResyncSuite: https://jenkins.pwx.dev.purestorage.com/job/Dev/job/Porx-10/88/ - Pass
TestReplSuite: https://jenkins.pwx.dev.purestorage.com/job/Dev/job/Porx-10/90/ - Pass
TestStatus: https://jenkins.pwx.dev.purestorage.com/job/Dev/job/Porx-09/173/ - Pass
TestResyncSuite: https://jenkins.pwx.dev.purestorage.com/job/Dev/job/Porx-10/91/ - Pass
TestCloneSticky: https://jenkins.pwx.dev.purestorage.com/job/Dev/job/Porx-01/275/ - Pass
TestDevSuite: https://jenkins.pwx.dev.purestorage.com/job/Dev/job/Porx-03/141/ - Pass


