### PR TITLE
PWX-31637 & PWX-31128: Compile fixes for 6.0.12-100.fc35.x86_64 & 6.2…

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1260,6 +1260,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 		 PXD_DEV"%llu", pxd_dev->dev_id);
 	disk->major = pxd_dev->major;
 	disk->first_minor = pxd_dev->minor;
+
 #if defined(GENHD_FL_NO_PART) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(BLKDEV_DISCARD_SECURE))
 	disk->flags |= GENHD_FL_NO_PART;
 #else
@@ -1337,7 +1338,7 @@ static void pxd_free_disk(struct pxd_device *pxd_dev)
 	if (disk) {
 		del_gendisk(disk);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,0,0) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__) 
 		if (disk->queue) {
 			put_disk(disk);
 		}

--- a/pxd.c
+++ b/pxd.c
@@ -182,7 +182,7 @@ static long pxd_ioctl_init(struct file *file, void __user *argp)
 	struct iov_iter iter;
 	struct iovec iov = {argp, sizeof(struct pxd_ioctl_init_args)};
 
-	iov_iter_init(&iter, WRITE, &iov, 1, sizeof(struct pxd_ioctl_init_args));
+	iov_iter_init(&iter, READ, &iov, 1, sizeof(struct pxd_ioctl_init_args));
 
 	return pxd_read_init(&ctx->fc, &iter);
 }

--- a/pxd.c
+++ b/pxd.c
@@ -1708,6 +1708,7 @@ ssize_t pxd_read_init(struct fuse_conn *fc, struct iov_iter *iter)
 		printk(KERN_ERR "%s: copy pxd_init error\n", __func__);
 		goto copy_error;
 	}
+
 	copied += sizeof(pxd_init);
 
 	list_for_each_entry(pxd_dev, &ctx->list, node) {
@@ -1731,6 +1732,8 @@ ssize_t pxd_read_init(struct fuse_conn *fc, struct iov_iter *iter)
 		}
 		copied += sizeof(id);
 	}
+
+	iter->data_source = WRITE;   // Reset to 'WRITE'  
 
 	spin_unlock(&fc->lock);
 

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -172,12 +172,14 @@ static inline char *bdevname(struct block_device *bdev, char *buf) {
 
 #endif
 
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)
 static inline void bio_set_op_attrs(struct bio *bio, enum req_op op,
                                     blk_opf_t op_flags)
 {
-        bio->bi_opf = op_flags;                                                                                                                                                   
+  bio->bi_opf = op;
 }
+
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -134,7 +134,7 @@ static inline unsigned int get_op_flags(struct bio *bio)
 	return op_flags;
 }
 
-#if LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(QUEUE_FLAG_DEAD)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,0,0) || LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(QUEUE_FLAG_DEAD)
 
 #include <linux/ctype.h>
 
@@ -170,6 +170,14 @@ static inline char *bdevname(struct block_device *bdev, char *buf) {
 } while (0)
 #endif
 
+#endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)
+static inline void bio_set_op_attrs(struct bio *bio, enum req_op op,
+                                    blk_opf_t op_flags)
+{
+        bio->bi_opf = op_flags;                                                                                                                                                   
+}
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)


### PR DESCRIPTION
….15-300.fc38.x86_64.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Etisalat Customer is asking how much time we need to qualify below :
TKG/PKS version :  1.16.3 build 15
Os version             : Ubuntu 22.04.3 LTS
Kernel version       : 6.2.0-26-generic

**Which issue(s) this PR fixes** (optional)
Closes #
PWX-31637 & PWX-31128
**Special notes for your reviewer**:
 Builds ok .. but fails during testing will need help debugging 
```
Oct 14 17:31:17 ip-10-13-187-143.pwx.purestorage.com portworx[11171]: time="2023-10-14 17:31:17Z" level=WARN msg="zctx_new: Cannot set thread scheduler to SCHED_RR  1: Operation not permitted"
Oct 14 17:31:17 ip-10-13-187-143.pwx.purestorage.com portworx[11171]: time="2023-10-14 17:31:17Z" level=INFO msg="Datastore ready."
Oct 14 17:31:17 ip-10-13-187-143.pwx.purestorage.com portworx[11171]: time="2023-10-14 17:31:17Z" level=INFO msg="driver supported features 0x3"
Oct 14 17:31:17 ip-10-13-187-143.pwx.purestorage.com portworx[11171]: time="2023-10-14 17:31:17Z" level=INFO msg="fast_node_down_detection on: run Peer::established on peer 2"
Oct 14 17:31:17 ip-10-13-187-143.pwx.purestorage.com portworx[11171]: time="2023-10-14 17:31:17Z" level=ERROR msg="enumerate: init ioctl failed: 14(Bad address)"
Oct 14 17:31:17 ip-10-13-187-143.pwx.purestorage.com portworx[11171]: time="2023-10-14T17:31:17Z" level=info msg="[AlertType DRIVER_INIT_FAILED]" file="px_grpc_server.go:39" Function=grpc-server.RaiseAlert Tag=1 component=porx/storage/driver/volume/block
Oct 14 17:31:17 ip-10-13-187-143.pwx.purestorage.com portworx[11171]: time="2023-10-14T17:31:17Z" level=info msg="[Done]" file="px_grpc_server.go:238" Function=grpc-server.RaiseAlert Tag=1 component=porx/storage/driver/volume/block
Oct 14 17:31:17 ip-10-13-187-143.pwx.purestorage.com portworx[11171]: time="2023-10-14 17:31:17Z" level=INFO msg="Shutdown invoked, will exit without core"
Oct 14 17:31:17 ip-10-13-187-143.pwx.purestorage.com portworx[11171]: time="2023-10-14T17:31:17Z" level=info msg=Done file="px_client.go:223" Function=grpc-client.BlockInit Tag=4 component=porx/grpcgo/client
Oct 14 17:31:17 ip-10-13-187-143.pwx.purestorage.com portworx[11171]: time="2023-10-14T17:31:17Z" level=error msg="Failed to Start driver: Block Driver Error [-14]" file="driver.go:2235" Driver=pxd Error="Block Driver Error [-14]" Function=NodeStart component=porx/storage/driver/volume
Oct 14 17:31:17 ip-10-13-187-143.pwx.purestorage.com portworx[11171]: time="2023-10-14T17:31:17Z" level=error msg="Failed to Start driver: Block Driver Error [-14]" file="driver.go:883" component=porx/storage/driver/volume
Oct 14 17:31:17 ip-10-13-187-143.pwx.purestorage.com portworx[11171]: time="2023-10-14T17:31:17Z" level=error msg="Unable to start node.  Error while loading volume driver pxd: Block Driver Error [-14]" file="stor.go:746" component=porx/px/storage
Oct 14 17:31:17 ip-10-13-187-143.pwx.purestorage.com portworx[11171]: time="2023-10-14T17:31:17Z" level=warning msg="Failed to initialize Join PX Storage Service: Block Driver Error [-14]" file="manager.go:732" component=openstorage/cluster/manager
Oct 14 17:31:17 ip-10-13-187-143.pwx.purestorage.com portworx[11171]: time="2023-10-14T17:31:17Z" level=error msg="Failed to join cluster. Block Driver Error [-14]" file="manager.go:734" component=openstorage/cluster/manager
Oct 14 17:31:17 ip-10-13-187-143.pwx.purestorage.com portworx[11171]: time="2023-10-14T17:31:17Z" level=info msg="Stopping updates collector" file="updates_collector.go:66" component=kvdb