### PR TITLE
PWX-42349: Fix fuse compilation for kernel 6.11.0 and 6.11.9

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1344,6 +1344,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 	disk->private_data = pxd_dev;
 	set_capacity(disk, pxd_dev->size / SECTOR_SIZE);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,9,0)
 	blk_queue_max_hw_sectors(q, SEGMENT_SIZE / SECTOR_SIZE);
 	blk_queue_max_segment_size(q, SEGMENT_SIZE);
 	blk_queue_max_segments(q, (SEGMENT_SIZE / PXD_LBS));
@@ -1351,6 +1352,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 	blk_queue_io_opt(q, PXD_LBS);
 	blk_queue_logical_block_size(q, PXD_LBS);
 	blk_queue_physical_block_size(q, PXD_LBS);
+#endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,19,0)
 #if defined(__EL8__) || defined(__SUSE_EQ_SP5__)

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -22,7 +22,10 @@
 #define HAVE_BVEC_ITER
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0) || defined(REQ_PREFLUSH)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,11,0)
+#define BLK_QUEUE_FLUSH(q) \
+	q->limits.features |= BLK_FEAT_WRITE_CACHE | BLK_FEAT_FUA
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0) || defined(REQ_PREFLUSH)
 #define BLK_QUEUE_FLUSH(q) \
 	blk_queue_write_cache(q, true, true)
 #else
@@ -141,7 +144,11 @@ static inline unsigned int get_op_flags(struct bio *bio)
 // Pulled from v5.19.17/source/block/genhd.c
 static inline char *bdevname(struct block_device *bdev, char *buf) {
         struct gendisk *hd = bdev->bd_disk;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,10,0)
 	int partno = bdev->bd_partno;
+#else
+	int partno = BD_PARTNO; 
+#endif
 
 	if (!partno)
 		snprintf(buf, BDEVNAME_SIZE, "%s", hd->disk_name);


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
px-fuse does not compile for kernel 6.11

**Which issue(s) this PR fixes** (optional)
Closes # PWX-42349 , PTX-29484

**Special notes for your reviewer**:
Ubuntu 24.04 LTS
```
root@ip-10-38-36-210:~/px-fuse# KERNELPATH=/usr/src/linux-headers-$(uname -r) make 
Kernel version 6.11 supports fastpath.
Kernel version 6.11 supports blkmq driver model.
make  -C /usr/src/linux-headers-6.11.0-17-generic  M=/root/px-fuse modules
make[1]: Entering directory '/usr/src/linux-headers-6.11.0-17-generic'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: x86_64-linux-gnu-gcc-13 (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
  You are using:           gcc-13 (Ubuntu 13.2.0-23ubuntu4) 13.2.0
Kernel version 6.11 supports fastpath.
Kernel version 6.11 supports blkmq driver model.
Kernel version 6.11 supports fastpath.
Kernel version 6.11 supports blkmq driver model.
make[1]: Leaving directory '/usr/src/linux-headers-6.11.0-17-generic'
```
Fedora Linux 39
```
root@ip-10-38-15-239:~/px-fuse# KERNELPATH=/usr/src/kernels/$(uname -r) make
Kernel version 6.11 supports fastpath.
Kernel version 6.11 supports blkmq driver model.
make  -C /usr/src/kernels/6.11.9-100.fc39.x86_64  M=/root/px-fuse modules
make[1]: Entering directory '/usr/src/kernels/6.11.9-100.fc39.x86_64'
Kernel version 6.11 supports fastpath.
Kernel version 6.11 supports blkmq driver model.
Kernel version 6.11 supports fastpath.
Kernel version 6.11 supports blkmq driver model.
make[1]: Leaving directory '/usr/src/kernels/6.11.9-100.fc39.x86_64'
```
Px came up fine on kernel 6.11
```
root@ip-10-38-36-210:~/px-fuse# pxctl status 
Status: PX is operational
Telemetry: Disabled or Unhealthy
Metering: Disabled or Unhealthy
License: Trial (expires in 31 days)
Node ID: 7b75be76-a2e1-431a-893f-f47d6c15cc5a
	IP: 10.38.36.210 
 	Local Storage Pool: 2 pools
	POOL	IO_PRIORITY	RAID_LEVEL	USABLE	USED	STATUS	ZONE	REGION
	0	HIGH		raid0		64 GiB	4.0 GiB	Online	default	default
	1	HIGH		raid0		256 GiB	12 GiB	Online	default	default
	Local Storage Devices: 3 devices
	Device	Path		Media Type		Size		Last-Scan
	0:1	/dev/sdb	STORAGE_MEDIUM_SSD	64 GiB		26 Mar 25 17:49 UTC
	1:1	/dev/sdc	STORAGE_MEDIUM_SSD	128 GiB		26 Mar 25 17:49 UTC
	1:2	/dev/sdd	STORAGE_MEDIUM_SSD	128 GiB		26 Mar 25 17:49 UTC
	total			-			320 GiB
	Cache Devices:
	 * No cache devices
Cluster Summary
	Cluster ID: vivek260325-01
	Cluster UUID: 0e00c6f8-65e4-4e0b-819b-43c953f8f03e
	Scheduler: none
	Total Nodes: 1 node(s) with storage (1 online)
	IP		ID					SchedulerNodeName	Auth		StorageNode	Used	Capacity	Status	StorageStatus	Version		Kernel			OS
	10.38.36.210	7b75be76-a2e1-431a-893f-f47d6c15cc5a	N/A			Disabled	Yes		16 GiB	320 GiB		Online	Up (This node)	3.2.3.0-a6d48c7	6.11.0-17-generic	Ubuntu 24.04 LTS
Global Storage Pool
	Total Used    	:  16 GiB
	Total Capacity	:  320 GiB
Collected at: 2025-03-26 17:52:59 UTC
```
Old kernel 5.15.0
```
root@ip-10-13-190-254:~# pxctl status 
Status: PX is operational
Telemetry: Disabled or Unhealthy
Metering: Disabled or Unhealthy
License: Trial (expires in 25 days)
Node ID: 4ff60cf9-3e9c-4e19-a764-94d93a2b5a2f
	IP: 10.13.190.254 
 	Local Storage Pool: 2 pools
	POOL	IO_PRIORITY	RAID_LEVEL	USABLE	USED	STATUS	ZONE	REGION
	0	HIGH		raid0		64 GiB	4.0 GiB	Online	default	default
	1	HIGH		raid0		384 GiB	12 GiB	Online	default	default
	Local Storage Devices: 4 devices
	Device	Path		Media Type		Size		Last-Scan
	0:1	/dev/sdb	STORAGE_MEDIUM_SSD	64 GiB		01 Apr 25 04:23 UTC
	1:1	/dev/sdd	STORAGE_MEDIUM_SSD	128 GiB		01 Apr 25 04:23 UTC
	1:2	/dev/sde	STORAGE_MEDIUM_SSD	128 GiB		01 Apr 25 04:23 UTC
	1:3	/dev/sdc	STORAGE_MEDIUM_SSD	128 GiB		01 Apr 25 04:23 UTC
	total			-			448 GiB
	Cache Devices:
	 * No cache devices
Cluster Summary
	Cluster ID: vivek260325-01
	Cluster UUID: 0e00c6f8-65e4-4e0b-819b-43c953f8f03e
	Scheduler: none
	Total Nodes: 2 node(s) with storage (2 online)
	IP		ID					SchedulerNodeName	Auth		StorageNode	Used	Capacity	Status	StorageStatus	Version		Kernel			OS
	10.38.36.210	7b75be76-a2e1-431a-893f-f47d6c15cc5a	N/A			Disabled	Yes		0 B	320 GiB		Online	Up		3.2.3.0-a6d48c7	6.11.0-17-generic	Ubuntu 24.04 LTS
	10.13.190.254	4ff60cf9-3e9c-4e19-a764-94d93a2b5a2f	N/A			Disabled	Yes		16 GiB	448 GiB		Online	Up (This node)	3.2.3.0-a6d48c7	5.15.0-67-generic	Ubuntu 22.04.2 LTS
	Warnings: 
		 WARNING: Swap is enabled on this node.
Global Storage Pool
	Total Used    	:  16 GiB
	Total Capacity	:  768 GiB
Collected at: 2025-04-01 05:10:40 UTC
root@ip-10-13-190-254:~# runc exec -t portworx pxd -v 
Version: PWX-42349:39ef90b1f28b36621353a8e5f3a4052599279df0
```
