### PR TITLE
PWX-35639: device removal got stuck

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1623,19 +1623,24 @@ static void pxd_finish_remove(struct work_struct *work)
 
 		mutex_unlock(&pxd_dev->disk->queue->sysfs_lock);
 #else
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,13,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,25)
 	// del_gendisk will try to fsync device
-	// so freeze queue and then mark queue dead to ensure no new reqs
+	// so freeze queue and then *mark queue dead* to ensure no new reqs
 	// gets accepted.
     blk_freeze_queue_start(pxd_dev->disk->queue);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,25)
     blk_mark_disk_dead(pxd_dev->disk);
-#else
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(5,13,0)
+	// del_gendisk will not submit any new IO.
+	// so freeze queue and then queue dying, to ensure no new reqs
+	// gets accepted.
+    blk_freeze_queue_start(pxd_dev->disk->queue);
     blk_set_queue_dying(pxd_dev->disk->queue);
 #endif
-#else
-    blk_set_queue_dying(pxd_dev->disk->queue);
-#endif
+	// kernel bug here, disk deletion code, fsync IO, checking for disk dead while queue is marked dying,
+	// which will never happen, and the disk deletion code is stuck in deadlock.
+	// in this case, allow IOs to go to the queue and let px-storage handle IO
+	// on the device, so fsync can pass, and del_gendisk can proceed
+	// to safely delete the device.
 #endif
 	}
 
@@ -1663,6 +1668,7 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
 	int err;
 	struct pxd_device *pxd_dev;
+	long remtimeo;
 	DEFINE_WAIT(wait);
 
 	spin_lock(&ctx->lock);
@@ -1695,8 +1701,14 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 	prepare_to_wait(&pxd_dev->remove_wait, &wait, TASK_INTERRUPTIBLE);
 	spin_unlock(&pxd_dev->lock);
 	spin_unlock(&ctx->lock);
-	schedule();
+	// future proof against device removal bugs
+	// schedule and forget if not done in reasonable time.
+	remtimeo = schedule_timeout(msecs_to_jiffies(500));
 	finish_wait(&pxd_dev->remove_wait, &wait);
+	if (remtimeo == 0) {
+		pr_warn("remove device %llu scheduled but timedout waiting to complete",
+				remove->dev_id);
+	}
 	put_device(&pxd_dev->dev);
 	return 0;
 out_lock:


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

linux kernel version: 5.15.13-1.el7.elrepo.x86_64

```
[root@ip-10-13-160-160 ~]# cat /etc/os-release
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"

[root@ip-10-13-160-160 ~]#
```


bio_queue_enter: wait forever here for a condition that will never happen.
->blk_try_enter_queue -> will return false as percpu ref is marked dying.
-> wait event here forever which never happens.
```
wait_event(q->mq_freeze_wq,
			   (!q->mq_freeze_depth &&
			    blk_pm_resume_queue(false, q)) ||
			   test_bit(GD_DEAD, &disk->state)); <<<<< This is not going to be marked DEAD, as its the del_gendisk which is waiting for fsync to complete before marking device dead.

[<0>] __submit_bio+0xec/0x1e0
[<0>] submit_bio_noacct+0x263/0x2c0
[<0>] submit_bio+0x48/0x130
[<0>] submit_bio_wait+0x5a/0xc0
[<0>] blkdev_issue_flush+0x6e/0x90
[<0>] ext4_sync_fs+0x13f/0x1c0 [ext4]
[<0>] sync_filesystem+0x79/0xa0
[<0>] fsync_bdev+0x25/0x60
```

**Which issue(s) this PR fixes** (optional)
Closes #PWX-35639

**Special notes for your reviewer**:

* This got fixed in later kernel, so marking disk dead and freezing queue, will fail newer IOs.

* if this condition were to happen the background scheduled task for device removal was supposed to help.
But all removal are waiting for the signal from device removal code which will never come because of a kernel bug.
If px fuse driver had let it proceed then px-storage will continue to operate except for this stale device that exists.

Changed code to allow this to happen, by using schedule_timeout instead of schedule.
