### PR TITLE
PWX-41245: Fix compilation issue for SLE Micro 6.1

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -102,13 +102,24 @@ endif
 
 # Check for Suse
 ifeq ($(shell test -f "/host-os-release"; echo $$?),0)   # inside PX container
-ifeq ($(shell cat "/host-os-release" | grep  ID_LIKE | grep -q suse; echo $$?),0)
+ifeq ($(shell cat "/host-os-release" | grep ID_LIKE | grep -q suse; echo $$?),0)
 PXDEFINES += -D__SUSE__
 endif
-else
+
+# Detect SUSE Linux Micro 6.1 inside PX container --
+ifeq ($(shell cat "/host-os-release" | grep -q "SUSE Linux Micro 6.1"; echo $$?),0)
+PXDEFINES += -D__SLE_MICRO_EQ_6_1__
+endif
+
+else  # Not inside PX container
 ifeq ($(shell test -f "/etc/os-release"; echo $$?),0)    # check OS
-ifeq ($(shell cat "/etc/os-release" | grep  ID_LIKE | grep -q suse; echo $$?),0)
+ifeq ($(shell cat "/etc/os-release" | grep ID_LIKE | grep -q suse; echo $$?),0)
 PXDEFINES += -D__SUSE__
+endif
+
+# Detect SUSE Linux Micro 6.1 on host
+ifeq ($(shell cat "/etc/os-release" | grep -q "SUSE Linux Micro 6.1"; echo $$?),0)
+PXDEFINES += -D__SLE_MICRO_EQ_6_1__
 endif
 endif
 endif

--- a/pxd.c
+++ b/pxd.c
@@ -99,7 +99,7 @@ struct pxd_context* find_context(unsigned ctx)
 }
 
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(__RHEL_GT_94__)  || defined(__SUSE_GTE_SP6__)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(__RHEL_GT_94__)  || defined(__SUSE_GTE_SP6__) || defined(__SLE_MICRO_EQ_6_1__)
 static int pxd_open(struct gendisk *bdev, blk_mode_t mode)
 #else
 static int pxd_open(struct block_device *bdev, fmode_t mode)
@@ -107,7 +107,7 @@ static int pxd_open(struct block_device *bdev, fmode_t mode)
 {
 	struct pxd_device *pxd_dev;
 	int err = 0;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(__RHEL_GT_94__)  || defined(__SUSE_GTE_SP6__)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(__RHEL_GT_94__)  || defined(__SUSE_GTE_SP6__) || defined(__SLE_MICRO_EQ_6_1__)
 	pxd_dev = bdev->private_data;
 #else
 	pxd_dev = bdev->bd_disk->private_data;
@@ -134,7 +134,7 @@ static int pxd_open(struct block_device *bdev, fmode_t mode)
 	return err;
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(__RHEL_GT_94__) || defined(__SUSE_GTE_SP6__)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(__RHEL_GT_94__) || defined(__SUSE_GTE_SP6__) || defined(__SLE_MICRO_EQ_6_1__)
 static void pxd_release(struct gendisk *disk)
 #else
 static void pxd_release(struct gendisk *disk, fmode_t mode)
@@ -152,7 +152,7 @@ static void pxd_release(struct gendisk *disk, fmode_t mode)
 	BUG_ON(pxd_dev->magic != PXD_DEV_MAGIC);
 	pxd_dev->open_count--;
 	spin_unlock(&pxd_dev->lock);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(__RHEL_GT_94__) || defined(__SUSE_GTE_SP6__)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(__RHEL_GT_94__) || defined(__SUSE_GTE_SP6__) || defined(__SLE_MICRO_EQ_6_1__)
 	trace_pxd_release(pxd_dev->dev_id, pxd_dev->major, pxd_dev->minor);
 #else
 	trace_pxd_release(pxd_dev->dev_id, pxd_dev->major, pxd_dev->minor, mode);

--- a/pxd_trace.h
+++ b/pxd_trace.h
@@ -32,7 +32,7 @@ TRACE_EVENT(
 
 TRACE_EVENT(
 	pxd_release,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(__RHEL_GT_94__) || defined(__SUSE_GTE_SP6__)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(__RHEL_GT_94__) || defined(__SUSE_GTE_SP6__) || defined(__SLE_MICRO_EQ_6_1__)
 	TP_PROTO(uint64_t dev_id, int major, int minor),
 	TP_ARGS(dev_id, major, minor),
 	TP_STRUCT__entry(


### PR DESCRIPTION
What this PR does / why we need it:
This fixes compilation issues for SLE Micro 6.1 by adding `__SLE_MICRO_EQ_6_1__`

The following is the compilation error.
```
/root/sebas/px-fuse/pxd.c:398:35: error: initialization of ‘int (*)(struct gendisk *, blk_mode_t)’ {aka ‘int (*)(struct gendisk *, unsigned int)’} from incompatible pointer type ‘int (*)(struct block_device *, fmode_t)’ {aka ‘int (*)(struct block_device *, unsigned int)’} [-Wincompatible-pointer-types]
  398 |         .open                   = pxd_open,
      |                                   ^~~~~~~~
/root/sebas/px-fuse/pxd.c:398:35: note: (near initialization for ‘pxd_bd_ops.open’)
/root/sebas/px-fuse/pxd.c:399:35: error: initialization of ‘void (*)(struct gendisk *)’ from incompatible pointer type ‘void (*)(struct gendisk *, fmode_t)’ {aka ‘void (*)(struct gendisk *, unsigned int)’} [-Wincompatible-pointer-types]
  399 |         .release                = pxd_release,
      |                                   ^~~~~~~~~~~
/root/sebas/px-fuse/pxd.c:399:35: note: (near initialization for ‘pxd_bd_ops.release’)
make[2]: *** [/root/charu/linux-6.4.0-19/scripts/Makefile.build:252: /root/sebas/px-fuse/pxd.o] Error 1
make[1]: *** [../../../linux-6.4.0-19/Makefile:2066: /root/sebas/px-fuse] Error 2
```
Which issue(s) this PR fixes (optional)
Closes #

Special notes for your reviewer:
