### PR TITLE
PWX-33031: Fix conditional for bio_set_dev existence; PWX-33219: Remove spinlock before calling pxd_bus_add_dev

### DIFF
--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -62,7 +62,7 @@
 #define BIOSET_CREATE(sz, pad, opt)   bioset_create(sz, pad)
 #endif
 
-#if defined(bio_set_dev)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0) || defined __EL8__
 #define BIO_SET_DEV(bio, bdev)  bio_set_dev(bio, bdev)
 #else
 #define BIO_SET_DEV(bio, bdev)  do { \


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Volume creation failure on 5.14

**Which issue(s) this PR fixes** (optional)
Closes #PWX-33031
Closes #PWX-33219

**Special notes for your reviewer**:
[Tue Aug 29 09:32:36 2023] BUG: scheduling while atomic: px-storage/2966058/0x00000002
[Tue Aug 29 09:32:36 2023] BUG: scheduling while atomic: px-storage/2966058/0x00000000
[Tue Aug 29 09:32:50 2023] BUG: scheduling while atomic: px-storage/2966784/0x00000002
[Tue Aug 29 09:32:50 2023] BUG: scheduling while atomic: px-storage/2966784/0x00000000
[Tue Aug 29 09:33:23 2023] BUG: scheduling while atomic: px-storage/2968136/0x00000002
[Tue Aug 29 09:33:23 2023] BUG: scheduling while atomic: px-storage/2968136/0x00000000
[Tue Aug 29 09:33:23 2023] BUG: scheduling while atomic: px-storage/2968145/0x00000002
[Tue Aug 29 09:33:23 2023] BUG: scheduling while atomic: px-storage/2968145/0x00000000
[root@ocp-dmthin-bvtmn-hd8b5-worker-0-hd92k ~]#


**Able to reproduce the issue and verify fix is working**