### PR TITLE
PWX-31128: Changes to support 6.0.12-100.fc35.x86_64

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1333,8 +1333,11 @@ static void pxd_free_disk(struct pxd_device *pxd_dev)
 	pxd_dev->disk = NULL;
 	if (disk) {
 		del_gendisk(disk);
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,0,0)
+		if (disk->queue) {
+			put_disk(disk);
+		}
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
 		if (disk->queue) {
 			blk_cleanup_disk(disk);
 		}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
In 6.0.12-100.fc35.x86_64 they removed bdevname() completely which is used by #define BDEVNAME.  So rather than change code in the places were the BDEVNAME define is used just pulled in the bdevname() function from 5.19.x code and use that.   
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-31128
**Special notes for your reviewer**:
This PR builds but needs testing though.  I will have to come back too this.   I am being pulled into something else.    So don't merge...