### PR TITLE
Allow access to device queue only at the end of export

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1263,6 +1263,10 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 	q->queuedata = pxd_dev;
 	pxd_dev->disk = disk;
 
+#if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
+	blk_mq_freeze_queue(q);
+#endif
+
 	return 0;
 out_disk:
 	put_disk(disk);
@@ -1522,6 +1526,9 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
         pxd_dev->exported = true;
         spin_unlock(&pxd_dev->lock);
 
+#if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
+		blk_mq_unfreeze_queue(pxd_dev->disk->queue);
+#endif
         return 0;
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Seeing the issue with device and and lsblk again on FACD runs. I'm not sure what changed.
Putting this back to unblock the FACD automation.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-32998

**Special notes for your reviewer**:

