### PR TITLE
PWX-31637: set iterator direction based on kernel version. Prevent older kernels builds from breaking.

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1260,6 +1260,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 		 PXD_DEV"%llu", pxd_dev->dev_id);
 	disk->major = pxd_dev->major;
 	disk->first_minor = pxd_dev->minor;
+
 #if defined(GENHD_FL_NO_PART) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(BLKDEV_DISCARD_SECURE))
 	disk->flags |= GENHD_FL_NO_PART;
 #else
@@ -1337,7 +1338,7 @@ static void pxd_free_disk(struct pxd_device *pxd_dev)
 	if (disk) {
 		del_gendisk(disk);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,0,0) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__) 
 		if (disk->queue) {
 			put_disk(disk);
 		}

--- a/pxd.c
+++ b/pxd.c
@@ -182,7 +182,7 @@ static long pxd_ioctl_init(struct file *file, void __user *argp)
 	struct iov_iter iter;
 	struct iovec iov = {argp, sizeof(struct pxd_ioctl_init_args)};
 
-	iov_iter_init(&iter, WRITE, &iov, 1, sizeof(struct pxd_ioctl_init_args));
+	iov_iter_init(&iter, READ, &iov, 1, sizeof(struct pxd_ioctl_init_args));
 
 	return pxd_read_init(&ctx->fc, &iter);
 }

--- a/pxd.c
+++ b/pxd.c
@@ -1708,6 +1708,7 @@ ssize_t pxd_read_init(struct fuse_conn *fc, struct iov_iter *iter)
 		printk(KERN_ERR "%s: copy pxd_init error\n", __func__);
 		goto copy_error;
 	}
+
 	copied += sizeof(pxd_init);
 
 	list_for_each_entry(pxd_dev, &ctx->list, node) {
@@ -1731,6 +1732,8 @@ ssize_t pxd_read_init(struct fuse_conn *fc, struct iov_iter *iter)
 		}
 		copied += sizeof(id);
 	}
+
+	iter->data_source = WRITE;   // Reset to 'WRITE'  
 
 	spin_unlock(&fc->lock);
 

--- a/pxd.c
+++ b/pxd.c
@@ -181,8 +181,13 @@ static long pxd_ioctl_init(struct file *file, void __user *argp)
 	struct pxd_context *ctx = container_of(file->f_op, struct pxd_context, fops);
 	struct iov_iter iter;
 	struct iovec iov = {argp, sizeof(struct pxd_ioctl_init_args)};
+	int direction = WRITE;
 
-	iov_iter_init(&iter, READ, &iov, 1, sizeof(struct pxd_ioctl_init_args));
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)
+	direction = READ;
+#endif
+	  
+	iov_iter_init(&iter, direction, &iov, 1, sizeof(struct pxd_ioctl_init_args));
 
 	return pxd_read_init(&ctx->fc, &iter);
 }
@@ -1732,9 +1737,9 @@ ssize_t pxd_read_init(struct fuse_conn *fc, struct iov_iter *iter)
 		}
 		copied += sizeof(id);
 	}
-
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)
 	iter->data_source = WRITE;   // Reset to 'WRITE'  
-
+#endif
 	spin_unlock(&fc->lock);
 
 	printk(KERN_INFO "%s: pxd-control-%d init OK %d devs version %d\n", __func__,

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -172,12 +172,14 @@ static inline char *bdevname(struct block_device *bdev, char *buf) {
 
 #endif
 
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)
 static inline void bio_set_op_attrs(struct bio *bio, enum req_op op,
                                     blk_opf_t op_flags)
 {
-        bio->bi_opf = op_flags;                                                                                                                                                   
+  bio->bi_opf = op;
 }
+
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -134,7 +134,7 @@ static inline unsigned int get_op_flags(struct bio *bio)
 	return op_flags;
 }
 
-#if LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(QUEUE_FLAG_DEAD)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,0,0) || LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(QUEUE_FLAG_DEAD)
 
 #include <linux/ctype.h>
 
@@ -170,6 +170,14 @@ static inline char *bdevname(struct block_device *bdev, char *buf) {
 } while (0)
 #endif
 
+#endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)
+static inline void bio_set_op_attrs(struct bio *bio, enum req_op op,
+                                    blk_opf_t op_flags)
+{
+        bio->bi_opf = op_flags;                                                                                                                                                   
+}
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #
PWX-31637
**Special notes for your reviewer**:

