### PR TITLE
fix discard parameter initialization part of pxd device

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1414,8 +1414,8 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 	pxd_dev->nr_congestion_off = 0;
 	atomic_set(&pxd_dev->ncount, 0);
 
-	printk(KERN_INFO"Device %llu (discard %d) added %px with mode %#x fastpath %d npath %lu\n",
-			add->dev_id, pxd_dev->discard_size, pxd_dev, add->open_mode, add->enable_fp, add->paths.count);
+	printk(KERN_INFO"Device %llu added %px with mode %#x fastpath %d npath %lu\n",
+			add->dev_id, pxd_dev, add->open_mode, add->enable_fp, add->paths.count);
 
 	// initializes fastpath context part of pxd_dev
 	err = pxd_fastpath_init(pxd_dev);

--- a/pxd.c
+++ b/pxd.c
@@ -1401,9 +1401,9 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 	}
 
 	if (add->discard_size < SECTOR_SIZE)
-		pxd_dev->discard_size = SEGMENT_SIZE / SECTOR_SIZE;
+		pxd_dev->discard_size = SEGMENT_SIZE;
 	else
-		pxd_dev->discard_size = add->discard_size / SECTOR_SIZE;
+		pxd_dev->discard_size = add->discard_size;
 
 	// congestion init
 	init_waitqueue_head(&pxd_dev->suspend_wq);
@@ -1414,8 +1414,8 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 	pxd_dev->nr_congestion_off = 0;
 	atomic_set(&pxd_dev->ncount, 0);
 
-	printk(KERN_INFO"Device %llu added %px with mode %#x fastpath %d npath %lu\n",
-			add->dev_id, pxd_dev, add->open_mode, add->enable_fp, add->paths.count);
+	printk(KERN_INFO"Device %llu (discard %d) added %px with mode %#x fastpath %d npath %lu\n",
+			add->dev_id, pxd_dev->discard_size, pxd_dev, add->open_mode, add->enable_fp, add->paths.count);
 
 	// initializes fastpath context part of pxd_dev
 	err = pxd_fastpath_init(pxd_dev);


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Regression from last commit, pxd device caches all the parameters from add request, and uses it later during export to publish it all in one shot.

Original failure: 
https://jenkins.pwx.dev.purestorage.com/view/StoragePlane/job/Dev/job/Porx-UT-Master/535/console
```
09:37:17  time="2022-12-17 04:07:11Z" level=INFO msg=update_nodes: dev 1 rset 0 curr [0] next [0] next clean [empty] resync to [0], near_sync[invalid], near_sync_coordinator[invalid]
09:37:17  time="2022-12-17 04:07:11Z" level=INFO msg=Device 1 starting repl set start event
09:37:17  time="2022-12-17 04:07:11Z" level=NOTE msg=attach_if_mounted: dev 1 should be mounted but is not
09:37:17  mke2fs 1.44.1 (24-Mar-2018)
09:37:17  time="2022-12-17 04:07:11Z" level=ERROR msg=px::coordinator::WriteRequest::WriteRequest(px::coordinator::DataStore&, px::gc::ptr<px::coordinator::Device>&&, px::io::Range, px::req::flags, px::req::KernelId, px::StateMachine*, const px::sm::TransitionTable&): sm 0x7f387807fcf0 1(WriteRequest::start) Received a too large discard request 16777216(bytes) supported 8388608(bytes)
09:37:17  
09:37:17  t: gdsd/system_monitor.cc:644: px::SystemMonitor::handler_func& px::SystemMonitor::handler(px::NodeErrState): Assertion `err < NodeErrState::max' failed.
09:37:19  timeout: the monitored command dumped core
09:37:19  /root/git/go/src/github.com/portworx/porx/build/run_storage_ut.sh: line 65: 18927 Aborted                 timeout --foreground -s 6 360m ./t --gtest_filter=$include_filter:-$exclude_filter --gtest_break_on_failure ${GTEST_OPTIONS}
```

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

This UT run passed the original failure: https://jenkins.pwx.dev.purestorage.com/view/StoragePlane/job/Dev/job/Porx-UT-Branch-01/77/


