### PR TITLE
PWX-36736: kernel v6.8/9 support (#315)

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -294,7 +294,7 @@ __acquires(fc->lock)
 	remove_wait_queue(&fc->waitq, &wait);
 }
 
-ssize_t fuse_copy_req_read(struct fuse_req *req, struct iov_iter *iter)
+static ssize_t fuse_copy_req_read(struct fuse_req *req, struct iov_iter *iter)
 {
 	size_t copied, len;
 
@@ -597,7 +597,8 @@ struct fuse_req *request_find(struct fuse_conn *fc, u64 unique)
 	return req;
 }
 
-struct fuse_req* request_find_in_ctx(unsigned ctx, u64 unique)
+/*
+static struct fuse_req* request_find_in_ctx(unsigned ctx, u64 unique)
 {
 	struct pxd_context *pctx = find_context(ctx);
 
@@ -605,6 +606,7 @@ struct fuse_req* request_find_in_ctx(unsigned ctx, u64 unique)
 
 	return request_find(&pctx->fc, unique);
 }
+*/
 
 #define IOV_BUF_SIZE 64
 
@@ -1252,7 +1254,7 @@ void fuse_abort_conn(struct fuse_conn *fc)
 	spin_unlock(&fc->lock);
 }
 
-int fuse_dev_release(struct inode *inode, struct file *file)
+static int fuse_dev_release(struct inode *inode, struct file *file)
 {
 	struct fuse_conn *fc = fuse_get_conn(file);
 	if (fc) {

--- a/kiolib.c
+++ b/kiolib.c
@@ -6,6 +6,7 @@
 
 #include "pxd_compat.h"
 #include "pxd_core.h"
+#include "kiolib.h"
 
 static int _pxd_flush(struct pxd_device *pxd_dev, struct file *file) {
         int ret = 0;

--- a/pxd.c
+++ b/pxd.c
@@ -1255,7 +1255,6 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0)
 	  struct queue_limits lim = {
-		  .max_hw_sectors = SEGMENT_SIZE / SECTOR_SIZE,
 		  .logical_block_size = PXD_LBS,
 		  .physical_block_size = PXD_LBS,
 		  .max_segment_size = SEGMENT_SIZE,

--- a/pxd.c
+++ b/pxd.c
@@ -12,7 +12,7 @@
 #include <linux/bio.h>
 #include <linux/pid_namespace.h>
 
-#if defined(RHEL_RELEASE_CODE) && defined(RHEL_RELEASE_VERSION)
+#if defined(RHEL_RELEASE_CODE) && defined(RHEL_RELEASE_VERSION) && defined(__EL8__)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9,4)
 #define __RHEL_GT_94__
 #endif
@@ -991,6 +991,7 @@ int pxd_initiate_fallback(struct pxd_device *pxd_dev)
 	return rc;
 }
 
+#ifdef __PXD_BIO_MAKEREQ__
 // similar function to make_request_slowpath only optimized to ensure its a reroute
 // from fastpath on IO fail.
 void pxd_reroute_slowpath(struct request_queue *q, struct bio *bio)
@@ -1021,6 +1022,7 @@ void pxd_reroute_slowpath(struct request_queue *q, struct bio *bio)
 
 	fuse_request_send_nowait(&pxd_dev->ctx->fc, req);
 }
+#endif
 
 #ifdef __PXD_BIO_BLKMQ__
 #if !defined(__PX_BLKMQ__)
@@ -1250,7 +1252,27 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 	  }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0)
+	  struct queue_limits lim = {
+		  .max_hw_sectors = SEGMENT_SIZE / SECTOR_SIZE,
+		  .logical_block_size = PXD_LBS,
+		  .physical_block_size = PXD_LBS,
+		  .max_segment_size = SEGMENT_SIZE,
+		  .max_segments = SEGMENT_SIZE / PXD_LBS,
+		  .max_hw_sectors = SEGMENT_SIZE / SECTOR_SIZE,
+		  .discard_alignment = PXD_MAX_DISCARD_GRANULARITY,
+		  .discard_granularity = PXD_MAX_DISCARD_GRANULARITY,
+		  .io_min = PXD_LBS,
+		  .io_opt = PXD_LBS,
+		  .max_hw_discard_sectors = pxd_dev->discard_size / SECTOR_SIZE,
+		  .max_discard_sectors = pxd_dev->discard_size / SECTOR_SIZE
+	  };
+	  disk = blk_mq_alloc_disk(&pxd_dev->tag_set, &lim, pxd_dev);
+#else
 	  disk = blk_mq_alloc_disk(&pxd_dev->tag_set, pxd_dev);
+#endif
+
 	  if (IS_ERR(disk)) {
 		blk_mq_free_tag_set(&pxd_dev->tag_set);
 		return PTR_ERR(disk);
@@ -1910,7 +1932,7 @@ static ssize_t pxd_timeout_show(struct device *dev,
 	return sprintf(buf, "%u\n", pxd_timeout_secs);
 }
 
-ssize_t pxd_timeout_store(struct device *dev, struct device_attribute *attr,
+static ssize_t pxd_timeout_store(struct device *dev, struct device_attribute *attr,
 			   const char *buf, size_t count)
 {
 	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
@@ -2447,7 +2469,7 @@ static void pxd_abort_context(struct work_struct *work)
 	pxdctx_set_connected(ctx, false);
 }
 
-int pxd_context_init(struct pxd_context *ctx, int i)
+static int pxd_context_init(struct pxd_context *ctx, int i)
 {
 	int err;
 
@@ -2487,7 +2509,7 @@ static void pxd_context_destroy(struct pxd_context *ctx)
 	}
 }
 
-int pxd_init(void)
+static int pxd_init(void)
 {
 	int err, i, j;
 
@@ -2571,7 +2593,7 @@ out:
 	return err;
 }
 
-void pxd_exit(void)
+static void pxd_exit(void)
 {
 	int i;
 


### PR DESCRIPTION
* PWX-36736: Fix compile issues when building on kernels 6.8 & 6.9



* Only check RHEL_RELEASE on Rhel kernels. Fedora also has these defines.



* PWX-36736:  PR review changes.  Specify more to the limits structure for 6.9 compiles.



---------

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This is a cherry pick:  https://github.com/portworx/px-fuse/pull/315

**Which issue(s) this PR fixes** (optional)
Closes #
 PWX-36736
**Special notes for your reviewer**:

