### PR TITLE
fastpath - submit path optimization

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1083,7 +1083,7 @@ static void pxd_rq_fn(struct request_queue *q)
 		fp_root_context_init(fproot);
 		if (pxd_dev->fp.fastpath) {
 			// route through fastpath
-			fastpath_queue_work(&fproot->work, smp_processor_id(), false);
+			fastpath_queue_work(&fproot->work, false);
 			spin_lock_irq(&pxd_dev->qlock);
 			continue;
 		}
@@ -1158,7 +1158,7 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 		// route through fastpath
 		// while in blkmq mode: cannot directly process IO from this thread... involves
 		// recursive BIO submission to the backing devices, causing deadlock.
-		fastpath_queue_work(&fproot->work, hctx->queue_num, false);
+		fastpath_queue_work(&fproot->work, false);
 		return BLK_STS_OK;
 	}
 }

--- a/pxd.c
+++ b/pxd.c
@@ -72,10 +72,12 @@ uint32_t pxd_num_contexts = PXD_NUM_CONTEXTS;
 uint32_t pxd_num_contexts_exported = PXD_NUM_CONTEXT_EXPORTED;
 uint32_t pxd_timeout_secs = PXD_TIMER_SECS_DEFAULT;
 uint32_t pxd_detect_zero_writes = 0;
+uint32_t pxd_num_fpthreads = DEFAULT_PXFP_WORKERS_PER_NODE;
 
 module_param(pxd_num_contexts_exported, uint, 0644);
 module_param(pxd_num_contexts, uint, 0644);
 module_param(pxd_detect_zero_writes, uint, 0644);
+module_param(pxd_num_fpthreads, uint, 0644);
 
 static void pxd_abort_context(struct work_struct *work);
 static int pxd_nodewipe_cleanup(struct pxd_context *ctx);
@@ -1081,7 +1083,7 @@ static void pxd_rq_fn(struct request_queue *q)
 		fp_root_context_init(fproot);
 		if (pxd_dev->fp.fastpath) {
 			// route through fastpath
-			queue_work(fastpath_workqueue(), &fproot->work);
+			fastpath_queue_work(&fproot->work, smp_processor_id());
 			spin_lock_irq(&pxd_dev->qlock);
 			continue;
 		}
@@ -1123,7 +1125,6 @@ void pxdmq_reroute_slowpath(struct fuse_req *req)
     fuse_request_send_nowait(&pxd_dev->ctx->fc, req);
 }
 
-
 static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 		const struct blk_mq_queue_data *bd)
 {
@@ -1157,7 +1158,7 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 		// route through fastpath
 		// while in blkmq mode: cannot directly process IO from this thread... involves
 		// recursive BIO submission to the backing devices, causing deadlock.
-		queue_work(fastpath_workqueue(), &fproot->work);
+		fastpath_queue_work(&fproot->work, hctx->queue_num);
 		return BLK_STS_OK;
 	}
 }
@@ -1233,7 +1234,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 	  pxd_dev->tag_set.queue_depth = pxd_dev->queue_depth;
 	  pxd_dev->tag_set.numa_node = NUMA_NO_NODE;
 	  pxd_dev->tag_set.flags = BLK_MQ_F_SHOULD_MERGE;
-	  pxd_dev->tag_set.nr_hw_queues = 8;
+	  pxd_dev->tag_set.nr_hw_queues = num_online_nodes() * pxd_num_fpthreads;
 	  pxd_dev->tag_set.cmd_size = sizeof(struct fuse_req);
 
 	  err = blk_mq_alloc_tag_set(&pxd_dev->tag_set);
@@ -1496,8 +1497,7 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 	if (fastpath_enabled(pxd_dev)) {
 		err = pxd_init_fastpath_target(pxd_dev, &add->paths);
 		if (err) {
-			pxd_fastpath_cleanup(pxd_dev);
-			goto out_id;
+			goto out_fp;
 		}
 	}
 
@@ -1506,7 +1506,7 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 		if (pxd_dev_itr->dev_id == add->dev_id) {
 			err = -EEXIST;
 			spin_unlock(&ctx->lock);
-			goto out_id;
+			goto out_fp;
 		}
 	}
 
@@ -1515,6 +1515,8 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 	spin_unlock(&ctx->lock);
 	return pxd_dev->minor | (fastpath_active(pxd_dev) << MINORBITS);
 
+out_fp:
+	pxd_fastpath_cleanup(pxd_dev);
 out_id:
 	ida_simple_remove(&pxd_minor_ida, new_minor);
 out_module:

--- a/pxd.c
+++ b/pxd.c
@@ -1083,7 +1083,7 @@ static void pxd_rq_fn(struct request_queue *q)
 		fp_root_context_init(fproot);
 		if (pxd_dev->fp.fastpath) {
 			// route through fastpath
-			fastpath_queue_work(&fproot->work, smp_processor_id());
+			fastpath_queue_work(&fproot->work, smp_processor_id(), false);
 			spin_lock_irq(&pxd_dev->qlock);
 			continue;
 		}
@@ -1158,7 +1158,7 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 		// route through fastpath
 		// while in blkmq mode: cannot directly process IO from this thread... involves
 		// recursive BIO submission to the backing devices, causing deadlock.
-		fastpath_queue_work(&fproot->work, hctx->queue_num);
+		fastpath_queue_work(&fproot->work, hctx->queue_num, false);
 		return BLK_STS_OK;
 	}
 }

--- a/pxd_bio.h
+++ b/pxd_bio.h
@@ -4,7 +4,13 @@
 struct pxd_device;
 struct fuse_req;
 
+// default number of worker threads assigned for fastpath
+#define DEFAULT_PXFP_WORKERS_PER_NODE (4) /// keep it power of 2.
+
 #ifdef __PX_FASTPATH__
+
+#include <linux/types.h>
+#include <linux/kthread.h>
 
 int __fastpath_init(void);
 void __fastpath_cleanup(void);
@@ -29,14 +35,14 @@ void pxd_resume_io(struct pxd_device *pxd_dev);
 
 #ifdef __PXD_BIO_BLKMQ__
 // io entry point
-void fp_handle_io(struct work_struct *work);
+void fp_handle_io(struct kthread_work *work);
 
 // structure is exported only so, it can be embedded within fuse_context.
 // Treat it as private outside fastpath
 struct fp_root_context {
 #define FP_ROOT_MAGIC (0xbaadf00du)
   unsigned int magic;
-  struct work_struct work;  // for discard handling
+  struct kthread_work work; // thread work
   struct bio *bio;          // consolidated bio
   struct fp_clone_context *clones; // linked clones
   struct list_head wait;  // wait for resources
@@ -49,7 +55,7 @@ static inline void fp_root_context_init(struct fp_root_context *fproot) {
   fproot->clones = NULL;
   atomic_set(&fproot->nactive, 0);
   INIT_LIST_HEAD(&fproot->wait);
-  INIT_WORK(&fproot->work, fp_handle_io);
+  kthread_init_work(&fproot->work, fp_handle_io);
 }
 
 #endif

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -75,7 +75,7 @@ static inline void fp_clone_context_init(struct fp_clone_context *cc,
         cc->fproot = fproot;
         cc->file = file;
         cc->clones = NULL;
-        cc->qnum = smp_processor_id();
+        cc->qnum = smp_processor_id(); // not used anymore
         cc->status = 0;
         // work should get initialized at the point of usage.
 }
@@ -520,13 +520,13 @@ clone_and_map(struct fp_root_context *fproot) {
                         atomic_inc(&pxd_dev->fp.nswitch);
                         if (rq_is_special(rq)) {
                                 kthread_init_work(&cc->work, fp_handle_specialops);
-                                fastpath_queue_work(&cc->work, -1, false);
+                                fastpath_queue_work(&cc->work, false);
                         } else {
                                 SUBMIT_BIO(clone);
                         }
                 } else {
                         kthread_init_work(&cc->work, pxd_process_fileio);
-                        fastpath_queue_work(&cc->work, -1, false);
+                        fastpath_queue_work(&cc->work, false);
                 }
         }
 
@@ -591,7 +591,7 @@ static void pxd_failover_initiate(struct fp_root_context *fproot) {
         BUG_ON(fproot->magic != FP_ROOT_MAGIC);
 
         kthread_init_work(&fproot->work, pxd_io_failover);
-        fastpath_queue_work(&fproot->work, -1, false);
+        fastpath_queue_work(&fproot->work, false);
 }
 
 // io handling functions
@@ -751,7 +751,7 @@ static void end_clone_bio(struct bio *bio, int error)
 #else
     cc->status = error;
 #endif
-    fastpath_queue_work(&cc->work, cc->qnum, true);
+    fastpath_queue_work(&cc->work, true);
 }
 
 // entry point to handle IO

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -520,13 +520,13 @@ clone_and_map(struct fp_root_context *fproot) {
                         atomic_inc(&pxd_dev->fp.nswitch);
                         if (rq_is_special(rq)) {
                                 kthread_init_work(&cc->work, fp_handle_specialops);
-                                fastpath_queue_work(&cc->work, -1);
+                                fastpath_queue_work(&cc->work, -1, false);
                         } else {
                                 SUBMIT_BIO(clone);
                         }
                 } else {
                         kthread_init_work(&cc->work, pxd_process_fileio);
-                        fastpath_queue_work(&cc->work, -1);
+                        fastpath_queue_work(&cc->work, -1, false);
                 }
         }
 
@@ -591,7 +591,7 @@ static void pxd_failover_initiate(struct fp_root_context *fproot) {
         BUG_ON(fproot->magic != FP_ROOT_MAGIC);
 
         kthread_init_work(&fproot->work, pxd_io_failover);
-        fastpath_queue_work(&fproot->work, -1);
+        fastpath_queue_work(&fproot->work, -1, false);
 }
 
 // io handling functions
@@ -751,7 +751,7 @@ static void end_clone_bio(struct bio *bio, int error)
 #else
     cc->status = error;
 #endif
-    fastpath_queue_work(&cc->work, cc->qnum);
+    fastpath_queue_work(&cc->work, cc->qnum, true);
 }
 
 // entry point to handle IO

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -47,7 +47,7 @@ static void stub_endio(struct bio *bio, int error)
         BUG_ON("stub_endio called");
 }
 static void clone_cleanup(struct fp_root_context *fproot);
-static void fp_handle_specialops(struct work_struct *work);
+static void fp_handle_specialops(struct kthread_work *work);
 
 static atomic_t nclones;
 static atomic_t nrootbios;
@@ -59,11 +59,12 @@ static void dump_allocs(void) {
 struct fp_clone_context {
 #define FP_CLONE_MAGIC (0xea7ef00du)
         unsigned int magic;
+        int qnum;
         struct fp_clone_context *clones;
         struct fp_root_context *fproot;
         struct file *file;
         int status;
-        struct work_struct work;
+        struct kthread_work work;
         struct bio clone; // should be last
 };
 
@@ -74,6 +75,7 @@ static inline void fp_clone_context_init(struct fp_clone_context *cc,
         cc->fproot = fproot;
         cc->file = file;
         cc->clones = NULL;
+        cc->qnum = smp_processor_id();
         cc->status = 0;
         // work should get initialized at the point of usage.
 }
@@ -90,7 +92,7 @@ static int reconcile_status(struct fp_root_context *fproot) {
         return status;
 }
 
-static void pxd_process_fileio(struct work_struct *work) {
+static void pxd_process_fileio(struct kthread_work *work) {
         struct fp_clone_context *cc =
             container_of(work, struct fp_clone_context, work);
         struct bio *clone = &cc->clone;
@@ -158,7 +160,7 @@ void pxd_suspend_io(struct pxd_device *pxd_dev) {
                 // it is possible to call suspend during initial creation with
                 // no disk, ignore as in any case, no IO can flow through.
                 if (pxd_dev->disk && pxd_dev->disk->queue) {
-                        blk_freeze_queue_start(pxd_dev->disk->queue);
+                        blk_mq_quiesce_queue(pxd_dev->disk->queue);
                         atomic_set(&fp->blkmq_frozen, 1);
                 }
                 printk("For pxd device %llu IO suspended\n", pxd_dev->dev_id);
@@ -177,7 +179,7 @@ void pxd_resume_io(struct pxd_device *pxd_dev) {
         if (wakeup) {
                 if (atomic_read(&fp->blkmq_frozen)) {
                         if (pxd_dev->disk && pxd_dev->disk->queue) {
-                                blk_mq_unfreeze_queue(pxd_dev->disk->queue);
+                                blk_mq_unquiesce_queue(pxd_dev->disk->queue);
                         }
                         atomic_set(&fp->blkmq_frozen, 0);
                 }
@@ -436,6 +438,8 @@ clone_and_map(struct fp_root_context *fproot) {
         BUG_ON(pxd_dev->magic != PXD_DEV_MAGIC);
         BUG_ON(fproot->magic != FP_ROOT_MAGIC);
 
+        atomic_inc(&pxd_dev->ncount);
+
 // filter out only supported requests
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0) || defined(REQ_PREFLUSH)
         switch (req_op(rq)) {
@@ -515,14 +519,14 @@ clone_and_map(struct fp_root_context *fproot) {
                 if (S_ISBLK(get_mode(cc->file))) {
                         atomic_inc(&pxd_dev->fp.nswitch);
                         if (rq_is_special(rq)) {
-                                INIT_WORK(&cc->work, fp_handle_specialops);
-                                queue_work(fastpath_workqueue(), &cc->work);
+                                kthread_init_work(&cc->work, fp_handle_specialops);
+                                fastpath_queue_work(&cc->work, -1);
                         } else {
                                 SUBMIT_BIO(clone);
                         }
                 } else {
-                        INIT_WORK(&cc->work, pxd_process_fileio);
-                        queue_work(fastpath_workqueue(), &cc->work);
+                        kthread_init_work(&cc->work, pxd_process_fileio);
+                        fastpath_queue_work(&cc->work, -1);
                 }
         }
 
@@ -533,7 +537,7 @@ err:
 }
 
 // failover handling
-static void pxd_io_failover(struct work_struct *work) {
+static void pxd_io_failover(struct kthread_work *work) {
         struct fp_root_context *fproot =
             container_of(work, struct fp_root_context, work);
         struct pxd_device *pxd_dev = fproot_to_pxd(fproot);
@@ -586,13 +590,13 @@ static void pxd_io_failover(struct work_struct *work) {
 static void pxd_failover_initiate(struct fp_root_context *fproot) {
         BUG_ON(fproot->magic != FP_ROOT_MAGIC);
 
-        INIT_WORK(&fproot->work, pxd_io_failover);
-        queue_work(fastpath_workqueue(), &fproot->work);
+        kthread_init_work(&fproot->work, pxd_io_failover);
+        fastpath_queue_work(&fproot->work, -1);
 }
 
 // io handling functions
 // discard is special ops
-static void fp_handle_specialops(struct work_struct *work) {
+static void fp_handle_specialops(struct kthread_work *work) {
         struct fp_clone_context *cc =
             container_of(work, struct fp_clone_context, work);
         struct fp_root_context *fproot = cc->fproot;
@@ -660,14 +664,11 @@ static void fp_handle_specialops(struct work_struct *work) {
 	BIO_ENDIO(&cc->clone, r);
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 3, 0)
-static void end_clone_bio(struct bio *bio)
-#else
-static void end_clone_bio(struct bio *bio, int error)
-#endif
+static void _end_clone_bio(struct kthread_work *work)
 {
         struct fp_clone_context *cc =
-            container_of(bio, struct fp_clone_context, clone);
+            container_of(work, struct fp_clone_context, work);
+        struct bio *bio = &cc->clone;
         struct fp_root_context *fproot = bio->bi_private;
         struct pxd_device *pxd_dev = fproot_to_pxd(fproot);
         struct request *rq = fproot_to_request(fproot);
@@ -686,7 +687,7 @@ static void end_clone_bio(struct bio *bio, int error)
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 3, 0)
         blkrc = bio->bi_error;
 #else
-        blkrc = error;
+        blkrc = cc->status;
 #endif
 
         if (blkrc != 0) {
@@ -735,12 +736,29 @@ static void end_clone_bio(struct bio *bio, int error)
         atomic_dec(&pxd_dev->ncount);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 3, 0)
+static void end_clone_bio(struct bio *bio)
+#else
+static void end_clone_bio(struct bio *bio, int error)
+#endif
+{
+    struct fp_clone_context *cc =
+            container_of(bio, struct fp_clone_context, clone);
+
+    kthread_init_work(&cc->work, _end_clone_bio);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 3, 0)
+    cc->status = 0;
+#else
+    cc->status = error;
+#endif
+    fastpath_queue_work(&cc->work, cc->qnum);
+}
+
 // entry point to handle IO
-void fp_handle_io(struct work_struct *work) {
-        struct fp_root_context *fproot =
-            container_of(work, struct fp_root_context, work);
-        struct request *rq = fproot_to_request(fproot); // orig request
-        struct pxd_device *pxd_dev = fproot_to_pxd(fproot);
+void fp_handle_io(struct kthread_work *work) {
+	struct fp_root_context *fproot = container_of(work, struct fp_root_context, work);
+	struct request *rq = fproot_to_request(fproot); // orig request
+	struct pxd_device *pxd_dev = fproot_to_pxd(fproot);
 #ifndef __PX_BLKMQ__
         int r;
 #else
@@ -749,8 +767,6 @@ void fp_handle_io(struct work_struct *work) {
 
         BUG_ON(fproot->magic != FP_ROOT_MAGIC);
         BUG_ON(pxd_dev->magic != PXD_DEV_MAGIC);
-
-        atomic_inc(&pxd_dev->ncount);
 
         r = clone_and_map(fproot);
 #ifndef __PX_BLKMQ__

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -726,14 +726,14 @@ int pxd_debug_switch_nativepath(struct pxd_device* pxd_dev)
 
 // assign work on the worker thread with least penalty. loadbalance
 // across threads if no hint provided through 'qnum'
-void fastpath_queue_work(struct kthread_work* work, int qnum)
+void fastpath_queue_work(struct kthread_work* work, int qnum, bool completion)
 {
 	struct kthread_worker *worker = fpdefault;
 	int node = cpu_to_node(smp_processor_id());
 	if (node < MAX_NUMNODES) {
 		struct pxfpcontext_per_node *c = &pxfpctxt[node];
 		if (c->valid) {
-			if (qnum < 0) {
+			if (!completion || qnum < 0) {
 				qnum = atomic_add_return(1, &c->last_worker);
 			}
 

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -30,12 +30,28 @@ extern uint32_t pxd_num_fpthreads;
 
 struct pxfpcontext_per_node {
 	bool valid;
-	atomic_t last_worker;
 #define MAX_ALLOC_PXFP_WORKER_THREADS_PER_NODE (8)
 	struct kthread_worker *fpworker[MAX_ALLOC_PXFP_WORKER_THREADS_PER_NODE];
 };
 struct kthread_worker *fpdefault = NULL;
 struct pxfpcontext_per_node pxfpctxt[MAX_NUMNODES];
+
+#define BURST_IO (8)
+#define BURST_MASK (BURST_IO-1)
+struct pxfpcontext_percpu {
+  uint8_t fpbatch;
+  unsigned mapped_cpu;
+};
+struct pxfpcontext_percpu pxfp_percpu[NR_CPUS];
+
+static void fastpath_map_workers(void)
+{
+    int i;
+
+    for (i=0; i<NR_CPUS; i++) {
+	pxfp_percpu[i].mapped_cpu = i;
+    }
+}
 
 static void fastpath_flush_work(void) {
        int node;
@@ -102,7 +118,6 @@ int fastpath_init(void)
 			continue;
 		}
 
-		atomic_set(&c->last_worker, 0);
 		active = 0;
 		for_each_cpu(cpu, cpumask) {
 			struct kthread_worker* worker;
@@ -131,6 +146,8 @@ int fastpath_init(void)
 		rc = -EINVAL;
 		goto out;
 	}
+
+	fastpath_map_workers();
 
 	rc = __fastpath_init();
 	if (rc == 0) {
@@ -724,20 +741,37 @@ int pxd_debug_switch_nativepath(struct pxd_device* pxd_dev)
 	return 0;
 }
 
+static
+unsigned int balanceIO(struct pxfpcontext_per_node *c, unsigned int cpuid, bool completion)
+{
+	if (completion)
+		return cpuid;
+
+	if (cpuid < NR_CPUS) {
+		struct pxfpcontext_percpu *this = &pxfp_percpu[cpuid];
+		int burst = ++this->fpbatch;
+		if ((burst & BURST_MASK)== 0) {
+			this->mapped_cpu++;
+		}
+		return this->mapped_cpu;
+	}
+
+	return 0; // not possible case
+}
+
 // assign work on the worker thread with least penalty. loadbalance
 // across threads if no hint provided through 'qnum'
-void fastpath_queue_work(struct kthread_work* work, int qnum, bool completion)
+void fastpath_queue_work(struct kthread_work* work, bool completion)
 {
+	unsigned int cpuid = smp_processor_id();
+	int node = cpu_to_node(cpuid);
 	struct kthread_worker *worker = fpdefault;
-	int node = cpu_to_node(smp_processor_id());
+
 	if (node < MAX_NUMNODES) {
 		struct pxfpcontext_per_node *c = &pxfpctxt[node];
 		if (c->valid) {
-			if (!completion || qnum < 0) {
-				qnum = atomic_add_return(1, &c->last_worker);
-			}
-
-			worker = c->fpworker[qnum & MAX_PXFP_WORKERS_PER_NODE_MASK];
+			cpuid = balanceIO(c, cpuid, completion);
+			worker = c->fpworker[cpuid & MAX_PXFP_WORKERS_PER_NODE_MASK];
 		}
 	}
 	kthread_queue_work(worker, work);

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -152,7 +152,7 @@ int remap_io_status(int status)
 	return -EIO;
 }
 
-void fastpath_queue_work(struct kthread_work*, int qnum);
+void fastpath_queue_work(struct kthread_work*, int qnum, bool completion);
 #endif /* __PX_FASTPATH__ */
 
 #endif /* _PXD_FASTPATH_H_ */

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -151,8 +151,7 @@ int remap_io_status(int status)
 
 	return -EIO;
 }
-
-void fastpath_queue_work(struct kthread_work*, int qnum, bool completion);
+void fastpath_queue_work(struct kthread_work*, bool completion);
 #endif /* __PX_FASTPATH__ */
 
 #endif /* _PXD_FASTPATH_H_ */

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -151,6 +151,8 @@ int remap_io_status(int status)
 
 	return -EIO;
 }
+
+void fastpath_queue_work(struct kthread_work*, int qnum);
 #endif /* __PX_FASTPATH__ */
 
 #endif /* _PXD_FASTPATH_H_ */


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
perf opt
this PR addresses submission path optimization 

rootcause:
1/ resources underprovisioned for fastpath
2/ workqueues get throttled on io load.
3/ routing completion through kthreads also improves perf as the block device completions also use workqueues which 
get throttled at io load.

## Job:  (numjobs=8, 1 job on each px vol, randwrite. 50G) ##
```
fio --blocksize=4k --numjobs=1 --ioengine=libaio --direct=1 --iodepth=128 --group_reporting --readwrite=randwrite --filesize=50G --end_fsync=1 --name=fiojob1 --filename=/dev/pxd/pxd911641125860330767 --name=fiojob2 --filename=/dev/pxd/pxd440908276035619902 --name=fiojob3 --filename=/dev/pxd/pxd9496376647647828 --name=fiojob4 --filename=/dev/pxd/pxd392231402311292274 --name=fiojob5 --filename=/dev/pxd/pxd394648074750351375 --name=fiojob6 --filename=/dev/pxd/pxd999525659159923651 --name=fiojob7 --filename=/dev/pxd/pxd461464996199763580 --name=fiojob8 --filename=/dev/pxd/pxd521428744562065549
```
## submission path optimization ##
```
fastpath:     slat (nsec): min=944, max=615530, avg=4958.88, stdev=1273.33
nativepath:   slat (nsec): min=1614, max=2034.2k, avg=13374.26, stdev=9862.98

run2:
-----
fastpath:    slat (nsec): min=963, max=528205, avg=4812.89, stdev=1465.31
nativepath:  slat (nsec): min=1647, max=2763.7k, avg=16527.34, stdev=11888.90
```

## TODO: pending completion path optimization. ##
```
fastpath:    clat (nsec): min=1727, max=32056k, avg=5392952.12, stdev=2510229.92
nativepath:  clat (usec): min=2507, max=14376, avg=4502.06, stdev=1703.01

run2:
-----
fastpath:     clat (usec): min=11, max=136210, avg=5346.29, stdev=3400.42
nativepath:   clat (usec): min=649, max=21629, avg=4740.23, stdev=1959.26
```



**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

