### PR TITLE
PWX-35753: handle device detach timeouts 

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -743,14 +743,15 @@ static int fuse_notify_suspend(struct fuse_conn *conn, unsigned int size,
 	struct pxd_suspend req;
 	size_t len = sizeof(req);
 	struct pxd_device *pxd_dev;
+	bool stale;
 
 	if (copy_from_iter(&req, len, iter) != len) {
 		printk(KERN_ERR "%s: can't copy arg\n", __func__);
 		return -EFAULT;
 	}
 
-	pxd_dev = find_pxd_device(ctx, req.dev_id);
-	if (!pxd_dev) {
+	pxd_dev = find_pxd_device(ctx, req.dev_id, &stale);
+	if (stale || !pxd_dev) {
 		printk(KERN_ERR "device %llu not found\n", req.dev_id);
 		return -EINVAL;
 	}
@@ -763,14 +764,15 @@ static int fuse_notify_resume(struct fuse_conn *conn, unsigned int size,
 	struct pxd_resume req;
 	size_t len = sizeof(req);
 	struct pxd_device *pxd_dev;
+	bool stale;
 
 	if (copy_from_iter(&req, len, iter) != len) {
 		printk(KERN_ERR "%s: can't copy arg\n", __func__);
 		return -EFAULT;
 	}
 
-	pxd_dev = find_pxd_device(ctx, req.dev_id);
-	if (!pxd_dev) {
+	pxd_dev = find_pxd_device(ctx, req.dev_id, &stale);
+	if (stale || !pxd_dev) {
 		printk(KERN_ERR "device %llu not found\n", req.dev_id);
 		return -EINVAL;
 	}
@@ -784,14 +786,15 @@ static int fuse_notify_ioswitch_event(struct fuse_conn *conn, unsigned int size,
        struct pxd_ioswitch req;
        size_t len = sizeof(req);
        struct pxd_device *pxd_dev;
+       bool stale;
 
        if (copy_from_iter(&req, len, iter) != len) {
                printk(KERN_ERR "%s: can't copy arg\n", __func__);
                return -EFAULT;
        }
 
-       pxd_dev = find_pxd_device(ctx, req.dev_id);
-       if (!pxd_dev) {
+       pxd_dev = find_pxd_device(ctx, req.dev_id, &stale);
+       if (stale || !pxd_dev) {
                printk(KERN_ERR "device %llu not found\n", req.dev_id);
                return -EINVAL;
        }

--- a/pxd.c
+++ b/pxd.c
@@ -1339,7 +1339,9 @@ struct pxd_device* find_pxd_device(struct pxd_context *ctx, uint64_t dev_id, boo
 	list_for_each_entry(pxd_dev_itr, &ctx->list, node) {
 		if (pxd_dev_itr->dev_id == dev_id) {
 			pxd_dev = pxd_dev_itr;
+			spin_lock(&pxd_dev->lock);
 			*stale = pxd_dev->removing;
+			spin_unlock(&pxd_dev->lock);
 			break;
 		}
 	}

--- a/pxd.h
+++ b/pxd.h
@@ -246,7 +246,7 @@ struct pxd_ioswitch {
 };
 
 struct pxd_context;
-struct pxd_device* find_pxd_device(struct pxd_context *ctx, uint64_t dev_id);
+struct pxd_device* find_pxd_device(struct pxd_context *ctx, uint64_t dev_id, bool*);
 
 /**
  * PXD_GET_FEATURES request from user space

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -16,7 +16,7 @@
 #endif
 
 struct pxd_context {
-	spinlock_t lock;
+	spinlock_t lock; // Protects the device list
 	struct list_head list;
 	size_t num_devices;
 	struct fuse_conn fc;
@@ -39,7 +39,7 @@ struct pxd_device {
 	struct gendisk *disk;
 	struct device dev;
 	size_t size;
-	spinlock_t lock;
+	spinlock_t lock; // Protects open_count, removing, connected, exported
 	spinlock_t qlock;
 	struct list_head node;
 	int open_count;


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
handle device detach timeouts and subsequent attach incorrectly passing because of stale block device. 

**Which issue(s) this PR fixes** (optional)
Closes # PWX-35753

**Special notes for your reviewer**:
https://jenkins.pwx.dev.purestorage.com/job/Dev/job/Porx-08/116
```
block device detached
block device detachment scheduled and wait upon with a timeout
detachment action timeout
px-storage and px continues further with block device marked detached, while block device detachment still continues in the kernel block layer
new request to attach same block device
block device gets attached with a nop from the kernel fuse driver because of stale device that is being detached.
block attachment fails with no block device,  because previous stale device got removed.
```