### PR TITLE
PWX-39098: Add ioctl to detach a device on the local node

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1810,11 +1810,6 @@ out:
 	return err;
 }
 
-ssize_t pxd_ioc_detach_device(struct fuse_conn *fc, struct pxd_detach_device *detach_device)
-{
-        return pxd_remove_dev(fc, detach_device->dev_id, false /*force*/);
-}
-
 ssize_t pxd_read_init(struct fuse_conn *fc, struct iov_iter *iter)
 {
 	size_t copied = 0;

--- a/pxd.c
+++ b/pxd.c
@@ -88,6 +88,7 @@ module_param(pxd_num_fpthreads, uint, 0644);
 static void pxd_abort_context(struct work_struct *work);
 static int pxd_nodewipe_cleanup(struct pxd_context *ctx);
 static int pxd_bus_add_dev(struct pxd_device *pxd_dev);
+static ssize_t pxd_remove_dev(struct fuse_conn *fc, uint64_t dev_id, bool force);
 
 struct pxd_context* find_context(unsigned ctx)
 {
@@ -259,7 +260,7 @@ static long pxd_ioctl_detach_device(struct file *file, void __user *argp)
                 return -EFAULT;
         }
 
-        ret = pxd_ioc_detach_device(&ctx->fc, &detach_device_args);
+        ret = pxd_remove_dev(&ctx->fc, detach_device_args.dev_id, false /* force */);
         return ret;
 }
 

--- a/pxd.c
+++ b/pxd.c
@@ -240,6 +240,29 @@ static long pxd_ioctl_resize(struct file *file, void __user *argp)
 	return ret;
 }
 
+static long pxd_ioctl_detach_device(struct file *file, void __user *argp)
+{
+        struct pxd_context *ctx = NULL;
+        struct pxd_detach_device detach_device_args;
+        long ret = 0;
+
+        if (copy_from_user(&detach_device_args, argp, sizeof(detach_device_args))) {
+                return -EFAULT;
+        }
+        if (detach_device_args.context_id >= pxd_num_contexts_exported) {
+                printk("%s : invalid context: %d\n", __func__, detach_device_args.context_id);
+                return -EFAULT;
+        }
+
+        ctx =  &pxd_contexts[detach_device_args.context_id];
+        if (!ctx || ctx->id >= pxd_num_contexts_exported) {
+                return -EFAULT;
+        }
+
+        ret = pxd_ioc_detach_device(&ctx->fc, &detach_device_args);
+        return ret;
+}
+
 static long pxd_ioctl_fp_cleanup(struct file *file, void __user *argp)
 {
 	struct pxd_context *ctx = NULL;
@@ -388,6 +411,8 @@ static long pxd_control_ioctl(struct file *file, unsigned int cmd, unsigned long
 		return pxd_ioctl_fp_cleanup(file, (void __user *)arg);
 	case PXD_IOC_IO_FLUSHER:
 		return pxd_ioflusher_state((void __user *)arg);
+	case PXD_IOC_DETACH_DEVICE:
+		return pxd_ioctl_detach_device(file, (void __user *)arg);
 	default:
 		return -ENOTTY;
 	}
@@ -1665,7 +1690,7 @@ static void pxd_finish_remove(struct work_struct *work)
 	module_put(THIS_MODULE);
 }
 
-ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
+static ssize_t pxd_remove_dev(struct fuse_conn *fc, uint64_t dev_id, bool force)
 {
 	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
 	int err;
@@ -1675,7 +1700,7 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 
 	spin_lock(&ctx->lock);
 	list_for_each_entry(pxd_dev, &ctx->list, node) {
-		if (pxd_dev->dev_id == remove->dev_id) {
+		if (pxd_dev->dev_id == dev_id) {
 			spin_lock(&pxd_dev->lock);
 			break;
 		}
@@ -1689,7 +1714,7 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 		goto out_lock;
 	}
 
-	if (pxd_dev->open_count && !remove->force) {
+	if (pxd_dev->open_count && !force) {
 		err = -EBUSY;
 		goto out_lock;
 	}
@@ -1709,7 +1734,7 @@ ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
 	finish_wait(&pxd_dev->remove_wait, &wait);
 	if (remtimeo == 0) {
 		pr_warn("remove device %llu scheduled but timedout waiting to complete",
-				remove->dev_id);
+				dev_id);
 	}
 	put_device(&pxd_dev->dev);
 	return 0;
@@ -1717,8 +1742,13 @@ out_lock:
 	spin_unlock(&pxd_dev->lock);
 out:
 	spin_unlock(&ctx->lock);
-	pr_err("remove device %llu failed %d\n", remove->dev_id, err);
+	pr_err("remove device %llu failed %d\n", dev_id, err);
 	return err;
+}
+
+ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove)
+{
+        return pxd_remove_dev(fc, remove->dev_id, remove->force);
 }
 
 ssize_t pxd_update_size(struct fuse_conn *fc, struct pxd_update_size *update_size)
@@ -1777,6 +1807,11 @@ ssize_t pxd_ioc_update_size(struct fuse_conn *fc, struct pxd_update_size *update
 	return 0;
 out:
 	return err;
+}
+
+ssize_t pxd_ioc_detach_device(struct fuse_conn *fc, struct pxd_detach_device *detach_device)
+{
+        return pxd_remove_dev(fc, detach_device->dev_id, false /*force*/);
 }
 
 ssize_t pxd_read_init(struct fuse_conn *fc, struct iov_iter *iter)

--- a/pxd.h
+++ b/pxd.h
@@ -43,6 +43,7 @@
 #define PXD_IOC_UNREGISTER_FILE	_IO(PXD_IOCTL_MAGIC, 8)		/* 0x505808 */
 #define PXD_IOC_FPCLEANUP		_IO(PXD_IOCTL_MAGIC, 9)		/* 0x505809 */
 #define PXD_IOC_IO_FLUSHER		_IO(PXD_IOCTL_MAGIC, 10)	/* 0x50580a */
+#define PXD_IOC_DETACH_DEVICE		_IO(PXD_IOCTL_MAGIC, 11)	/* 0x50580b */
 
 #define PXD_MAX_DEVICES	512			/**< maximum number of devices supported */
 #define PXD_MAX_IO		(1024*1024)	/**< maximum io size in bytes */
@@ -183,6 +184,14 @@ struct pxd_read_data_out {
 struct pxd_update_size {
 	uint64_t dev_id;
 	size_t size;
+	int context_id;
+};
+
+/**
+ * PXD_DETACH_DEVICE ioctl from user space
+ */
+struct pxd_detach_device {
+	uint64_t dev_id;
 	int context_id;
 };
 


### PR DESCRIPTION
PWX-39098.
For Encapsulated devices, control plane needs to issue an ioctl through which we can detach devices attached locally after completing CP clean up.
introduce a ioctl to do the device clean up.

