### PR TITLE
use add_disk instead of device_add_disk

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1532,18 +1532,6 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 	struct pxd_device *pxd_dev = find_pxd_device(ctx, dev_id);
 
 	if (pxd_dev) {
-#if 0
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0)
-		int rc = device_add_disk(&pxd_dev->dev, pxd_dev->disk, NULL);
-		if (rc) {
-			return rc;
-		}
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,13,0)
-		device_add_disk(&pxd_dev->dev, pxd_dev->disk, NULL);
-#else
-		add_disk(pxd_dev->disk);
-#endif
-#endif
 #if LINUX_VERSION_CODE > KERNEL_VERSION(5,15,50)
 		int rc = add_disk(pxd_dev->disk);
 		if (rc) {
@@ -1619,9 +1607,6 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 	spin_unlock(&pxd_dev->lock);
 
 	mutex_lock(&pxd_ctl_mutex);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,13,0)
-	pxd_free_disk(pxd_dev);
-#endif
 	disableFastPath(pxd_dev, false);
 	device_unregister(&pxd_dev->dev);
 	mutex_unlock(&pxd_ctl_mutex);

--- a/pxd.c
+++ b/pxd.c
@@ -1532,6 +1532,7 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 	struct pxd_device *pxd_dev = find_pxd_device(ctx, dev_id);
 
 	if (pxd_dev) {
+#if 0
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0)
 		int rc = device_add_disk(&pxd_dev->dev, pxd_dev->disk, NULL);
 		if (rc) {
@@ -1542,6 +1543,16 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 #else
 		add_disk(pxd_dev->disk);
 #endif
+#endif
+#if LINUX_VERSION_CODE > KERNEL_VERSION(5,15,50)
+		int rc = add_disk(pxd_dev->disk);
+		if (rc) {
+			return rc;
+		}
+#else
+		add_disk(pxd_dev->disk);
+#endif
+
 #if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
 		blk_mq_unfreeze_queue(pxd_dev->disk->queue);
 #endif


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
For supporting kernel 5.15 and above we used the device_add_disk() api when attaching px device. This api takes an additional ref on the associated struct device. This ref gets dropped when del_gendisk is called.
In the old detach/free path del_gendisk is called only through device_release (pxd_dev_device_release) path. i.e. after the last ref is gone. To accommodate the conflicting requirements the solution was to make sure call to del_gendisk happens in the detach path - pxd_remove(). The release path would make the call again but would be a no-op.

The change was made because of this: https://lkml.iu.edu/hypermail/linux/kernel/1602.3/02004.html
It indicated that add_disk was being replaced with device_add_disk. But that doesn't seem to be the case. Hence restoring back to add_disk(). 

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

