### PR TITLE
harden device remove

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1615,8 +1615,8 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 		mutex_unlock(&pxd_dev->disk->queue->sysfs_lock);
 #else
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,13,0)
-		// Do not mark queue dead, del_gendisk will try to
-		// submit all outstanding IOs on this device
+		blk_freeze_queue_start(pxd_dev->disk->queue);
+		blk_mark_disk_dead(pxd_dev->disk);
 #else
 		blk_set_queue_dying(pxd_dev->disk->queue);
 #endif

--- a/pxd.c
+++ b/pxd.c
@@ -159,8 +159,12 @@ static long pxd_ioctl_get_version(void __user *argp)
 	int ver_len = 0;
 
 	if (argp) {
-		ver_len = strlen(gitversion) < 64 ? strlen(gitversion) : 64;
+		ver_len = strlen(gitversion) + 1; // account for null
+		if (sizeof(ver_data) < ver_len) {
+			ver_len = sizeof(ver_data);
+		}
 		strncpy(ver_data, gitversion, ver_len);
+		ver_data[ver_len-1]='\0';
 		if (copy_to_user(argp +
 				 offsetof(struct pxd_ioctl_version_args, piv_len),
 			&ver_len, sizeof(ver_len))) {

--- a/pxd.c
+++ b/pxd.c
@@ -1166,16 +1166,13 @@ static const struct blk_mq_ops pxd_mq_ops = {
 #endif /* __PX_BLKMQ__ */
 #endif /* __PXD_BIO_BLKMQ__ */
 
-static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add)
+static int pxd_init_disk(struct pxd_device *pxd_dev)
 {
 	struct gendisk *disk;
 	struct request_queue *q;
 #ifdef __PX_BLKMQ__
 	int err = 0;
 #endif
-
-	if (add->queue_depth < 0 || add->queue_depth > PXD_MAX_QDEPTH)
-		return -EINVAL;
 
 	// only fastpath uses direct block io process bypassing request queuing
 #ifndef __PX_FASTPATH__
@@ -1219,7 +1216,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 #ifdef __PX_BLKMQ__
 	  memset(&pxd_dev->tag_set, 0, sizeof(pxd_dev->tag_set));
 	  pxd_dev->tag_set.ops = &pxd_mq_ops;
-	  pxd_dev->tag_set.queue_depth = add->queue_depth;
+	  pxd_dev->tag_set.queue_depth = pxd_dev->queue_depth;
 	  pxd_dev->tag_set.numa_node = NUMA_NO_NODE;
 	  pxd_dev->tag_set.flags = BLK_MQ_F_SHOULD_MERGE;
 	  pxd_dev->tag_set.nr_hw_queues = 8;
@@ -1269,6 +1266,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 	snprintf(disk->disk_name, sizeof(disk->disk_name),
 		 PXD_DEV"%llu", pxd_dev->dev_id);
 	disk->major = pxd_dev->major;
+	disk->minors = 1;
 	disk->first_minor = pxd_dev->minor;
 
 #if defined(GENHD_FL_NO_PART) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(BLKDEV_DISCARD_SECURE))
@@ -1277,13 +1275,9 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 	disk->flags |= GENHD_FL_EXT_DEVT | GENHD_FL_NO_PART_SCAN;
 #endif
 
-#ifdef __PXD_BIO_MAKEREQ__
-		disk->fops = get_bd_fpops();
-#else
-		disk->fops = &pxd_bd_ops;
-#endif
+	disk->fops = get_bd_fpops();
 	disk->private_data = pxd_dev;
-	set_capacity(disk, add->size / SECTOR_SIZE);
+	set_capacity(disk, pxd_dev->size / SECTOR_SIZE);
 
 	blk_queue_max_hw_sectors(q, SEGMENT_SIZE / SECTOR_SIZE);
 	blk_queue_max_segment_size(q, SEGMENT_SIZE);
@@ -1308,10 +1302,10 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, struct pxd_add_ext_out *add
 #endif
     q->limits.discard_granularity = PXD_MAX_DISCARD_GRANULARITY;
     q->limits.discard_alignment = PXD_MAX_DISCARD_GRANULARITY;
-	if (add->discard_size < SECTOR_SIZE)
+	if (pxd_dev->discard_size < SECTOR_SIZE)
 		q->limits.max_discard_sectors = SEGMENT_SIZE / SECTOR_SIZE;
 	else
-		q->limits.max_discard_sectors = add->discard_size / SECTOR_SIZE;
+		q->limits.max_discard_sectors = pxd_dev->discard_size / SECTOR_SIZE;
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0)
 	q->limits.discard_zeroes_data = 1;
@@ -1406,16 +1400,6 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 	struct pxd_device *pxd_dev_itr;
 	int new_minor;
 	int err;
-	char devfile[128];
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
-	struct block_device *bdev;
-#else
-	dev_t kdev;
-#endif
-
-	err = -ENODEV;
-	if (!try_module_get(THIS_MODULE))
-		goto out;
 
 	err = -ENOMEM;
 	if (ctx->num_devices >= PXD_MAX_DEVICES) {
@@ -1426,8 +1410,6 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 	// if device already exists, then return it
 	pxd_dev = find_pxd_device(ctx, add->dev_id);
 	if (pxd_dev) {
-		module_put(THIS_MODULE);
-
 		if (add->enable_fp && add->paths.count > 0) {
 			__pxd_update_path(pxd_dev, &add->paths);
 		} else {
@@ -1436,25 +1418,6 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 		return pxd_dev->minor | (fastpath_active(pxd_dev) << MINORBITS);
 	}
 
-	/* pre-check to detect if prior instance is removed */
-	sprintf(devfile, "/dev/pxd/pxd%llu", add->dev_id);
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
-	bdev = lookup_bdev_wrapper(devfile, 0);
-	if (!IS_ERR(bdev)) {
-		bdput(bdev);
-		pr_err("stale bdev %s still alive", devfile);
-		err = -EEXIST;
-		goto out_module;
-	}
-#else
-	err = lookup_bdev(devfile, &kdev);
-	if (!err) {
-		pr_err("stale bdev %s still alive", devfile);
-		err = -EEXIST;
-		goto out_module;
-	}
-#endif
-
 	pxd_dev = kzalloc(sizeof(*pxd_dev), GFP_KERNEL);
 	if (!pxd_dev)
 		goto out_module;
@@ -1462,6 +1425,7 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 	pxd_mem_printk("device %llu allocated at %px\n", add->dev_id, pxd_dev);
 
 	pxd_dev->magic = PXD_DEV_MAGIC;
+	pxd_dev->exported = false;
 	pxd_dev->removing = false;
 	spin_lock_init(&pxd_dev->lock);
 	spin_lock_init(&pxd_dev->qlock);
@@ -1493,6 +1457,18 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 	pxd_dev->nr_congestion_off = 0;
 	atomic_set(&pxd_dev->ncount, 0);
 
+	if (add->queue_depth < 0 || add->queue_depth > PXD_MAX_QDEPTH) {
+		err = -EINVAL;
+		goto out_module;
+	} else if (add->queue_depth != 0) {
+		pxd_dev->qdepth = add->queue_depth;
+	}
+
+	if (add->discard_size < SECTOR_SIZE)
+		pxd_dev->discard_size = SEGMENT_SIZE;
+	else
+		pxd_dev->discard_size = add->discard_size;
+
 	printk(KERN_INFO"Device %llu added %px with mode %#x fastpath %d npath %lu\n",
 			add->dev_id, pxd_dev, add->open_mode, add->enable_fp, add->paths.count);
 
@@ -1509,45 +1485,26 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 		}
 	}
 
-	err = pxd_init_disk(pxd_dev, add);
-	if (err) {
-		pxd_fastpath_cleanup(pxd_dev);
-		goto out_id;
-	}
-
 	spin_lock(&ctx->lock);
 	list_for_each_entry(pxd_dev_itr, &ctx->list, node) {
 		if (pxd_dev_itr->dev_id == add->dev_id) {
 			err = -EEXIST;
 			spin_unlock(&ctx->lock);
-			goto out_disk;
+			goto out_id;
 		}
 	}
 
 	list_add(&pxd_dev->node, &ctx->list);
 	++ctx->num_devices;
 	spin_unlock(&ctx->lock);
-	err = pxd_bus_add_dev(pxd_dev);
-	if (err) {
-		goto out_list;
-	}
-
 	return pxd_dev->minor | (fastpath_active(pxd_dev) << MINORBITS);
 
-out_list:
-	spin_lock(&ctx->lock);
-	list_del(&pxd_dev->node);
-	--ctx->num_devices;
-	spin_unlock(&ctx->lock);
-out_disk:
-	pxd_free_disk(pxd_dev);
 out_id:
 	ida_simple_remove(&pxd_minor_ida, new_minor);
 out_module:
 	if (pxd_dev)
 		kfree(pxd_dev);
-	module_put(THIS_MODULE);
-out:
+
 	return err;
 }
 
@@ -1555,24 +1512,97 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 {
 	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
 	struct pxd_device *pxd_dev = find_pxd_device(ctx, dev_id);
-
-	if (pxd_dev) {
-#if LINUX_VERSION_CODE > KERNEL_VERSION(5,15,50) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
-		int rc = add_disk(pxd_dev->disk);
-		if (rc) {
-			return rc;
-		}
+	char devfile[128];
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
+	struct block_device *bdev;
 #else
-		add_disk(pxd_dev->disk);
+	dev_t kdev;
 #endif
+	int err = 0;
 
-#if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
-		blk_mq_unfreeze_queue(pxd_dev->disk->queue);
-#endif
+	if (!pxd_dev) {
+		return -ENOENT;
+	}
+
+	if (pxd_dev->exported) {
 		return 0;
 	}
 
-	return -ENOENT;
+	spin_lock(&pxd_dev->lock);
+    /* pre-check to detect if prior instance is removed */
+    sprintf(devfile, "/dev/pxd/pxd%llu", pxd_dev->dev_id);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
+    bdev = lookup_bdev_wrapper(devfile, 0);
+    if (!IS_ERR(bdev)) {
+		spin_unlock(&pxd_dev->lock);
+    	bdput(bdev);
+    	pr_err("stale bdev %s still alive", devfile);
+    	err = -EEXIST;
+		goto cleanup;
+   }
+#else
+   err = lookup_bdev(devfile, &kdev);
+   if (!err) {
+		spin_unlock(&pxd_dev->lock);
+		pr_err("stale bdev %s still alive", devfile);
+		err = -EEXIST;
+		goto cleanup;
+	}
+#endif
+
+	if (!try_module_get(THIS_MODULE)) {
+		spin_unlock(&pxd_dev->lock);
+		err = -ENODEV;
+		goto cleanup;
+	}
+
+
+	err = pxd_init_disk(pxd_dev);
+	if (err) {
+		spin_unlock(&pxd_dev->lock);
+		module_put(THIS_MODULE);
+		goto cleanup;
+	}
+
+	err = pxd_bus_add_dev(pxd_dev);
+	if (err) {
+		pxd_free_disk(pxd_dev);
+		module_put(THIS_MODULE);
+		goto cleanup;
+	}
+
+	pxd_dev->exported = true;
+	spin_unlock(&pxd_dev->lock);
+
+#if LINUX_VERSION_CODE > KERNEL_VERSION(5,15,50) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
+	err = add_disk(pxd_dev->disk);
+	if (err) {
+		device_unregister(&pxd_dev->dev);
+		pxd_free_disk(pxd_dev);
+		module_put(THIS_MODULE);
+		goto cleanup;
+	}
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,13,0)
+	device_add_disk(&pxd_dev->dev, pxd_dev->disk, NULL);
+#else
+	add_disk(pxd_dev->disk);
+#endif
+
+#if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
+	blk_mq_unfreeze_queue(pxd_dev->disk->queue);
+#endif
+	return 0;
+cleanup:
+    spin_lock(&ctx->lock);
+    spin_lock(&pxd_dev->lock);
+    list_del(&pxd_dev->node);
+    --ctx->num_devices;
+	pxd_dev->exported = false;
+    ida_simple_remove(&pxd_minor_ida, pxd_dev->minor);
+    spin_unlock(&pxd_dev->lock);
+    spin_unlock(&ctx->lock);
+	kfree(pxd_dev);
+	return err;
 }
 
 static void pxd_finish_remove(struct work_struct *work)

--- a/pxd.c
+++ b/pxd.c
@@ -1457,11 +1457,12 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 	pxd_dev->nr_congestion_off = 0;
 	atomic_set(&pxd_dev->ncount, 0);
 
+	pxd_dev->queue_depth = PXD_MAX_QDEPTH;
 	if (add->queue_depth < 0 || add->queue_depth > PXD_MAX_QDEPTH) {
 		err = -EINVAL;
 		goto out_module;
 	} else if (add->queue_depth != 0) {
-		pxd_dev->qdepth = add->queue_depth;
+		pxd_dev->queue_depth = add->queue_depth;
 	}
 
 	if (add->discard_size < SECTOR_SIZE)

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -55,6 +55,9 @@ struct pxd_device {
 	unsigned int nr_congestion_on;
 	unsigned int nr_congestion_off;
 
+	struct work_struct remove_work;
+
+	wait_queue_head_t remove_wait;
 	wait_queue_head_t suspend_wq;
 #if defined(__PXD_BIO_BLKMQ__) && defined(__PX_BLKMQ__)
         struct blk_mq_tag_set tag_set;

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -46,12 +46,15 @@ struct pxd_device {
 	bool connected;
 	mode_t mode;
 	bool fastpath; // this is persistent, how the block device registered with kernel
+	unsigned int queue_depth; // sysfs attribute bdev io queue depth
+	unsigned int discard_size;
 
 #define PXD_ACTIVE(pxd_dev)  (atomic_read(&pxd_dev->ncount))
 	// congestion handling
 	atomic_t ncount; // [global] total active requests, always modify with pxd_dev.lock
 	unsigned int qdepth;
 	atomic_t congested;
+	bool exported;
 	unsigned int nr_congestion_on;
 	unsigned int nr_congestion_off;
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
1/ harden device removal path
--- freeze queue and mark device dead to ensure newer IOs do not continue to flow while device is being detached.

2/ fix the version report that does not account for the null char.


**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-35419

**Special notes for your reviewer**:
1/ harden volume detach path

QA note: 
posted changes are running for 2 days with the issue not seen.

2/ also fix version report include null
```
// exact match
#cat px_version.c
const char *gitversion = "ln/minordevs:34234325345435345464565453524234242432423423423477";
# ./pxd -v
Version: ln/minordevs:34234325345435345464565453524234242432423423423477
#

// more than 64
#cat px_version.c
const char *gitversion = "ln/LARGER:34234325345435345464565453524234242432423423423477888888888888";
# ./pxd -v
Version: ln/LARGER:34234325345435345464565453524234242432423423423477888
#


// less than 64
# cat px_version.c
const char *gitversion = "ln/SMALL:2345454";
# ./pxd -v
Version: ln/SMALL:2345454
#
```