### PR TITLE
fix compilation

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1585,10 +1585,17 @@ static void pxd_finish_remove(struct work_struct *work)
 		mutex_unlock(&pxd_dev->disk->queue->sysfs_lock);
 #else
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,13,0)
-		// Do not mark queue dead, del_gendisk will try to
-		// submit all outstanding IOs on this device
+	// del_gendisk will try to fsync device
+	// so freeze queue and then mark queue dead to ensure no new reqs
+	// gets accepted.
+    blk_freeze_queue_start(pxd_dev->disk->queue);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0)
+    blk_mark_disk_dead(pxd_dev->disk);
 #else
-		blk_set_queue_dying(pxd_dev->disk->queue);
+    blk_set_queue_dying(pxd_dev->disk->queue);
+#endif
+#else
+    blk_set_queue_dying(pxd_dev->disk->queue);
 #endif
 #endif
 	}

--- a/pxd.c
+++ b/pxd.c
@@ -1589,7 +1589,7 @@ static void pxd_finish_remove(struct work_struct *work)
 	// so freeze queue and then mark queue dead to ensure no new reqs
 	// gets accepted.
     blk_freeze_queue_start(pxd_dev->disk->queue);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,25)
     blk_mark_disk_dead(pxd_dev->disk);
 #else
     blk_set_queue_dying(pxd_dev->disk->queue);


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
```
Kernel version 5.15 supports fastpath.
Kernel version 5.15 supports blkmq driver model.
make -C /usr/src/kernels/5.15.13-1.el7.elrepo.x86_64  M=/home/px-fuse clean
make[1]: Entering directory '/usr/src/kernels/5.15.13-1.el7.elrepo.x86_64'
Kernel version 5.15 supports fastpath.
Kernel version 5.15 supports blkmq driver model.
make[1]: Leaving directory '/usr/src/kernels/5.15.13-1.el7.elrepo.x86_64'
Kernel version 5.15 supports fastpath.
Kernel version 5.15 supports blkmq driver model.
make  -C /usr/src/kernels/5.15.13-1.el7.elrepo.x86_64  M=/home/px-fuse modules
make[1]: Entering directory '/usr/src/kernels/5.15.13-1.el7.elrepo.x86_64'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2)
  You are using:           gcc-7 (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
Kernel version 5.15 supports fastpath.
Kernel version 5.15 supports blkmq driver model.
  CC [M]  /home/px-fuse/pxd.o
/home/px-fuse/pxd.c: In function 'pxd_finish_remove':
/home/px-fuse/pxd.c:1628:3: error: implicit declaration of function 'blk_mark_disk_dead'; did you mean 'do_task_dead'? [-Werror=implicit-function-declaration]
   blk_mark_disk_dead(pxd_dev->disk);
   ^~~~~~~~~~~~~~~~~~
   do_task_dead
cc1: all warnings being treated as errors
scripts/Makefile.build:277: recipe for target '/home/px-fuse/pxd.o' failed
make[2]: *** [/home/px-fuse/pxd.o] Error 1
Makefile:1868: recipe for target '/home/px-fuse' failed
make[1]: *** [/home/px-fuse] Error 2
make[1]: Leaving directory '/usr/src/kernels/5.15.13-1.el7.elrepo.x86_64'
Makefile:135: recipe for target 'all' failed
make: *** [all] Error 2
```
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

```
[root@ip-10-13-160-160 ~]# runc exec -t portworx bash
root@ip-10-13-160-160:/# cd /home/px-fuse/
root@ip-10-13-160-160:/home/px-fuse# make CC=gcc-7
Kernel version 5.15 supports fastpath.
Kernel version 5.15 supports blkmq driver model.
make  -C /usr/src/kernels/5.15.13-1.el7.elrepo.x86_64  M=/home/px-fuse modules
make[1]: Entering directory '/usr/src/kernels/5.15.13-1.el7.elrepo.x86_64'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2)
  You are using:           gcc-7 (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
Kernel version 5.15 supports fastpath.
Kernel version 5.15 supports blkmq driver model.
  CC [M]  /home/px-fuse/pxd.o
  CC [M]  /home/px-fuse/dev.o
  CC [M]  /home/px-fuse/iov_iter.o
  CC [M]  /home/px-fuse/px_version.o
  CC [M]  /home/px-fuse/kiolib.o
  CC [M]  /home/px-fuse/pxd_bio_makereq.o
  CC [M]  /home/px-fuse/pxd_bio_blkmq.o
  CC [M]  /home/px-fuse/pxd_fastpath.o
  LD [M]  /home/px-fuse/px.o
Kernel version 5.15 supports fastpath.
Kernel version 5.15 supports blkmq driver model.
  MODPOST /home/px-fuse/Module.symvers
  CC [M]  /home/px-fuse/px.mod.o
  LD [M]  /home/px-fuse/px.ko
make[1]: Leaving directory '/usr/src/kernels/5.15.13-1.el7.elrepo.x86_64'
root@ip-10-13-160-160:/home/px-fuse#
```