### PR TITLE
PWX-37390: revise discard granularity for pxd devices

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1417,10 +1417,7 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 		goto out_module;
 	}
 
-	if (add->discard_size < SECTOR_SIZE)
-		pxd_dev->discard_size = SEGMENT_SIZE;
-	else
-		pxd_dev->discard_size = add->discard_size;
+	pxd_dev->discard_size = ALIGN(add->discard_size, PXD_MAX_DISCARD_GRANULARITY);
 
 	// congestion init
 	init_waitqueue_head(&pxd_dev->suspend_wq);

--- a/pxd.c
+++ b/pxd.c
@@ -1417,7 +1417,10 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 		goto out_module;
 	}
 
-	pxd_dev->discard_size = ALIGN(add->discard_size, PXD_MAX_DISCARD_GRANULARITY);
+	pxd_dev->discard_size = PXD_MAX_DISCARD_GRANULARITY;
+	if (add->discard_size != 0) {
+		pxd_dev->discard_size = ALIGN(add->discard_size, PXD_MAX_DISCARD_GRANULARITY);
+	}
 
 	// congestion init
 	init_waitqueue_head(&pxd_dev->suspend_wq);

--- a/pxd.c
+++ b/pxd.c
@@ -1510,7 +1510,7 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
         }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0)
-		err = device_add_disk(&pxd_dev->dev, pxd_dev->disk, NULL);
+        err = device_add_disk(&pxd_dev->dev, pxd_dev->disk, NULL);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,13,0)
         device_add_disk(&pxd_dev->dev, pxd_dev->disk, NULL);
 #else

--- a/pxd.h
+++ b/pxd.h
@@ -76,7 +76,7 @@ struct pxd_ioc_free_buffers {
 #define PXD_MAX_IO		(1024*1024)	/**< maximum io size in bytes */
 #define PXD_MAX_QDEPTH  256			/**< maximum device queue depth */
 #define PXD_MIN_DISCARD_GRANULARITY		PXD_LBS
-#define PXD_MAX_DISCARD_GRANULARITY		(64 * 1024)
+#define PXD_MAX_DISCARD_GRANULARITY		(2 << 20)
 
 // NOTE: nvme devices can go upto 1023 queue depth
 #define MAX_CONGESTION_THRESHOLD (1024)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
pxd devices currently hard code discard granularity which gets assigned to pxd device.
if those pxd devices receives discard which are not aligned to advertised real target devices, then userspace process can intelligently split and act correctly.
But while in fastpath, if the requests are not aligned to the actual device attribute then (some or all) discards become nop.
There currently exist no interface from userspace to configure this value dynamically.
For now, revising the discard param to the max supported value at the raw device end (which would be 2M),


Test logs are attached part of https://github.com/pure-px/porx/pull/13439/
**Which issue(s) this PR fixes** (optional)
Closes # PWX-37390

**Special notes for your reviewer**:

