### PR TITLE
kernel 5.16 compilation fixes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -139,7 +139,7 @@ insert: all
 
 clean:
 	make -C $(KERNELPATH) $(KERNELOTHEROPT) M=$(CURDIR) clean
-	@/bin/rm -f .px_version.c
+	echo '\044(px_version.o):' > .px_version.o.cmd
 
 install:
 	make V=1 -C $(KERNELPATH) $(KERNELOTHEROPT) M=$(CURDIR) modules_install
@@ -159,9 +159,10 @@ docker-build: docker-build-dev
 .px_version.c:
 	echo "const char *gitversion = \"$(shell git name-rev --name-only HEAD | sed 's/remotes\/origin\///g'):$(shell git rev-parse HEAD)\";" > $@
 	cc -c -o px_version.o_shipped  $@
-	echo "$(px_version.o):" > .px_version.o.cmd
+	echo '\044(px_version.o):' > .px_version.o.cmd
 
 distclean: clean
 	@/bin/rm -f  config.* Makefile
 	@/bin/rm -f .px_version.c
 	@/bin/rm -f px_version.o_shipped
+	@/bin/rm -f .px_version.o.cmd

--- a/Makefile.in
+++ b/Makefile.in
@@ -131,7 +131,7 @@ ccflags-y := $(ADDCCFLAGS) -Wframe-larger-than=2048 -Werror -I$(src) $(KBUILD_CP
 
 .PHONY: rpm
 
-all: px_version.c
+all: .px_version.c
 	make $(FORCE_CC) -C $(KERNELPATH) $(KERNELOTHEROPT) M=$(CURDIR) modules
 
 insert: all
@@ -139,6 +139,7 @@ insert: all
 
 clean:
 	make -C $(KERNELPATH) $(KERNELOTHEROPT) M=$(CURDIR) clean
+	@/bin/rm -f .px_version.c
 
 install:
 	make V=1 -C $(KERNELPATH) $(KERNELOTHEROPT) M=$(CURDIR) modules_install
@@ -155,10 +156,10 @@ docker-build: docker-build-dev
 	-v $(shell pwd):/home/px-fuse \
 	portworx/px-fuse:dev make
 
-px_version.c:
-	echo "const char *gitversion = \"$(shell git name-rev --name-only HEAD | sed 's/remotes\/origin\///g'):$(shell git rev-parse HEAD)\";" > .$@
-	cc -c -o px_version.o_shipped  .$@
-	touch .px_version.o.cmd
+.px_version.c:
+	echo "const char *gitversion = \"$(shell git name-rev --name-only HEAD | sed 's/remotes\/origin\///g'):$(shell git rev-parse HEAD)\";" > $@
+	cc -c -o px_version.o_shipped  $@
+	echo "$(px_version.o):" > .px_version.o.cmd
 
 distclean: clean
 	@/bin/rm -f  config.* Makefile

--- a/Makefile.in
+++ b/Makefile.in
@@ -139,7 +139,7 @@ insert: all
 
 clean:
 	make -C $(KERNELPATH) $(KERNELOTHEROPT) M=$(CURDIR) clean
-	echo '\044(px_version.o):' > .px_version.o.cmd
+	echo '$$(px_version.o):' > .px_version.o.cmd
 
 install:
 	make V=1 -C $(KERNELPATH) $(KERNELOTHEROPT) M=$(CURDIR) modules_install
@@ -159,7 +159,7 @@ docker-build: docker-build-dev
 .px_version.c:
 	echo "const char *gitversion = \"$(shell git name-rev --name-only HEAD | sed 's/remotes\/origin\///g'):$(shell git rev-parse HEAD)\";" > $@
 	cc -c -o px_version.o_shipped  $@
-	echo '\044(px_version.o):' > .px_version.o.cmd
+	echo '$$(px_version.o):' > .px_version.o.cmd
 
 distclean: clean
 	@/bin/rm -f  config.* Makefile

--- a/io.c
+++ b/io.c
@@ -581,7 +581,7 @@ static inline void io_rw_done(struct kiocb *kiocb, ssize_t ret)
 {
 	switch (ret) {
 	case -EIOCBQUEUED:
-		break;
+		return;
 	case -ERESTARTSYS:
 	case -ERESTARTNOINTR:
 	case -ERESTARTNOHAND:

--- a/io.c
+++ b/io.c
@@ -507,7 +507,11 @@ static void kiocb_end_write(struct kiocb *kiocb)
 	}
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,16,0)
+static void io_complete_rw(struct kiocb *kiocb, long res)
+#else
 static void io_complete_rw(struct kiocb *kiocb, long res, long res2)
+#endif
 {
 	struct io_kiocb *req = container_of(kiocb, struct io_kiocb, rw);
 
@@ -588,11 +592,13 @@ static inline void io_rw_done(struct kiocb *kiocb, ssize_t ret)
 		 * IO with EINTR.
 		 */
 		ret = -EINTR;
-		kiocb->ki_complete(kiocb, ret, 0);
 		break;
-	default:
-		kiocb->ki_complete(kiocb, ret, 0);
 	}
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,16,0)
+		kiocb->ki_complete(kiocb, ret);
+#else
+		kiocb->ki_complete(kiocb, ret, 0);
+#endif
 }
 
 static int io_import_fixed(struct io_ring_ctx *ctx, int rw,


### PR DESCRIPTION
**What this PR does / why we need it**:
Kernel 5.16 compilation fixes
Also include some fixes for handling the binary blob compilation. A bit hacky but does the job. Will try to come up a better way as a follow up.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

```
[root@ip-10-13-196-60 ~]# cat  /opt/pwx/oci/rootfs/home/px-fuse/pxfuse-bld.1695084353.out
Kernel version 5.16 supports fastpath.
Kernel version 5.16 supports blkmq driver model.
make -C /usr/src/kernels/5.16.14-1.el7.elrepo.x86_64  M=/home/px-fuse clean
make[1]: Entering directory '/usr/src/kernels/5.16.14-1.el7.elrepo.x86_64'
Kernel version 5.16 supports fastpath.
Kernel version 5.16 supports blkmq driver model.
make[1]: Leaving directory '/usr/src/kernels/5.16.14-1.el7.elrepo.x86_64'
Kernel version 5.16 supports fastpath.
Kernel version 5.16 supports blkmq driver model.
/bin/sh: 1: git: not found
make: git: Command not found
echo "const char *gitversion = \":\";" > .px_version.c
cc -c -o px_version.o_shipped  .px_version.c
touch .px_version.o.cmd
make  -C /usr/src/kernels/5.16.14-1.el7.elrepo.x86_64  M=/home/px-fuse modules
make[1]: Entering directory '/usr/src/kernels/5.16.14-1.el7.elrepo.x86_64'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2)
  You are using:           gcc-7 (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
Kernel version 5.16 supports fastpath.
Kernel version 5.16 supports blkmq driver model.
  SHIPPED /home/px-fuse/px_version.o
  CC [M]  /home/px-fuse/pxd.o
  CC [M]  /home/px-fuse/dev.o
  CC [M]  /home/px-fuse/iov_iter.o
  CC [M]  /home/px-fuse/io.o
  CC [M]  /home/px-fuse/kiolib.o
  CC [M]  /home/px-fuse/pxd_bio_makereq.o
  CC [M]  /home/px-fuse/pxd_bio_blkmq.o
  CC [M]  /home/px-fuse/pxd_fastpath.o
  LD [M]  /home/px-fuse/px.o
Kernel version 5.16 supports fastpath.
Kernel version 5.16 supports blkmq driver model.
  MODPOST /home/px-fuse/Module.symvers
  CC [M]  /home/px-fuse/px.mod.o
  LD [M]  /home/px-fuse/px.ko
make[1]: Leaving directory '/usr/src/kernels/5.16.14-1.el7.elrepo.x86_64'
```
