### PR TITLE
PWX-26219: handle device removal/wipe from suspended state

### DIFF
--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -529,8 +529,6 @@ void pxd_fastpath_reset_device(struct pxd_device *pxd_dev)
 	}
 
 	disableFastPath(pxd_dev, true);
-	// resume from userspace IO suspends after px restarts
-	pxd_request_resume(pxd_dev);
 
 	// abort any inflight ioswitch
 	if (atomic_read(&fp->ioswitch_active)) {
@@ -541,6 +539,9 @@ void pxd_fastpath_reset_device(struct pxd_device *pxd_dev)
 			request_end(fc, req, -EIO);
 		}
 	}
+
+	// resume from userspace IO suspends
+	pxd_request_resume(pxd_dev);
 
 	// resume all suspended callstacks
 	while (atomic_read(&fp->suspend) > 0) {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
harden cleanup/removal of pxd virtual device while from suspended state.
change order to release userspace suspends after iopath switch abort cleanup, as ordering matters.

**Which issue(s) this PR fixes** (optional)
Closes #
https://portworx.atlassian.net/browse/PWX-26219

**Special notes for your reviewer**:

