### PR TITLE
PWX-37281: fix tracebacks in kernels during dev add and removals

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1350,18 +1350,6 @@ struct pxd_device* find_pxd_device(struct pxd_context *ctx, uint64_t dev_id, boo
 	return pxd_dev;
 }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
-typedef struct block_device* (*lookup_bdev_wrapper_fn)(char *dev, int mask);
-// This hack is needed because in ubuntu lookup_bdev is defined with 2 arg.
-// ubuntu commit id 6bdf7d686366556020b6ed044fa9eadd090d3984
-// struct block_device *lookup_bdev(const char *pathname, int mask)
-// mask = 0, no perm checks are done
-// So this module shall always push 2 args into stack, but the kernel function
-// decides whether it uses both or only 1.
-// This satisfies the compilation.
-static lookup_bdev_wrapper_fn lookup_bdev_wrapper = (lookup_bdev_wrapper_fn)lookup_bdev;
-#endif
-
 static int __pxd_update_path(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path);
 ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 {
@@ -1487,12 +1475,6 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 	bool stale;
 	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
 	struct pxd_device *pxd_dev = find_pxd_device(ctx, dev_id, &stale);
-	char devfile[128];
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
-	struct block_device *bdev;
-#else
-	dev_t kdev;
-#endif
 	int err = 0;
 
 	if (pxd_dev) {
@@ -1504,42 +1486,19 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 			spin_unlock(&pxd_dev->lock);
 			return 0;
 		}
-
-        /* pre-check to detect if prior instance is removed */
-        sprintf(devfile, "/dev/pxd/pxd%llu", pxd_dev->dev_id);
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
-        bdev = lookup_bdev_wrapper(devfile, 0);
-        if (!IS_ERR(bdev)) {
-            spin_unlock(&pxd_dev->lock);
-            bdput(bdev);
-            pr_err("stale bdev %s still alive", devfile);
-            err = -EEXIST;
-            goto cleanup;
-        }
-#else
-        err = lookup_bdev(devfile, &kdev);
-        if (!err) {
-            spin_unlock(&pxd_dev->lock);
-            pr_err("stale bdev %s still alive", devfile);
-            err = -EEXIST;
-            goto cleanup;
-        }
-#endif
+        spin_unlock(&pxd_dev->lock);
 
         if (!try_module_get(THIS_MODULE)) {
-            spin_unlock(&pxd_dev->lock);
             err = -ENODEV;
             goto cleanup;
         }
 
         err = pxd_init_disk(pxd_dev);
         if (err) {
-            spin_unlock(&pxd_dev->lock);
             module_put(THIS_MODULE);
             goto cleanup;
         }
 
-        spin_unlock(&pxd_dev->lock);
         err = pxd_bus_add_dev(pxd_dev);
         if (err) {
             pxd_free_disk(pxd_dev);
@@ -1768,7 +1727,9 @@ ssize_t pxd_read_init(struct fuse_conn *fc, struct iov_iter *iter)
 	struct pxd_device *pxd_dev;
 	struct pxd_init_in pxd_init;
 
-	spin_lock(&ctx->lock);
+	// Taking context lock is unnecessary, as this gets called during
+	// userspace init only once, no changes to the pxd block device
+	// layer is expected during this window.
 
 	pxd_init.num_devices = ctx->num_devices;
 	pxd_init.version = PXD_VERSION;
@@ -1802,15 +1763,12 @@ ssize_t pxd_read_init(struct fuse_conn *fc, struct iov_iter *iter)
 		copied += sizeof(id);
 	}
 
-	spin_unlock(&ctx->lock);
-
 	printk(KERN_INFO "%s: pxd-control-%d init OK %d devs version %d\n", __func__,
 		ctx->id, pxd_init.num_devices, pxd_init.version);
 
 	return copied;
 
 copy_error:
-	spin_unlock(&ctx->lock);
 	return -EFAULT;
 }
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
 fix tracebacks in kernels during dev add and removals
 
several context and kernel actions from ioctl calls during drive add/remove and px init are not clean.
below are collected tracebacks from linux kernel 6.5 with debug options enabled.

## px init path issue ##
```
[Thu May 30 14:43:11 2024] BUG: sleeping function called from invalid context at lib/iov_iter.c:315
[Thu May 30 14:43:11 2024] in_atomic(): 1, irqs_disabled(): 0, non_block: 0, pid: 9301, name: px-storage
[Thu May 30 14:43:11 2024] preempt_count: 1, expected: 0
[Thu May 30 14:43:11 2024] RCU nest depth: 0, expected: 0
[Thu May 30 14:43:11 2024] 1 lock held by px-storage/9301:
[Thu May 30 14:43:11 2024]  #0: ffff967fd9f70018 (&ctx->lock#2){+.+.}-{3:3}, at: pxd_read_init+0x3b/0x1b0 [px]
[Thu May 30 14:43:11 2024] Preemption disabled at:
[Thu May 30 14:43:11 2024] [<ffffffffc0c12eab>] pxd_read_init+0x3b/0x1b0 [px]
[Thu May 30 14:43:11 2024] CPU: 2 PID: 9301 Comm: px-storage Tainted: G           OE      6.5.13 #2
[Thu May 30 14:43:11 2024] Hardware name: VMware, Inc. VMware Virtual Platform/440BX Desktop Reference Platform, BIOS 6.00 11/12/2020
[Thu May 30 14:43:11 2024] Call Trace:
[Thu May 30 14:43:11 2024]  <TASK>
[Thu May 30 14:43:11 2024]  dump_stack_lvl+0xb9/0xd0
[Thu May 30 14:43:11 2024]  dump_stack+0x10/0x20
[Thu May 30 14:43:11 2024]  __might_resched+0x1d5/0x320
[Thu May 30 14:43:11 2024]  __might_sleep+0x50/0xa0
[Thu May 30 14:43:11 2024]  __might_fault+0x41/0xb0
[Thu May 30 14:43:11 2024]  _copy_to_iter+0xe9/0x630
[Thu May 30 14:43:11 2024]  ? do_mprotect_pkey+0x435/0x570
[Thu May 30 14:43:11 2024]  pxd_read_init+0x5a/0x1b0 [px]
[Thu May 30 14:43:11 2024]  ? __fget_files+0xd9/0x1d0
[Thu May 30 14:43:11 2024]  pxd_control_ioctl+0xa1/0x840 [px]
[Thu May 30 14:43:11 2024]  ? __fget_files+0xde/0x1d0
[Thu May 30 14:43:11 2024]  __x64_sys_ioctl+0x9d/0xe0
[Thu May 30 14:43:11 2024]  x64_sys_call+0x1fe9/0x2570
[Thu May 30 14:43:11 2024]  do_syscall_64+0x56/0x90
[Thu May 30 14:43:11 2024]  ? syscall_exit_to_user_mode+0x3c/0x50
[Thu May 30 14:43:11 2024]  ? do_syscall_64+0x63/0x90
[Thu May 30 14:43:11 2024]  ? syscall_exit_to_user_mode+0x3c/0x50
[Thu May 30 14:43:11 2024]  ? do_syscall_64+0x63/0x90
[Thu May 30 14:43:11 2024]  ? __this_cpu_preempt_check+0x13/0x20
[Thu May 30 14:43:11 2024]  ? lockdep_hardirqs_on+0xd0/0x180
[Thu May 30 14:43:11 2024]  ? syscall_exit_to_user_mode+0x3c/0x50
[Thu May 30 14:43:11 2024]  ? do_syscall_64+0x63/0x90
[Thu May 30 14:43:11 2024]  ? syscall_exit_to_user_mode+0x3c/0x50
[Thu May 30 14:43:11 2024]  ? do_syscall_64+0x63/0x90
[Thu May 30 14:43:11 2024]  ? do_syscall_64+0x63/0x90
[Thu May 30 14:43:11 2024]  ? sysvec_apic_timer_interrupt+0x52/0xd0
[Thu May 30 14:43:11 2024]  entry_SYSCALL_64_after_hwframe+0x73/0xdd
[Thu May 30 14:43:11 2024] RIP: 0033:0x78e5fcd225cb
[Thu May 30 14:43:11 2024] Code: 0f 1e fa 48 8b 05 c5 78 0d 00 64 c7 00 26 00 00 00 48 c7 c0 ff ff ff ff c3 66 0f 1f 44 00 00 f3 0f 1e fa b8 10 00 00 00 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 8b 0d 95 78 0d 00 f7 d8 64 89 01 48
[Thu May 30 14:43:11 2024] RSP: 002b:000078e5f0ff5ea8 EFLAGS: 00000246 ORIG_RAX: 0000000000000010
[Thu May 30 14:43:11 2024] RAX: ffffffffffffffda RBX: fffffffffffffe40 RCX: 000078e5fcd225cb
[Thu May 30 14:43:11 2024] RDX: 000078e5e1625e50 RSI: 0000000000505803 RDI: 0000000000000031
[Thu May 30 14:43:11 2024] RBP: 0000000000000000 R08: 000078e5e1625e50 R09: 0000000001626000
[Thu May 30 14:43:11 2024] R10: 000078e5e1626000 R11: 0000000000000246 R12: 0000000000000031
[Thu May 30 14:43:11 2024] R13: 0000000000505803 R14: 000078e5e1625e50 R15: 0000000000000000
[Thu May 30 14:43:11 2024]  </TASK>

```

## px init path issue ##
```
[Thu May 30 14:43:11 2024] =============================
[Thu May 30 14:43:11 2024] [ BUG: Invalid wait context ]
[Thu May 30 14:43:11 2024] 6.5.13 #2 Tainted: G        W  OE
[Thu May 30 14:43:11 2024] -----------------------------
[Thu May 30 14:43:11 2024] px-storage/9301 is trying to lock:
[Thu May 30 14:43:11 2024] ffff967f86d1a7b8 (&mm->mmap_lock){++++}-{4:4}, at: __might_fault+0x60/0xb0
[Thu May 30 14:43:11 2024] other info that might help us debug this:
[Thu May 30 14:43:11 2024] context-{5:5}
[Thu May 30 14:43:11 2024] 1 lock held by px-storage/9301:
[Thu May 30 14:43:11 2024]  #0: ffff967fd9f70018 (&ctx->lock#2){+.+.}-{3:3}, at: pxd_read_init+0x3b/0x1b0 [px]
[Thu May 30 14:43:11 2024] stack backtrace:
[Thu May 30 14:43:11 2024] CPU: 2 PID: 9301 Comm: px-storage Tainted: G        W  OE      6.5.13 #2
[Thu May 30 14:43:11 2024] Hardware name: VMware, Inc. VMware Virtual Platform/440BX Desktop Reference Platform, BIOS 6.00 11/12/2020
[Thu May 30 14:43:11 2024] Call Trace:
[Thu May 30 14:43:11 2024]  <TASK>
[Thu May 30 14:43:11 2024]  dump_stack_lvl+0x77/0xd0
[Thu May 30 14:43:11 2024]  dump_stack+0x10/0x20
[Thu May 30 14:43:11 2024]  __lock_acquire+0xaa0/0x2940
[Thu May 30 14:43:11 2024]  ? sysvec_apic_timer_interrupt+0x52/0xd0
[Thu May 30 14:43:11 2024]  ? asm_sysvec_apic_timer_interrupt+0x1b/0x20
[Thu May 30 14:43:11 2024]  ? pxd_read_init+0x3b/0x1b0 [px]
[Thu May 30 14:43:11 2024]  lock_acquire+0xe1/0x300
[Thu May 30 14:43:11 2024]  ? __might_fault+0x60/0xb0
[Thu May 30 14:43:11 2024]  ? __might_resched+0x1e1/0x320
[Thu May 30 14:43:11 2024]  ? __might_fault+0x60/0xb0
[Thu May 30 14:43:11 2024]  __might_fault+0x79/0xb0
[Thu May 30 14:43:11 2024]  ? __might_fault+0x60/0xb0
[Thu May 30 14:43:11 2024]  _copy_to_iter+0xe9/0x630
[Thu May 30 14:43:11 2024]  ? do_mprotect_pkey+0x435/0x570
[Thu May 30 14:43:11 2024]  pxd_read_init+0x5a/0x1b0 [px]
[Thu May 30 14:43:11 2024]  ? __fget_files+0xd9/0x1d0
[Thu May 30 14:43:11 2024]  pxd_control_ioctl+0xa1/0x840 [px]
[Thu May 30 14:43:11 2024]  ? __fget_files+0xde/0x1d0
[Thu May 30 14:43:11 2024]  __x64_sys_ioctl+0x9d/0xe0
[Thu May 30 14:43:11 2024]  x64_sys_call+0x1fe9/0x2570
[Thu May 30 14:43:11 2024]  do_syscall_64+0x56/0x90
[Thu May 30 14:43:11 2024]  ? syscall_exit_to_user_mode+0x3c/0x50
[Thu May 30 14:43:11 2024]  ? do_syscall_64+0x63/0x90
[Thu May 30 14:43:11 2024]  ? syscall_exit_to_user_mode+0x3c/0x50
[Thu May 30 14:43:11 2024]  ? do_syscall_64+0x63/0x90
[Thu May 30 14:43:11 2024]  ? __this_cpu_preempt_check+0x13/0x20
[Thu May 30 14:43:11 2024]  ? lockdep_hardirqs_on+0xd0/0x180
[Thu May 30 14:43:11 2024]  ? syscall_exit_to_user_mode+0x3c/0x50
[Thu May 30 14:43:11 2024]  ? do_syscall_64+0x63/0x90
[Thu May 30 14:43:11 2024]  ? syscall_exit_to_user_mode+0x3c/0x50
[Thu May 30 14:43:11 2024]  ? do_syscall_64+0x63/0x90
[Thu May 30 14:43:11 2024]  ? do_syscall_64+0x63/0x90
[Thu May 30 14:43:11 2024]  ? sysvec_apic_timer_interrupt+0x52/0xd0
[Thu May 30 14:43:11 2024]  entry_SYSCALL_64_after_hwframe+0x73/0xdd
[Thu May 30 14:43:11 2024] RIP: 0033:0x78e5fcd225cb
[Thu May 30 14:43:11 2024] Code: 0f 1e fa 48 8b 05 c5 78 0d 00 64 c7 00 26 00 00 00 48 c7 c0 ff ff ff ff c3 66 0f 1f 44 00 00 f3 0f 1e fa b8 10 00 00 00 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 8b 0d 95 78 0d 00 f7 d8 64 89 01 48
[Thu May 30 14:43:11 2024] RSP: 002b:000078e5f0ff5ea8 EFLAGS: 00000246 ORIG_RAX: 0000000000000010
[Thu May 30 14:43:11 2024] RAX: ffffffffffffffda RBX: fffffffffffffe40 RCX: 000078e5fcd225cb
[Thu May 30 14:43:11 2024] RDX: 000078e5e1625e50 RSI: 0000000000505803 RDI: 0000000000000031
[Thu May 30 14:43:11 2024] RBP: 0000000000000000 R08: 000078e5e1625e50 R09: 0000000001626000
[Thu May 30 14:43:11 2024] R10: 000078e5e1626000 R11: 0000000000000246 R12: 0000000000000031
[Thu May 30 14:43:11 2024] R13: 0000000000505803 R14: 000078e5e1625e50 R15: 0000000000000000
[Thu May 30 14:43:11 2024]  </TASK>
[Thu May 30 14:43:11 2024] pxd_read_init: pxd-control-0 init OK 0 devs version 12
```

## pxd device add path ##
```
[Fri May 31 11:40:28 2024] BUG: sleeping function called from invalid context at include/linux/sched/mm.h:306
[Fri May 31 11:40:28 2024] in_atomic(): 1, irqs_disabled(): 0, non_block: 0, pid: 30232, name: px-storage
[Fri May 31 11:40:28 2024] preempt_count: 1, expected: 0
[Fri May 31 11:40:28 2024] RCU nest depth: 0, expected: 0
[Fri May 31 11:40:28 2024] INFO: lockdep is turned off.
[Fri May 31 11:40:28 2024] Preemption disabled at:
[Fri May 31 11:40:28 2024] [<ffffffffc0b665e6>] pxd_export+0xe6/0x550 [px]
[Fri May 31 11:40:28 2024] CPU: 2 PID: 30232 Comm: px-storage Tainted: G        W  OE      6.5.13.lnsbuild #5
[Fri May 31 11:40:28 2024] Hardware name: VMware, Inc. VMware Virtual Platform/440BX Desktop Reference Platform, BIOS 6.00 11/12/2020
[Fri May 31 11:40:28 2024] Call Trace:
[Fri May 31 11:40:28 2024]  <TASK>
[Fri May 31 11:40:28 2024]  dump_stack_lvl+0xb9/0xd0
[Fri May 31 11:40:28 2024]  dump_stack+0x10/0x20
[Fri May 31 11:40:28 2024]  __might_resched+0x1d5/0x320
[Fri May 31 11:40:28 2024]  ? getname_kernel+0x2a/0x140
[Fri May 31 11:40:28 2024]  __might_sleep+0x50/0xa0
[Fri May 31 11:40:28 2024]  kmem_cache_alloc+0x306/0x350
[Fri May 31 11:40:28 2024]  getname_kernel+0x2a/0x140
[Fri May 31 11:40:28 2024]  kern_path+0x1a/0x60
[Fri May 31 11:40:28 2024]  lookup_bdev+0x44/0xd0
[Fri May 31 11:40:28 2024]  pxd_export+0x110/0x550 [px]
[Fri May 31 11:40:28 2024]  ? __might_fault+0x8f/0xb0
[Fri May 31 11:40:28 2024]  ? _copy_from_iter+0x15b/0x530
[Fri May 31 11:40:28 2024]  ? lock_release+0x256/0x4b0
[Fri May 31 11:40:28 2024]  fuse_dev_write_iter+0x373/0x740 [px]
[Fri May 31 11:40:28 2024]  ? aa_file_perm+0x1e5/0x750
[Fri May 31 11:40:28 2024]  do_iter_readv_writev+0xe1/0x150
[Fri May 31 11:40:28 2024]  do_iter_write+0xa6/0x230
[Fri May 31 11:40:28 2024]  vfs_writev+0xdc/0x2e0
[Fri May 31 11:40:28 2024]  ? __fget_files+0xde/0x1d0
[Fri May 31 11:40:28 2024]  do_writev+0x7b/0x140
[Fri May 31 11:40:28 2024]  ? do_writev+0x7b/0x140
[Fri May 31 11:40:28 2024]  __x64_sys_writev+0x1c/0x30
[Fri May 31 11:40:28 2024]  x64_sys_call+0xa86/0x2570
[Fri May 31 11:40:28 2024]  do_syscall_64+0x56/0x90
[Fri May 31 11:40:28 2024]  ? rcu_is_watching+0x13/0x70
[Fri May 31 11:40:28 2024]  ? syscall_exit_to_user_mode+0x3c/0x50
[Fri May 31 11:40:28 2024]  ? do_syscall_64+0x63/0x90
[Fri May 31 11:40:28 2024]  ? irqentry_exit+0x77/0xb0
[Fri May 31 11:40:28 2024]  ? sysvec_call_function_single+0x52/0xd0
[Fri May 31 11:40:28 2024]  entry_SYSCALL_64_after_hwframe+0x73/0xdd
[Fri May 31 11:40:28 2024] RIP: 0033:0x707f263226dd
[Fri May 31 11:40:28 2024] Code: 28 89 54 24 1c 48 89 74 24 10 89 7c 24 08 e8 1a ff f7 ff 8b 54 24 1c 48 8b 74 24 10 41 89 c0 8b 7c 24 08 b8 14 00 00 00 0f 05 <48> 3d 00 f0 ff ff 77 2f 44 89 c7 48 89 44 24 08 e8 4e ff f7 ff 48
[Fri May 31 11:40:28 2024] RSP: 002b:0000707f167faa20 EFLAGS: 00000293 ORIG_RAX: 0000000000000014
[Fri May 31 11:40:28 2024] RAX: ffffffffffffffda RBX: fffffffffffffe40 RCX: 0000707f263226dd
[Fri May 31 11:40:28 2024] RDX: 0000000000000002 RSI: 0000707f167faac0 RDI: 00000000000000fe
[Fri May 31 11:40:28 2024] RBP: 0000000000000000 R08: 0000000000000000 R09: 0000707f167fa930
[Fri May 31 11:40:28 2024] R10: 00005c7a3199f54e R11: 0000000000000293 R12: 00000000000000fe
[Fri May 31 11:40:28 2024] R13: 0000707f167faac0 R14: 0000000000000002 R15: 0000707f167faf80
[Fri May 31 11:40:28 2024]  </TASK>
[Fri May 31 11:40:29 2024] pxd_finish_remove: dev 699878371121050090

=====================================================================================

```

## pxd export path - device export ##
```
[Fri May 31 11:40:29 2024] BUG: sleeping function called from invalid context at include/linux/sched/mm.h:306
[Fri May 31 11:40:29 2024] in_atomic(): 1, irqs_disabled(): 0, non_block: 0, pid: 32284, name: px-storage
[Fri May 31 11:40:29 2024] preempt_count: 1, expected: 0
[Fri May 31 11:40:29 2024] RCU nest depth: 0, expected: 0
[Fri May 31 11:40:29 2024] INFO: lockdep is turned off.
[Fri May 31 11:40:30 2024] Preemption disabled at:
[Fri May 31 11:40:30 2024] [<ffffffffc0b665e6>] pxd_export+0xe6/0x550 [px]
[Fri May 31 11:40:30 2024] CPU: 1 PID: 32284 Comm: px-storage Tainted: G        W  OE      6.5.13.lnsbuild #5
[Fri May 31 11:40:30 2024] pxd_finish_remove: dev 1001599213553313369
[Fri May 31 11:40:30 2024] Hardware name: VMware, Inc. VMware Virtual Platform/440BX Desktop Reference Platform, BIOS 6.00 11/12/2020
[Fri May 31 11:40:30 2024] Call Trace:
[Fri May 31 11:40:30 2024] For pxd device 1001599213553313369 IO suspended
[Fri May 31 11:40:30 2024]  <TASK>
[Fri May 31 11:40:30 2024]  dump_stack_lvl+0xb9/0xd0
[Fri May 31 11:40:30 2024]  dump_stack+0x10/0x20
[Fri May 31 11:40:30 2024]  __might_resched+0x1d5/0x320
[Fri May 31 11:40:30 2024]  ? getname_kernel+0x2a/0x140
[Fri May 31 11:40:30 2024]  __might_sleep+0x50/0xa0
[Fri May 31 11:40:30 2024]  kmem_cache_alloc+0x306/0x350
[Fri May 31 11:40:30 2024]  getname_kernel+0x2a/0x140
[Fri May 31 11:40:30 2024]  kern_path+0x1a/0x60
[Fri May 31 11:40:30 2024]  lookup_bdev+0x44/0xd0
[Fri May 31 11:40:30 2024]  pxd_export+0x110/0x550 [px]
[Fri May 31 11:40:30 2024]  ? __might_fault+0x8f/0xb0
[Fri May 31 11:40:30 2024]  ? _copy_from_iter+0x15b/0x530
[Fri May 31 11:40:30 2024]  ? lock_release+0x256/0x4b0
[Fri May 31 11:40:30 2024]  fuse_dev_write_iter+0x373/0x740 [px]
[Fri May 31 11:40:30 2024]  ? aa_file_perm+0x1e5/0x750
[Fri May 31 11:40:30 2024]  do_iter_readv_writev+0xe1/0x150
[Fri May 31 11:40:30 2024]  do_iter_write+0xa6/0x230
[Fri May 31 11:40:30 2024]  vfs_writev+0xdc/0x2e0
[Fri May 31 11:40:30 2024]  ? __fget_files+0xde/0x1d0
[Fri May 31 11:40:30 2024]  do_writev+0x7b/0x140
[Fri May 31 11:40:30 2024]  ? do_writev+0x7b/0x140
[Fri May 31 11:40:30 2024]  __x64_sys_writev+0x1c/0x30
[Fri May 31 11:40:30 2024]  x64_sys_call+0xa86/0x2570
[Fri May 31 11:40:30 2024]  do_syscall_64+0x56/0x90
[Fri May 31 11:40:30 2024]  ? syscall_exit_to_user_mode+0x3c/0x50
[Fri May 31 11:40:30 2024]  ? do_syscall_64+0x63/0x90
[Fri May 31 11:40:30 2024]  ? do_syscall_64+0x63/0x90
[Fri May 31 11:40:30 2024]  entry_SYSCALL_64_after_hwframe+0x73/0xdd
[Fri May 31 11:40:30 2024] RIP: 0033:0x707f263226dd
[Fri May 31 11:40:30 2024] Code: 28 89 54 24 1c 48 89 74 24 10 89 7c 24 08 e8 1a ff f7 ff 8b 54 24 1c 48 8b 74 24 10 41 89 c0 8b 7c 24 08 b8 14 00 00 00 0f 05 <48> 3d 00 f0 ff ff 77 2f 44 89 c7 48 89 44 24 08 e8 4e ff f7 ff 48
[Fri May 31 11:40:30 2024] RSP: 002b:0000707f177fca20 EFLAGS: 00000293 ORIG_RAX: 0000000000000014
[Fri May 31 11:40:30 2024] RAX: ffffffffffffffda RBX: fffffffffffffe40 RCX: 0000707f263226dd
[Fri May 31 11:40:30 2024] RDX: 0000000000000002 RSI: 0000707f177fcac0 RDI: 00000000000000fe
[Fri May 31 11:40:30 2024] RBP: 0000000000000000 R08: 0000000000000000 R09: 0000707f177fc930
[Fri May 31 11:40:30 2024] R10: 00005c7a3199f54e R11: 0000000000000293 R12: 00000000000000fe
[Fri May 31 11:40:30 2024] R13: 0000707f177fcac0 R14: 0000000000000002 R15: 0000707f177fcf80
[Fri May 31 11:40:30 2024]  </TASK>
[Fri May 31 11:40:30 2024] For pxd device 1001599213553313369 IO resumed
[Fri May 31 11:40:30 2024] pxd fastpath device 1001599213553313369 reset complete
```


## pxd device export ##
```
[Fri May 31 11:59:48 2024] dev699878371121050090 completed setting up 1 paths
[Fri May 31 11:59:48 2024] BUG: sleeping function called from invalid context at include/linux/sched/mm.h:306
[Fri May 31 11:59:48 2024] in_atomic(): 1, irqs_disabled(): 0, non_block: 0, pid: 45805, name: px-storage
[Fri May 31 11:59:48 2024] preempt_count: 1, expected: 0
[Fri May 31 11:59:48 2024] RCU nest depth: 0, expected: 0
[Fri May 31 11:59:48 2024] INFO: lockdep is turned off.
[Fri May 31 11:59:48 2024] Preemption disabled at:
[Fri May 31 11:59:48 2024] [<ffffffffc0b665c4>] pxd_export+0xc4/0x530 [px]
[Fri May 31 11:59:48 2024] CPU: 3 PID: 45805 Comm: px-storage Tainted: G        W  OE      6.5.13.lnsbuild #5
[Fri May 31 11:59:48 2024] Hardware name: VMware, Inc. VMware Virtual Platform/440BX Desktop Reference Platform, BIOS 6.00 11/12/2020
[Fri May 31 11:59:48 2024] Call Trace:
[Fri May 31 11:59:48 2024]  <TASK>
[Fri May 31 11:59:48 2024]  dump_stack_lvl+0xb9/0xd0
[Fri May 31 11:59:48 2024]  dump_stack+0x10/0x20
[Fri May 31 11:59:48 2024]  __might_resched+0x1d5/0x320
[Fri May 31 11:59:48 2024]  __might_sleep+0x50/0xa0
[Fri May 31 11:59:48 2024]  ? blk_mq_alloc_tag_set+0x100/0x500
[Fri May 31 11:59:48 2024]  __kmem_cache_alloc_node+0x2ae/0x2f0
[Fri May 31 11:59:48 2024]  ? blk_mq_alloc_tag_set+0x100/0x500
[Fri May 31 11:59:48 2024]  ? pxd_export+0xc4/0x530 [px]
[Fri May 31 11:59:48 2024]  ? blk_mq_alloc_tag_set+0x100/0x500
[Fri May 31 11:59:48 2024]  __kmalloc_node+0x56/0x190
[Fri May 31 11:59:48 2024]  ? lock_release+0x256/0x4b0
[Fri May 31 11:59:48 2024]  blk_mq_alloc_tag_set+0x100/0x500
[Fri May 31 11:59:48 2024]  ? rcu_is_watching+0x13/0x70
[Fri May 31 11:59:48 2024]  pxd_export+0x166/0x530 [px]
[Fri May 31 11:59:48 2024]  fuse_dev_write_iter+0x373/0x740 [px]
[Fri May 31 11:59:48 2024]  ? aa_file_perm+0x1e5/0x750
[Fri May 31 11:59:48 2024]  do_iter_readv_writev+0xe1/0x150
[Fri May 31 11:59:48 2024]  do_iter_write+0xa6/0x230
[Fri May 31 11:59:48 2024]  vfs_writev+0xdc/0x2e0
[Fri May 31 11:59:48 2024]  ? vfs_fstatat+0x64/0x80
[Fri May 31 11:59:48 2024]  ? __fget_files+0xde/0x1d0
[Fri May 31 11:59:48 2024]  do_writev+0x7b/0x140
[Fri May 31 11:59:48 2024]  ? do_writev+0x7b/0x140
[Fri May 31 11:59:48 2024]  __x64_sys_writev+0x1c/0x30
[Fri May 31 11:59:48 2024]  x64_sys_call+0xa86/0x2570
[Fri May 31 11:59:48 2024]  do_syscall_64+0x56/0x90
[Fri May 31 11:59:48 2024]  ? do_syscall_64+0x63/0x90
[Fri May 31 11:59:48 2024]  ? sysvec_call_function_single+0x52/0xd0
[Fri May 31 11:59:48 2024]  entry_SYSCALL_64_after_hwframe+0x73/0xdd
[Fri May 31 11:59:48 2024] RIP: 0033:0x76ffec9226dd
[Fri May 31 11:59:48 2024] Code: 28 89 54 24 1c 48 89 74 24 10 89 7c 24 08 e8 1a ff f7 ff 8b 54 24 1c 48 8b 74 24 10 41 89 c0 8b 7c 24 08 b8 14 00 00 00 0f 05 <48> 3d 00 f0 ff ff 77 2f 44 89 c7 48 89 44 24 08 e8 4e ff f7 ff 48
[Fri May 31 11:59:48 2024] RSP: 002b:000076ffe1bf8a20 EFLAGS: 00000293 ORIG_RAX: 0000000000000014
[Fri May 31 11:59:48 2024] RAX: ffffffffffffffda RBX: fffffffffffffe40 RCX: 000076ffec9226dd
[Fri May 31 11:59:48 2024] RDX: 0000000000000002 RSI: 000076ffe1bf8ac0 RDI: 00000000000000fe
[Fri May 31 11:59:48 2024] RBP: 0000000000000000 R08: 0000000000000000 R09: 000076ffe1bf8930
[Fri May 31 11:59:48 2024] R10: 00005cbe3ff9f54e R11: 0000000000000293 R12: 00000000000000fe
[Fri May 31 11:59:48 2024] R13: 000076ffe1bf8ac0 R14: 0000000000000002 R15: 000076ffe1bf8f80
[Fri May 31 11:59:48 2024]  </TASK>
[Fri May 31 11:59:49 2024] pxd_finish_remove: dev 699878371121050090
[Fri May 31 11:59:49 2024] For pxd device 699878371121050090 IO suspended
[Fri May 31 11:59:49 2024] For pxd device 699878371121050090 IO resumed
[Fri May 31 11:59:49 2024] pxd fastpath device 699878371121050090 reset complete
```

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

Below sequence which used to show kernel traceback (BUG: schedule while atomic) is no longer seen
```
1/ create 100 px vols
2/ attach 100 vols
for i in {1..100}; do pxctl host attach tvol$i; done 
3/ run attach/detach seq in parallel
 for i in {1..100}; do pxctl host detach tvol$i; done & for i in {1..100}; do pxctl host attach tvol$i; done &
```
