### PR TITLE
PWX-35199: Null pointer crash fix

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1635,7 +1635,7 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 
 	return 0;
 out:
-	pr_err("remove device %llu failed %d", pxd_dev->dev_id, err);
+	pr_err("remove device %llu failed %d", remove->dev_id, err);
 	return err;
 }
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
As part of vsphere dmthin testing observed kernel crash.
With changes from this branch and PR the crash is not observed anymore.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-35199

**Special notes for your reviewer**:

