### PR TITLE
PWX-41114: handle iov_iter direction changes in RHEL9.5

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -209,11 +209,7 @@ static long pxd_ioctl_init(struct file *file, void __user *argp)
 	struct pxd_context *ctx = container_of(file->f_op, struct pxd_context, fops);
 	struct iov_iter iter;
 	struct iovec iov = {argp, sizeof(struct pxd_ioctl_init_args)};
-	int direction = WRITE;
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)
-	direction = READ;
-#endif
+	int direction = READ;
 
 	iov_iter_init(&iter, direction, &iov, 1, sizeof(struct pxd_ioctl_init_args));
 
@@ -1825,10 +1821,6 @@ ssize_t pxd_read_init(struct fuse_conn *fc, struct iov_iter *iter)
 		}
 		copied += sizeof(id);
 	}
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)
-	iter->data_source = WRITE;   // Reset to 'WRITE'
-#endif
 
 	printk(KERN_INFO "%s: pxd-control-%d init OK %d devs version %d\n", __func__,
 		ctx->id, pxd_init.num_devices, pxd_init.version);


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

~~iov_iter’s direction is reversed in RHEL 9.5 (possibly because of the backported changes). For eg)~~
~~kernel-5.14.0-503.14.1.el9_5~~
~~file include/linux/uio.h~~

~~Add a new define to handle only for RHEL 9.5~~

Rootcause is a bug in the original existing code with regards to direction usage. A sanity check on the direction in recent kernels exposed the bug. It is fixed now.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-41114

**Special notes for your reviewer**:

