### PR TITLE
PWX-34978: Use existence of define to fix px-fuse compilation issue o…

### DIFF
--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -173,7 +173,7 @@ static inline char *bdevname(struct block_device *bdev, char *buf) {
 #endif
 
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && defined(QUEUE_FLAG_SKIP_TAGSET_QUIESCE))
 static inline void bio_set_op_attrs(struct bio *bio, enum req_op op,
                                     blk_opf_t op_flags)
 {


### PR DESCRIPTION
…n 5.14.0-362.8.1.el9_3.x86_64.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
PX fuse does not build on Rhel 9.3 5.14.0-362.8.1.el9_3.x86_64
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-34978
**Special notes for your reviewer**:
Needs testing will merge when after testing. 

