### PR TITLE
PWX-33031: Fix conditional for bio_set_dev existence; PWX-33219: Remove spinlock before calling pxd_bus_add_dev

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1496,10 +1496,10 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
             goto cleanup;
         }
 
+        spin_unlock(&pxd_dev->lock);
         err = pxd_bus_add_dev(pxd_dev);
         if (err) {
             pxd_free_disk(pxd_dev);
-            spin_unlock(&pxd_dev->lock);
             module_put(THIS_MODULE);
             goto cleanup;
         }
@@ -1509,7 +1509,6 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
         if (err) {
             device_unregister(&pxd_dev->dev);
             pxd_free_disk(pxd_dev);
-            spin_unlock(&pxd_dev->lock);
             module_put(THIS_MODULE);
             goto cleanup;
         }
@@ -1519,6 +1518,7 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
         add_disk(pxd_dev->disk);
 #endif
 
+        spin_lock(&pxd_dev->lock);
         pxd_dev->exported = true;
         spin_unlock(&pxd_dev->lock);
 

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -62,7 +62,7 @@
 #define BIOSET_CREATE(sz, pad, opt)   bioset_create(sz, pad)
 #endif
 
-#if defined(bio_set_dev)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0) || defined __EL8__
 #define BIO_SET_DEV(bio, bdev)  bio_set_dev(bio, bdev)
 #else
 #define BIO_SET_DEV(bio, bdev)  do { \


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Volume creation failure on 5.14

**Which issue(s) this PR fixes** (optional)
Closes #PWX-33031
Closes #PWX-33219

**Special notes for your reviewer**:
**Below tests done with 3.1 as master has build issues**

[root@ip-10-13-178-54 ~]# pxctl v c --fastpath vol1
Volume successfully created: 520417853162175822
[root@ip-10-13-178-54 ~]# pxctl v c --fastpath vol2
Volume successfully created: 1053721687136814900
[root@ip-10-13-178-54 ~]# pxctl v c --fastpath vol3
Volume successfully created: 197800448740066505
[root@ip-10-13-178-54 ~]# pxctl v c --fastpath vol4
Volume successfully created: 1086831953832014918
[root@ip-10-13-178-54 ~]# pxctl v c --fastpath vol5
Volume successfully created: 1146031318832169221
[root@ip-10-13-178-54 ~]# pxctl v c --fastpath vol6
Volume successfully created: 629200718188714965
[root@ip-10-13-178-54 ~]# pxctl v c --fastpath vol7
Volume successfully created: 370871646358124477
[root@ip-10-13-178-54 ~]# pxctl v c --fastpath vol8
Volume successfully created: 583832088188617844
[root@ip-10-13-178-54 ~]# pxctl v c --fastpath vol9
Volume successfully created: 669888035814202834
[root@ip-10-13-178-54 ~]# pxctl v c --fastpath vol10
Volume successfully created: 541683201088051834
[root@ip-10-13-178-54 ~]#

[root@ip-10-13-178-54 ~]# pxctl host attach vol1
Volume successfully attached at: /dev/pxd/pxd520417853162175822
[root@ip-10-13-178-54 ~]# pxctl host attach vol2
Volume successfully attached at: /dev/pxd/pxd1053721687136814900
[root@ip-10-13-178-54 ~]# pxctl host attach vol3
Volume successfully attached at: /dev/pxd/pxd197800448740066505
[root@ip-10-13-178-54 ~]# pxctl host attach vol4
Volume successfully attached at: /dev/pxd/pxd1086831953832014918
[root@ip-10-13-178-54 ~]# pxctl host attach vol5
Volume successfully attached at: /dev/pxd/pxd1146031318832169221
[root@ip-10-13-178-54 ~]# pxctl host attach vol6
^[[AVolume successfully attached at: /dev/pxd/pxd629200718188714965
[root@ip-10-13-178-54 ~]# pxctl host attach vol7
Volume successfully attached at: /dev/pxd/pxd370871646358124477
[root@ip-10-13-178-54 ~]# pxctl host attach vol8
Volume successfully attached at: /dev/pxd/pxd583832088188617844
[root@ip-10-13-178-54 ~]# pxctl host attach vol9
Volume successfully attached at: /dev/pxd/pxd669888035814202834
[root@ip-10-13-178-54 ~]# pxctl host attach vol10
Volume successfully attached at: /dev/pxd/pxd541683201088051834
[root@ip-10-13-178-54 ~]#

**Put a log to confirm correct build is used**
[root@ip-10-13-178-54 ~]# dmesg -T | grep prince
[Thu Aug 24 00:46:47 2023] prince_log 1
[Thu Aug 24 00:46:47 2023] prince_log 1
[Thu Aug 24 00:46:47 2023] prince_log 1
[Thu Aug 24 00:46:47 2023] prince_log 1
[Thu Aug 24 00:46:47 2023] prince_log 1
[Thu Aug 24 00:46:47 2023] prince_log 1
[Thu Aug 24 00:46:47 2023] prince_log 1
[Thu Aug 24 00:46:47 2023] prince_log 1
[Thu Aug 24 00:46:47 2023] prince_log 1
[Thu Aug 24 00:46:47 2023] prince_log 1
[Thu Aug 24 00:50:55 2023] prince_log 1
[Thu Aug 24 00:50:57 2023] prince_log 1
[Thu Aug 24 00:50:59 2023] prince_log 1
[Thu Aug 24 00:51:01 2023] prince_log 1
[root@ip-10-13-178-54 ~]#
