### PR TITLE
Update PXD_MAX_DEVICES to 1024

### DIFF
--- a/pxd.h
+++ b/pxd.h
@@ -72,7 +72,7 @@ struct pxd_ioc_free_buffers {
 	void **buffers;	/* list of buffers returned to user space filled by ioctl */
 };
 
-#define PXD_MAX_DEVICES	512			/**< maximum number of devices supported */
+#define PXD_MAX_DEVICES	1024			/**< maximum number of devices supported */
 #define PXD_MAX_IO		(1024*1024)	/**< maximum io size in bytes */
 #define PXD_MAX_QDEPTH  256			/**< maximum device queue depth */
 #define PXD_MIN_DISCARD_GRANULARITY		PXD_LBS


### PR DESCRIPTION
**What this PR does / why we need it**:
Update `PXD_MAX_DEVICES` from 512 to 1024.
This is done in order to support 1024 volume attach support.

**Which issue(s) this PR fixes** (optional)
https://purestorage.atlassian.net/browse/PWX-36999
