### PR TITLE
PWX-36427: do not call add_disk with spinlock held

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1580,6 +1580,7 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 		goto cleanup;
 	}
 
+	spin_unlock(&pxd_dev->lock);
 	err = pxd_bus_add_dev(pxd_dev);
 	if (err) {
 		pxd_free_disk(pxd_dev);
@@ -1587,22 +1588,24 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 		goto cleanup;
 	}
 
-	pxd_dev->exported = true;
-	spin_unlock(&pxd_dev->lock);
 
 #if LINUX_VERSION_CODE > KERNEL_VERSION(5,15,50) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && (defined(__EL8__) || defined(__SUSE__)))
-	err = add_disk(pxd_dev->disk);
+	err = device_add_disk(&pxd_dev->dev, pxd_dev->disk, NULL);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,13,0)
+	device_add_disk(&pxd_dev->dev, pxd_dev->disk, NULL);
+#else
+	add_disk(pxd_dev->disk);
+#endif
 	if (err) {
 		device_unregister(&pxd_dev->dev);
 		pxd_free_disk(pxd_dev);
 		module_put(THIS_MODULE);
 		goto cleanup;
 	}
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,13,0)
-	device_add_disk(&pxd_dev->dev, pxd_dev->disk, NULL);
-#else
-	add_disk(pxd_dev->disk);
-#endif
+
+	spin_lock(&pxd_dev->lock);
+	pxd_dev->exported = true;
+	spin_unlock(&pxd_dev->lock);
 
 #if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
 	blk_mq_unfreeze_queue(pxd_dev->disk->queue);


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
BUG: scheduling while atomic: px-storage/15156/0x00000002 seen during pool expand and node restart
avoid this issue.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-36427

**Special notes for your reviewer**:

This is already addressed in master branch.
Please ensure a new base branch gets created for release before merging.
This PR is on top of v3.1.0 px-fuse driver.
