### PR TITLE
PWX-31041: Changes to support 5.14.0-284.11.1.el9_2.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -163,7 +163,7 @@ docker-build: docker-build-dev
 	portworx/px-fuse:dev make
 
 px_version.c:
-	echo "const char *gitversion = \"$(shell git name-rev --name-only HEAD):$(shell git rev-parse HEAD)\";" > $@
+	echo "const char *gitversion = \"$(shell git name-rev --name-only HEAD | sed 's/remotes\/origin\///g'):$(shell git rev-parse HEAD)\";" > $@
 
 distclean: clean
 	@/bin/rm -f  config.* Makefile

--- a/pxd.c
+++ b/pxd.c
@@ -748,7 +748,7 @@ static int pxd_write_same_request(struct fuse_req *req, uint32_t size, uint64_t 
 {
 	int rc;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
 	rc = pxd_handle_device_limits(req, &size, &off, REQ_OP_WRITE_ZEROES);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) || defined(REQ_PREFLUSH)
 	rc = pxd_handle_device_limits(req, &size, &off, REQ_OP_WRITE_SAME);
@@ -778,7 +778,7 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 	trace_pxd_request(req->in.h.unique, size, off, minor, flags);
 
 	switch (op) {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
 	case REQ_OP_WRITE_ZEROES:
 #else
 	case REQ_OP_WRITE_SAME:
@@ -1265,7 +1265,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 	disk->major = pxd_dev->major;
 	disk->first_minor = pxd_dev->minor;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
 	disk->flags |= GENHD_FL_NO_PART;
 #else
 	disk->flags |= GENHD_FL_EXT_DEVT | GENHD_FL_NO_PART_SCAN;
@@ -1288,8 +1288,18 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 	blk_queue_physical_block_size(q, PXD_LBS);
 
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(5,18,0)
+
+#if defined(__EL8__)
+	
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,14,0)
 	/* Enable discard support. */
 	QUEUE_FLAG_SET(QUEUE_FLAG_DISCARD,q);
+#endif
+	
+#else
+	/* Enable discard support. */
+	QUEUE_FLAG_SET(QUEUE_FLAG_DISCARD,q);
+#endif
 #endif
 
     q->limits.discard_granularity = PXD_MAX_DISCARD_GRANULARITY;
@@ -1334,7 +1344,11 @@ static void pxd_free_disk(struct pxd_device *pxd_dev)
 	if (disk) {
 		del_gendisk(disk);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__) 
+		if (disk->queue) {
+			put_disk(disk);
+		}
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
 		if (disk->queue) {
 			blk_cleanup_disk(disk);
 		}
@@ -1535,7 +1549,7 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 	struct pxd_device *pxd_dev = find_pxd_device(ctx, dev_id);
 
 	if (pxd_dev) {
-#if LINUX_VERSION_CODE > KERNEL_VERSION(5,15,50)
+#if LINUX_VERSION_CODE > KERNEL_VERSION(5,15,50) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
 		int rc = add_disk(pxd_dev->disk);
 		if (rc) {
 			return rc;

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -6,7 +6,7 @@
 #include <linux/errno.h>
 #include <linux/types.h>
 #include <linux/version.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
 #include <linux/kdev_t.h>
 #include <linux/uuid.h>
 #include <linux/blk_types.h>
@@ -249,9 +249,18 @@ static int prep_root_bio(struct fp_root_context *fproot) {
         int nr_bvec = 0;
         bool specialops = rq_is_special(rq);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0) /// to sync up with the usage of newer bio_alloc_bioset.
+
+#if defined(__EL8__)
+	
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,14,0)
+        unsigned int op_flags = get_op_flags(rq->bio);
+#endif
+	
+#else
         unsigned int op_flags = get_op_flags(rq->bio);
 #endif
 
+#endif
         BUG_ON(fproot->magic != FP_ROOT_MAGIC);
 
         // it is possible for sync request to carry no bio
@@ -268,7 +277,7 @@ static int prep_root_bio(struct fp_root_context *fproot) {
 
         if (!specialops)
                 rq_for_each_segment(bv, rq, rq_iter) nr_bvec++;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
 	bio = bio_alloc_bioset(rq->bio->bi_bdev, nr_bvec, rq->bio->bi_opf,GFP_KERNEL, get_fpbioset());
 #else
         bio = bio_alloc_bioset(GFP_KERNEL, nr_bvec, get_fpbioset());
@@ -289,8 +298,18 @@ static int prep_root_bio(struct fp_root_context *fproot) {
         bio->bi_end_io = stub_endio; // should never get called
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0) /// to sync up with the usage of newer bio_alloc_bioset.
+#if defined(__EL8__)
+	
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,14,0)
+	BIO_COPY_DEV(bio, rq->bio);
+        BIO_SET_OP_ATTRS(bio, BIO_OP(rq->bio), op_flags);
+#endif
+	
+#else
 	BIO_COPY_DEV(bio, rq->bio);
 	BIO_SET_OP_ATTRS(bio, BIO_OP(rq->bio), op_flags);
+#endif
+	
 #endif
         bio->bi_private = fproot;
 
@@ -351,7 +370,7 @@ static struct bio *clone_root(struct fp_root_context *fproot, int i) {
         BUG_ON(fproot->magic != FP_ROOT_MAGIC);
 
         if (!fproot->bio) { // can only be flush request
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
 	clone_bio = bio_alloc_bioset(NULL, 0, 0, GFP_KERNEL, get_fpbioset());
 #else
 	clone_bio = bio_alloc_bioset(GFP_KERNEL, 0, get_fpbioset());
@@ -365,7 +384,7 @@ static struct bio *clone_root(struct fp_root_context *fproot, int i) {
                 BIO_SET_OP_ATTRS(clone_bio, REQ_FLUSH, REQ_FUA);
 #endif
         } else {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
 	  clone_bio = bio_alloc_clone(fproot->bio->bi_bdev, fproot->bio, GFP_KERNEL, get_fpbioset());
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
                 clone_bio =
@@ -600,7 +619,7 @@ static void fp_handle_specialops(struct work_struct *work) {
         BUG_ON(!rq_is_special(rq));
         atomic_inc(&pxd_dev->fp.nio_discard);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
 	if (bdev_max_discard_sectors(bdev)) {  // discard supported
           r = blkdev_issue_discard(bdev, blk_rq_pos(rq),
 				   blk_rq_sectors(rq), GFP_NOIO);
@@ -608,7 +627,7 @@ static void fp_handle_specialops(struct work_struct *work) {
 	  r = blkdev_issue_zeroout(bdev, blk_rq_pos(rq),
 				   blk_rq_sectors(rq), GFP_NOIO, 0);
 	}
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) 
 	if (blk_queue_discard(q)) { // discard supported
 	  r = blkdev_issue_discard(bdev, blk_rq_pos(rq),
 				   blk_rq_sectors(rq), GFP_NOIO, 0);

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -134,8 +134,31 @@ static inline unsigned int get_op_flags(struct bio *bio)
 	return op_flags;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__)
+
+#include <linux/ctype.h>
+
+// Pulled from v5.19.17/source/block/genhd.c
+static inline char *bdevname(struct block_device *bdev, char *buf) {
+        struct gendisk *hd = bdev->bd_disk;
+	int partno = bdev->bd_partno;
+
+	if (!partno)
+		snprintf(buf, BDEVNAME_SIZE, "%s", hd->disk_name);
+	else if (isdigit(hd->disk_name[strlen(hd->disk_name)-1]))
+		snprintf(buf, BDEVNAME_SIZE, "%sp%d", hd->disk_name, partno);
+	else
+		snprintf(buf, BDEVNAME_SIZE, "%s%d", hd->disk_name, partno);
+
+	return buf;
+}
+
+#define BDEVNAME(bio, b)   bdevname(bio->bi_bdev, b)
+
+#else
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) 
 #define BDEVNAME(bio, b)   bdevname(bio->bi_bdev, b)
 #else
 #define BDEVNAME(bio, b)   bio_devname(bio, b)
@@ -146,6 +169,8 @@ static inline unsigned int get_op_flags(struct bio *bio)
 #define BIO_COPY_DEV(dst, src) do {			\
 	(dst)->bi_bdev = (src)->bi_bdev; 		\
 } while (0)
+#endif
+
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -2,7 +2,7 @@
 #include <linux/version.h>
 #include <linux/types.h>
 #include <linux/delay.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)  || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
 #include <linux/kdev_t.h>
 #include <linux/uuid.h>
 #include <linux/blk_types.h>


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Support OCP 4.13 latest kernel which is 5.14.0-284.13.1.el9_2.
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-31041
**Special notes for your reviewer**:
BTRFS also need to be added to the archive once testing is complete. 