### PR TITLE
PWX-43068

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -688,8 +688,8 @@ static int __fuse_notify_read_data(struct fuse_conn *conn,
 					BVEC(bvec).bv_offset + copied + copy_this,
 					len, &data_iter);
 				if (copied != len) {
-					printk(KERN_ERR "%s: copy failed new iovec\n",
-						__func__);
+					printk(KERN_ERR "%s: copy failed new iovec, bio_vec : page = %p len = %d offset = %d\n",
+						__func__, BVEC(bvec).bv_page, BVEC(bvec).bv_len, BVEC(bvec).bv_offset);
 					return -EFAULT;
 				}
 			}
@@ -755,8 +755,8 @@ static int __fuse_notify_read_data(struct fuse_conn *conn,
 					BVEC(bvec).bv_offset + copied + copy_this,
 					len, &data_iter);
 				if (copied != len) {
-					printk(KERN_ERR "%s: copy failed new iovec\n",
-						__func__);
+					printk(KERN_ERR "%s: copy failed new iovec, bio_vec : page = %p len = %d offset = %d\n",
+						__func__, BVEC(bvec).bv_page, BVEC(bvec).bv_len, BVEC(bvec).bv_offset);
 					return -EFAULT;
 				}
 			}

--- a/pxd.c
+++ b/pxd.c
@@ -1280,8 +1280,8 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 		  .logical_block_size = PXD_LBS,
 		  .physical_block_size = PXD_LBS,
 		  .max_segment_size = SEGMENT_SIZE,
-		  .max_segments = SEGMENT_SIZE / PXD_LBS,
-		  .max_hw_sectors = SEGMENT_SIZE / SECTOR_SIZE,
+		  .max_segments = PXD_MAX_IO / PXD_LBS,
+		  .max_hw_sectors = PXD_MAX_IO / SECTOR_SIZE,
 		  .discard_alignment = PXD_MAX_DISCARD_GRANULARITY,
 		  .discard_granularity = PXD_MAX_DISCARD_GRANULARITY,
 		  .io_min = PXD_LBS,
@@ -1345,9 +1345,9 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 	set_capacity(disk, pxd_dev->size / SECTOR_SIZE);
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6,9,0)
-	blk_queue_max_hw_sectors(q, SEGMENT_SIZE / SECTOR_SIZE);
+	blk_queue_max_hw_sectors(q, PXD_MAX_IO / SECTOR_SIZE);
 	blk_queue_max_segment_size(q, SEGMENT_SIZE);
-	blk_queue_max_segments(q, (SEGMENT_SIZE / PXD_LBS));
+	blk_queue_max_segments(q, (PXD_MAX_IO / PXD_LBS));
 	blk_queue_io_min(q, PXD_LBS);
 	blk_queue_io_opt(q, PXD_LBS);
 	blk_queue_logical_block_size(q, PXD_LBS);
@@ -1371,7 +1371,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
     q->limits.discard_granularity = PXD_MAX_DISCARD_GRANULARITY;
     q->limits.discard_alignment = PXD_MAX_DISCARD_GRANULARITY;
 	if (pxd_dev->discard_size < SECTOR_SIZE)
-		q->limits.max_discard_sectors = SEGMENT_SIZE / SECTOR_SIZE;
+		q->limits.max_discard_sectors = PXD_MAX_IO / SECTOR_SIZE;
 	else
 		q->limits.max_discard_sectors = pxd_dev->discard_size / SECTOR_SIZE;
 

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -98,7 +98,10 @@ void pxd_check_q_decongested(struct pxd_device *pxd_dev);
 #define SECTOR_SHIFT (9)
 #endif
 
-#define SEGMENT_SIZE (1024 * 1024)
+// the SEGMENT_SIZE is set to 512K because of a limitation
+// in __fuse_notify_read_data, which could process atmost
+// 128 iovecs per bio_vec (128 * 4096 = 512K)
+#define SEGMENT_SIZE (512 * 1024)
 
 #ifdef __PXD_BIO_MAKEREQ__
 void pxd_reroute_slowpath(struct request_queue *q, struct bio *bio);


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
change max segment size to 512K

* The reason for the change is because of a limitation in
      __fuse_notify_read_data where if it gets a bio_vec which
      has more than 512KB of data in it, it would fail since it
      can only process upto 128 iovecs (128 * 4K = 512K)
* also adjust other fields to use PXD_MAX_IO instead
      of SEGMENT_SIZE because they are not the same anymore
      PXD_MAX_IO is 1MB and SEGMENT_SIZE is 512K
**Which issue(s) this PR fixes** PWX-43068
Closes #

**Special notes for your reviewer**:

Testing notes 

Sanity test to make sure that PX is up with this new px-fuse ko

`[ 1105.317595] pxd: blk-mq driver loaded version PWX-43068:5c9b1b2f07ab0020e9ac50714f709e98aa5d93db, features 0x3`

```
pxctl status
Status: PX is operational
Telemetry: Disabled or Unhealthy
Metering: Disabled or Unhealthy
License: Trial (expires in 31 days)
Node ID: 152381b2-5f5c-4691-8f70-de0d01b7a540
	IP: 10.13.185.50 
 	Local Storage Pool: 1 pool
	POOL	IO_PRIORITY	RAID_LEVEL	USABLE	USED	STATUS	ZONE	REGION
	0	HIGH		raid0		111 GiB	68 MiB	Online	default	default
	Local Storage Devices: 1 device
	Device	Path		Media Type		Size		Last-Scan
	0:0	/dev/sdc	STORAGE_MEDIUM_SSD	128 GiB		02 Apr 25 19:48 UTC
	total			-			128 GiB
	Cache Devices:
	 * No cache devices
	Metadata Device: 
	1	/dev/sdb	STORAGE_MEDIUM_SSD	64 GiB
Cluster Summary
	Cluster ID: px_fuse_fixes_segment_size
	Cluster UUID: 939b9572-dd21-4de5-9d22-8928f948b019
	Scheduler: none
	Total Nodes: 1 node(s) with storage (1 online)
	IP		ID					SchedulerNodeName	Auth		StorageNode	Used	Capacity	Status	StorageStatus	Version		Kernel			OS
	10.13.185.50	152381b2-5f5c-4691-8f70-de0d01b7a540	N/A			Disabled	Yes(PX-StoreV2)	68 MiB	111 GiB		Online	Up (This node)	3.2.1.1-78a1272	5.4.0-193-generic	Ubuntu 20.04.2 LTS
	Warnings: 
		 WARNING: Swap is enabled on this node.
Global Storage Pool
	Total Used    	:  68 MiB
	Total Capacity	:  111 GiB
Collected at: 2025-04-02 19:49:01 UTC
```

Basic volume operations

```
pxctl v c v1
Volume successfully created: 772334657425893274

pxctl host attach v1
Volume successfully attached at: /dev/pxd/pxd772334657425893274

pxctl host mount --path /var/lib/osd/mounts/v1 v1
Volume v1 successfully mounted at /var/lib/osd/mounts/v1

dd if=/dev/urandom of=/var/lib/osd/mounts/v1/test bs=1M count=512 status=progress
522190848 bytes (522 MB, 498 MiB) copied, 5 s, 104 MB/s
512+0 records in
512+0 records out
536870912 bytes (537 MB, 512 MiB) copied, 5.1206 s, 105 MB/s

pxctl host unmount --path /var/lib/osd/mounts/v1 v1
Volume v1 successfully unmounted at /var/lib/osd/mounts/v1

pxctl host detach v1
Volume successfully detached

pxctl v delete v1
Delete volume 'v1', proceed ? (Y/N): y
Volume v1 successfully deleted.
```


