### PR TITLE
PWX-35471: Changes to fix compilation issue with SUSE-15

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -100,6 +100,12 @@ ifeq ($(shell echo "$(CHK_KVER)" | grep -Eq '.*\.el[8-9].*\.x86_64'; echo $$?),0
 PXDEFINES += -D__PX_BLKMQ__ -D__EL8__
 endif
 
+ifeq ($(shell test -f "/etc/os-release"; echo $$?),0)
+ifeq ($(shell cat "/etc/os-release" | grep  ID_LIKE | grep -q suse; echo $$?),0)
+PXDEFINES += -D__SUSE__
+endif
+endif
+
 ifdef KERNELOTHER
 KERNELOTHEROPT=O=$(KERNELOTHER)
 endif

--- a/Makefile.in
+++ b/Makefile.in
@@ -100,9 +100,16 @@ ifeq ($(shell echo "$(CHK_KVER)" | grep -Eq '.*\.el[8-9].*\.x86_64'; echo $$?),0
 PXDEFINES += -D__PX_BLKMQ__ -D__EL8__
 endif
 
-ifeq ($(shell test -f "/etc/os-release"; echo $$?),0)
+# Check for Suse
+ifeq ($(shell test -f "/host-os-release"; echo $$?),0)   # inside PX container
+ifeq ($(shell cat "/host-os-release" | grep  ID_LIKE | grep -q suse; echo $$?),0)
+PXDEFINES += -D__SUSE__
+endif
+else
+ifeq ($(shell test -f "/etc/os-release"; echo $$?),0)    # check OS
 ifeq ($(shell cat "/etc/os-release" | grep  ID_LIKE | grep -q suse; echo $$?),0)
 PXDEFINES += -D__SUSE__
+endif
 endif
 endif
 

--- a/pxd.c
+++ b/pxd.c
@@ -458,7 +458,7 @@ static void pxd_update_stats(struct fuse_req *req, int rw, unsigned int count)
 {
 		struct pxd_device *pxd_dev = req->queue->queuedata;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0) || defined(__EL8__)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0) || defined(__EL8__) 
 {
 		struct block_device *p = pxd_dev->disk->part0;
 		if (!p) return;
@@ -751,7 +751,7 @@ static int pxd_write_same_request(struct fuse_req *req, uint32_t size, uint64_t 
 {
 	int rc;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
 	rc = pxd_handle_device_limits(req, &size, &off, REQ_OP_WRITE_ZEROES);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) || defined(REQ_PREFLUSH)
 	rc = pxd_handle_device_limits(req, &size, &off, REQ_OP_WRITE_SAME);
@@ -781,7 +781,7 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 	trace_pxd_request(req->in.h.unique, size, off, minor, flags);
 
 	switch (op) {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
 	case REQ_OP_WRITE_ZEROES:
 #else
 	case REQ_OP_WRITE_SAME:
@@ -1193,7 +1193,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 	 	q = blk_alloc_queue(NUMA_NO_NODE);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0)
 		q = blk_alloc_queue(pxd_bio_make_request_entryfn, NUMA_NO_NODE);
-#elif LINUX_VERSION_CODE == KERNEL_VERSION(4,18,0) && defined(__EL8__) && defined(QUEUE_FLAG_NOWAIT)
+#elif LINUX_VERSION_CODE == KERNEL_VERSION(4,18,0) && defined(__EL8__) && defined(QUEUE_FLAG_NOWAIT) 
         q = blk_alloc_queue_rh(pxd_bio_make_request_entryfn, NUMA_NO_NODE);
 #else
 		q = blk_alloc_queue(GFP_KERNEL);
@@ -1269,7 +1269,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 	disk->minors = 1;
 	disk->first_minor = pxd_dev->minor;
 
-#if defined(GENHD_FL_NO_PART) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(BLKDEV_DISCARD_SECURE))
+#if defined(GENHD_FL_NO_PART) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(BLKDEV_DISCARD_SECURE)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
 	disk->flags |= GENHD_FL_NO_PART;
 #else
 	disk->flags |= GENHD_FL_EXT_DEVT | GENHD_FL_NO_PART_SCAN;
@@ -1295,7 +1295,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 	QUEUE_FLAG_SET(QUEUE_FLAG_DISCARD,q);
 #endif
 
-#else
+#elif  !defined(QUEUE_FLAG_DEAD) 
 	/* Enable discard support. */
 	QUEUE_FLAG_SET(QUEUE_FLAG_DISCARD,q);
 #endif
@@ -1342,7 +1342,7 @@ static void pxd_free_disk(struct pxd_device *pxd_dev)
 	if (disk) {
 		del_gendisk(disk);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,0,0) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__) 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,0,0) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__)  || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
 		if (disk->queue) {
 			put_disk(disk);
 		}
@@ -1575,7 +1575,7 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 	pxd_dev->exported = true;
 	spin_unlock(&pxd_dev->lock);
 
-#if LINUX_VERSION_CODE > KERNEL_VERSION(5,15,50) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
+#if LINUX_VERSION_CODE > KERNEL_VERSION(5,15,50) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
 	err = add_disk(pxd_dev->disk);
 	if (err) {
 		device_unregister(&pxd_dev->dev);
@@ -1623,7 +1623,7 @@ static void pxd_finish_remove(struct work_struct *work)
 
 		mutex_unlock(&pxd_dev->disk->queue->sysfs_lock);
 #else
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,13,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
 		blk_freeze_queue_start(pxd_dev->disk->queue);
 		blk_mark_disk_dead(pxd_dev->disk);
 #else

--- a/pxd.c
+++ b/pxd.c
@@ -1270,7 +1270,6 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 	disk->first_minor = pxd_dev->minor;
 
 #if defined(GENHD_FL_NO_PART) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(BLKDEV_DISCARD_SECURE)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
-	//#if defined(GENHD_FL_NO_PART) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(QUEUE_FLAG_DEAD)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__) && !defined(QUEUE_FLAG_DEAD))
 	disk->flags |= GENHD_FL_NO_PART;
 #else
 	disk->flags |= GENHD_FL_EXT_DEVT | GENHD_FL_NO_PART_SCAN;
@@ -1630,7 +1629,7 @@ static void pxd_finish_remove(struct work_struct *work)
 	// so freeze queue and then mark queue dead to ensure no new reqs
 	// gets accepted.
     blk_freeze_queue_start(pxd_dev->disk->queue);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,25) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(QUEUE_FLAG_DEAD))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,25) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && ((defined(__EL8__) && !defined(QUEUE_FLAG_DEAD)) || defined(__SUSE__)))
     blk_mark_disk_dead(pxd_dev->disk);
 #else
     blk_set_queue_dying(pxd_dev->disk->queue);

--- a/pxd.c
+++ b/pxd.c
@@ -751,7 +751,7 @@ static int pxd_write_same_request(struct fuse_req *req, uint32_t size, uint64_t 
 {
 	int rc;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && (defined(__EL8__) || defined(__SUSE__)))
 	rc = pxd_handle_device_limits(req, &size, &off, REQ_OP_WRITE_ZEROES);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) || defined(REQ_PREFLUSH)
 	rc = pxd_handle_device_limits(req, &size, &off, REQ_OP_WRITE_SAME);
@@ -781,7 +781,7 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 	trace_pxd_request(req->in.h.unique, size, off, minor, flags);
 
 	switch (op) {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && (defined(__EL8__) || defined(__SUSE__)))
 	case REQ_OP_WRITE_ZEROES:
 #else
 	case REQ_OP_WRITE_SAME:
@@ -1270,6 +1270,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 	disk->first_minor = pxd_dev->minor;
 
 #if defined(GENHD_FL_NO_PART) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(BLKDEV_DISCARD_SECURE)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
+	//#if defined(GENHD_FL_NO_PART) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(QUEUE_FLAG_DEAD)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__) && !defined(QUEUE_FLAG_DEAD))
 	disk->flags |= GENHD_FL_NO_PART;
 #else
 	disk->flags |= GENHD_FL_EXT_DEVT | GENHD_FL_NO_PART_SCAN;
@@ -1288,18 +1289,19 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 	blk_queue_physical_block_size(q, PXD_LBS);
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,19,0)
-#if defined(__EL8__)
+#if defined(__EL8__) || defined(__SUSE__)
 
-#if LINUX_VERSION_CODE != KERNEL_VERSION(5,14,0)
+#if defined(QUEUE_FLAG_DISCARD)
 	/* Enable discard support. */
 	QUEUE_FLAG_SET(QUEUE_FLAG_DISCARD,q);
-#endif
+#endif                                                       
 
-#elif  !defined(QUEUE_FLAG_DEAD) 
+#else                                                         // #else for defined(__EL8__) || defined(__SUSE__)
 	/* Enable discard support. */
 	QUEUE_FLAG_SET(QUEUE_FLAG_DISCARD,q);
-#endif
-#endif
+#endif                                                        // #endif for defined(__EL8__) || defined(__SUSE__)
+#endif                                                        // #endif for LINUX_VERSION_CODE < KERNEL_VERSION(5,19,0)
+	
     q->limits.discard_granularity = PXD_MAX_DISCARD_GRANULARITY;
     q->limits.discard_alignment = PXD_MAX_DISCARD_GRANULARITY;
 	if (pxd_dev->discard_size < SECTOR_SIZE)
@@ -1342,7 +1344,7 @@ static void pxd_free_disk(struct pxd_device *pxd_dev)
 	if (disk) {
 		del_gendisk(disk);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,0,0) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__)  || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,0,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && (defined(__EL8__) || defined(__SUSE__)))
 		if (disk->queue) {
 			put_disk(disk);
 		}
@@ -1575,7 +1577,7 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 	pxd_dev->exported = true;
 	spin_unlock(&pxd_dev->lock);
 
-#if LINUX_VERSION_CODE > KERNEL_VERSION(5,15,50) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
+#if LINUX_VERSION_CODE > KERNEL_VERSION(5,15,50) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && (defined(__EL8__) || defined(__SUSE__)))
 	err = add_disk(pxd_dev->disk);
 	if (err) {
 		device_unregister(&pxd_dev->dev);
@@ -1628,7 +1630,7 @@ static void pxd_finish_remove(struct work_struct *work)
 	// so freeze queue and then mark queue dead to ensure no new reqs
 	// gets accepted.
     blk_freeze_queue_start(pxd_dev->disk->queue);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,25)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,25) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(QUEUE_FLAG_DEAD))
     blk_mark_disk_dead(pxd_dev->disk);
 #else
     blk_set_queue_dying(pxd_dev->disk->queue);

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -6,7 +6,7 @@
 #include <linux/errno.h>
 #include <linux/types.h>
 #include <linux/version.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && (defined(__EL8__)) || defined(__SUSE__))
 #include <linux/kdev_t.h>
 #include <linux/uuid.h>
 #include <linux/blk_types.h>

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -6,7 +6,7 @@
 #include <linux/errno.h>
 #include <linux/types.h>
 #include <linux/version.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
 #include <linux/kdev_t.h>
 #include <linux/uuid.h>
 #include <linux/blk_types.h>
@@ -250,7 +250,7 @@ static int prep_root_bio(struct fp_root_context *fproot) {
         bool specialops = rq_is_special(rq);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0) /// to sync up with the usage of newer bio_alloc_bioset.
 
-#if defined(__EL8__)
+#if defined(__EL8__) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
 	
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,14,0)
         unsigned int op_flags = get_op_flags(rq->bio);
@@ -277,7 +277,7 @@ static int prep_root_bio(struct fp_root_context *fproot) {
 
         if (!specialops)
                 rq_for_each_segment(bv, rq, rq_iter) nr_bvec++;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(BLKDEV_DISCARD_SECURE))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(BLKDEV_DISCARD_SECURE)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
 	bio = bio_alloc_bioset(rq->bio->bi_bdev, nr_bvec, rq->bio->bi_opf,GFP_KERNEL, get_fpbioset());
 #else
         bio = bio_alloc_bioset(GFP_KERNEL, nr_bvec, get_fpbioset());
@@ -298,7 +298,7 @@ static int prep_root_bio(struct fp_root_context *fproot) {
         bio->bi_end_io = stub_endio; // should never get called
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0) /// to sync up with the usage of newer bio_alloc_bioset.
-#if defined(__EL8__)
+#if defined(__EL8__) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
 	
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,14,0)
 	BIO_COPY_DEV(bio, rq->bio);
@@ -370,7 +370,7 @@ static struct bio *clone_root(struct fp_root_context *fproot, int i) {
         BUG_ON(fproot->magic != FP_ROOT_MAGIC);
 
         if (!fproot->bio) { // can only be flush request
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(BLKDEV_DISCARD_SECURE))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(BLKDEV_DISCARD_SECURE)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
 	clone_bio = bio_alloc_bioset(NULL, 0, 0, GFP_KERNEL, get_fpbioset());
 #else
 	clone_bio = bio_alloc_bioset(GFP_KERNEL, 0, get_fpbioset());
@@ -384,7 +384,7 @@ static struct bio *clone_root(struct fp_root_context *fproot, int i) {
                 BIO_SET_OP_ATTRS(clone_bio, REQ_FLUSH, REQ_FUA);
 #endif
         } else {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(BLKDEV_DISCARD_SECURE))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(BLKDEV_DISCARD_SECURE)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
 	  clone_bio = bio_alloc_clone(fproot->bio->bi_bdev, fproot->bio, GFP_KERNEL, get_fpbioset());
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
                 clone_bio =
@@ -619,7 +619,7 @@ static void fp_handle_specialops(struct work_struct *work) {
         BUG_ON(!rq_is_special(rq));
         atomic_inc(&pxd_dev->fp.nio_discard);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(BLKDEV_DISCARD_SECURE))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(BLKDEV_DISCARD_SECURE))  || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
 	if (bdev_max_discard_sectors(bdev)) {  // discard supported
           r = blkdev_issue_discard(bdev, blk_rq_pos(rq),
 				   blk_rq_sectors(rq), GFP_NOIO);

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -173,7 +173,7 @@ static inline char *bdevname(struct block_device *bdev, char *buf) {
 #endif
 
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && defined(QUEUE_FLAG_SKIP_TAGSET_QUIESCE))
 static inline void bio_set_op_attrs(struct bio *bio, enum req_op op,
                                     blk_opf_t op_flags)
 {

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -2,7 +2,7 @@
 #include <linux/version.h>
 #include <linux/types.h>
 #include <linux/delay.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)  || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)  || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && (defined(__EL8__) || defined(__SUSE__)))
 #include <linux/kdev_t.h>
 #include <linux/uuid.h>
 #include <linux/blk_types.h>

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -2,7 +2,7 @@
 #include <linux/version.h>
 #include <linux/types.h>
 #include <linux/delay.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)  || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)  || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__)) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE__))
 #include <linux/kdev_t.h>
 #include <linux/uuid.h>
 #include <linux/blk_types.h>


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**ISSUE LOG**:
> KERNELPATH=/usr/src/linux-5.14.21-150500.55.39-obj/x86_64/default/  make
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
make  -C /usr/src/linux-5.14.21-150500.55.39-obj/x86_64/default/  M=/home/ec2-user/home/px-fuse modules
make[1]: Entering directory '/usr/src/linux-5.14.21-150500.55.39-obj/x86_64/default'
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
  CC [M]  /home/ec2-user/home/px-fuse/pxd.o
/home/ec2-user/home/px-fuse/pxd.c: In function 'pxd_write_same_request':
/home/ec2-user/home/px-fuse/pxd.c:757:50: error: 'REQ_OP_WRITE_SAME' undeclared (first use in this function); did you mean 'REQ_OP_WRITE_ZEROES'?
  rc = pxd_handle_device_limits(req, &size, &off, REQ_OP_WRITE_SAME);
                                                  ^~~~~~~~~~~~~~~~~
                                                  REQ_OP_WRITE_ZEROES
/home/ec2-user/home/px-fuse/pxd.c:757:50: note: each undeclared identifier is reported only once for each function it appears in
/home/ec2-user/home/px-fuse/pxd.c: In function 'pxd_request':
/home/ec2-user/home/px-fuse/pxd.c:787:7: error: 'REQ_OP_WRITE_SAME' undeclared (first use in this function); did you mean 'REQ_OP_WRITE_ZEROES'?
  case REQ_OP_WRITE_SAME:
       ^~~~~~~~~~~~~~~~~
       REQ_OP_WRITE_ZEROES
/home/ec2-user/home/px-fuse/pxd.c: In function 'pxd_init_disk':
/home/ec2-user/home/px-fuse/pxd.c:1275:17: error: 'GENHD_FL_EXT_DEVT' undeclared (first use in this function); did you mean 'GENHD_FL_NO_PART'?
  disk->flags |= GENHD_FL_EXT_DEVT | GENHD_FL_NO_PART_SCAN;
                 ^~~~~~~~~~~~~~~~~
                 GENHD_FL_NO_PART
/home/ec2-user/home/px-fuse/pxd.c:1275:37: error: 'GENHD_FL_NO_PART_SCAN' undeclared (first use in this function); did you mean 'GENHD_FL_NO_PART'?
  disk->flags |= GENHD_FL_EXT_DEVT | GENHD_FL_NO_PART_SCAN;
                                     ^~~~~~~~~~~~~~~~~~~~~
                                     GENHD_FL_NO_PART
In file included from /home/ec2-user/home/px-fuse/pxd.c:34:0:
/home/ec2-user/home/px-fuse/pxd.c:1300:17: error: 'QUEUE_FLAG_DISCARD' undeclared (first use in this function); did you mean 'QUEUE_FLAG_DEAD'?
  QUEUE_FLAG_SET(QUEUE_FLAG_DISCARD,q);
                 ^
/home/ec2-user/home/px-fuse/pxd_compat.h:115:51: note: in definition of macro 'QUEUE_FLAG_SET'
 #define QUEUE_FLAG_SET(flag,q) blk_queue_flag_set(flag, q);
                                                   ^~~~
/home/ec2-user/home/px-fuse/pxd.c: In function 'pxd_export':
/home/ec2-user/home/px-fuse/pxd.c:1587:2: error: ignoring return value of 'device_add_disk', declared with attribute warn_unused_result [-Werror=unused-result]
  device_add_disk(&pxd_dev->dev, pxd_dev->disk, NULL);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[3]: *** [/usr/src/linux-5.14.21-150500.55.39/scripts/Makefile.build:275: /home/ec2-user/home/px-fuse/pxd.o] Error 1
make[2]: *** [/usr/src/linux-5.14.21-150500.55.39/Makefile:1895: /home/ec2-user/home/px-fuse] Error 2
make[1]: *** [../../../linux-5.14.21-150500.55.39/Makefile:220: __sub-make] Error 2
make[1]: Leaving directory '/usr/src/linux-5.14.21-150500.55.39-obj/x86_64/default'
make: *** [Makefile:135: all] Error 2

**Compilation Success Log**
> KERNELPATH=/usr/src/linux-5.14.21-150500.55.39-obj/x86_64/default/  make
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
make  -C /usr/src/linux-5.14.21-150500.55.39-obj/x86_64/default/  M=/home/ec2-user/px-fuse modules
make[1]: Entering directory '/usr/src/linux-5.14.21-150500.55.39-obj/x86_64/default'
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
  CC [M]  /home/ec2-user/px-fuse/pxd.o
  CC [M]  /home/ec2-user/px-fuse/dev.o
  CC [M]  /home/ec2-user/px-fuse/iov_iter.o
  LD [M]  /home/ec2-user/px-fuse/px.o
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
  MODPOST /home/ec2-user/px-fuse/Module.symvers
  LD [M]  /home/ec2-user/px-fuse/px.ko
  BTF [M] /home/ec2-user/px-fuse/px.ko
Skipping BTF generation for /home/ec2-user/px-fuse/px.ko due to unavailability of vmlinux
make[1]: Leaving directory '/usr/src/linux-5.14.21-150500.55.39-obj/x86_64/default'



**Special notes for your reviewer**:

