### PR TITLE
PWX-33917: fix 5.15.132-flatcar compilation issue.

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1260,8 +1260,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 		 PXD_DEV"%llu", pxd_dev->dev_id);
 	disk->major = pxd_dev->major;
 	disk->first_minor = pxd_dev->minor;
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(BLKDEV_DISCARD_SECURE))
+#if defined(GENHD_FL_NO_PART) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(BLKDEV_DISCARD_SECURE))
 	disk->flags |= GENHD_FL_NO_PART;
 #else
 	disk->flags |= GENHD_FL_EXT_DEVT | GENHD_FL_NO_PART_SCAN;
@@ -1285,12 +1284,12 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,19,0)
 #if defined(__EL8__)
-	
+
 #if LINUX_VERSION_CODE != KERNEL_VERSION(5,14,0)
 	/* Enable discard support. */
 	QUEUE_FLAG_SET(QUEUE_FLAG_DISCARD,q);
 #endif
-	
+
 #else
 	/* Enable discard support. */
 	QUEUE_FLAG_SET(QUEUE_FLAG_DISCARD,q);
@@ -1338,7 +1337,7 @@ static void pxd_free_disk(struct pxd_device *pxd_dev)
 	if (disk) {
 		del_gendisk(disk);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__) 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__)
 		if (disk->queue) {
 			put_disk(disk);
 		}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Compilation issue caused by the addition of 'GENHD_FL_NO_PART' define in 5.15.132 kernel.    This exists as an "enum" in 5.17.x... so need to leave version check for 5.17.x
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-33917
**Special notes for your reviewer**:
Ran the distro test for this kernel version using a private and the startup was fine.

