### PR TITLE
Pwx 42778 fix

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -675,13 +675,8 @@ static int __fuse_notify_read_data(struct fuse_conn *conn,
 				BVEC(bvec).bv_offset + copied,
 				len - copied, &data_iter);
 			if (copy_this != len - copied) {
-				if (!iter->count) {
-					// running out of space in user iovecs when the last copy is a partial copy
-					// should be treated as an error
-					printk(KERN_ERR "%s: copy failed no space in user iovecs : dev id : %lld request id : %lld\n",
-						__func__, req->pxd_dev->dev_id, read_data_p->unique);
-					return -EFAULT;
-				}
+				if (!iter->count)
+					return 0;
 
 				/* out of space in destination, copy more iovec */
 				ret = copy_in_read_data_iovec(iter, read_data_p,
@@ -747,20 +742,15 @@ static int __fuse_notify_read_data(struct fuse_conn *conn,
 				BVEC(bvec).bv_offset + copied,
 				len - copied, &data_iter);
 			if (copy_this != len - copied) {
-				if (!iter->count) {
-					// running out of space in user iovecs when the last copy is a partial copy
-					// should be treated as an error
-					printk(KERN_ERR "%s: copy failed no space in user iovecs : dev id : %lld request id : %lld\n",
-						__func__, req->pxd_dev->dev_id, read_data_p->unique);
-					return -EFAULT;
-				}
+				if (!iter->count)
+					return 0;
 
 				/* out of space in destination, copy more iovec */
 				ret = copy_in_read_data_iovec(iter, read_data_p,
 					iov, &data_iter);
 				if (ret)
 					return ret;
-				len -= (copied + copy_this);
+				len -= copied;
 				copied = copy_page_to_iter(BVEC(bvec).bv_page,
 					BVEC(bvec).bv_offset + copied + copy_this,
 					len, &data_iter);

--- a/dev.c
+++ b/dev.c
@@ -750,7 +750,7 @@ static int __fuse_notify_read_data(struct fuse_conn *conn,
 					iov, &data_iter);
 				if (ret)
 					return ret;
-				len -= copied;
+				len -= (copied + copy_this);
 				copied = copy_page_to_iter(BVEC(bvec).bv_page,
 					BVEC(bvec).bv_offset + copied + copy_this,
 					len, &data_iter);


### PR DESCRIPTION
Revert changes for returning -EFAULT on user iovec count reaching 0 but there is data to be copied from bvecs since it is a valid scenario for aggr volumes.
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

