### PR TITLE
fix discard size/granularity limits

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1372,8 +1372,11 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
     q->limits.discard_alignment = PXD_MAX_DISCARD_GRANULARITY;
     q->limits.max_discard_sectors = pxd_dev->discard_size / SECTOR_SIZE;
 
+    // given unaligned discards are ignored at replica targets, it cannot be guaranteed zeroes after discard
+    // so never commit to zeroes being returned after a discard.
+    // this flag and behavior got deprecated
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0)
-	q->limits.discard_zeroes_data = 1;
+    q->limits.discard_zeroes_data = 0;
 #endif
 
 	/* Enable flush support. */

--- a/pxd.h
+++ b/pxd.h
@@ -48,8 +48,7 @@
 #define PXD_MAX_DEVICES	512			/**< maximum number of devices supported */
 #define PXD_MAX_IO		(1024*1024)	/**< maximum io size in bytes */
 #define PXD_MAX_QDEPTH  256			/**< maximum device queue depth */
-#define PXD_MIN_DISCARD_GRANULARITY		PXD_LBS
-#define PXD_MAX_DISCARD_GRANULARITY		(64 * 1024)
+#define PXD_MAX_DISCARD_GRANULARITY		(2 << 20) /**< 2MiB discard granularity on pxd device to cover all pool behavior */
 
 // use by fastpath for congestion control
 #define DEFAULT_CONGESTION_THRESHOLD (PXD_MAX_QDEPTH)
@@ -235,11 +234,13 @@ struct pxd_device* find_pxd_device(struct pxd_context *ctx, uint64_t dev_id);
 // No arguments necessary other than opcode
 #define PXD_FEATURE_FASTPATH (0x1)
 #define PXD_FEATURE_ATTACH_OPTIMIZED (0x2)
+// supports disabling discards, discard granularity at 2M(large)
+#define PXD_FEATURE_DISCARD_CONTROL (0x4)
 
 static inline
 int pxd_supported_features(void)
 {
-    int features = PXD_FEATURE_ATTACH_OPTIMIZED;
+    int features = PXD_FEATURE_ATTACH_OPTIMIZED | PXD_FEATURE_DISCARD_CONTROL;
 #ifdef __PX_FASTPATH__
     features |= PXD_FEATURE_FASTPATH;
 #endif


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Linked with https://github.com/pure-px/porx/pull/14721

***History of discard handling in the kernel***
```
commit 48920ff2a5a940cd07d12cc79e4a2c75f1185aee
Author: Christoph Hellwig <hch@lst.de>
Date:   Wed Apr 5 19:21:23 2017 +0200

    block: remove the discard_zeroes_data flag

    Now that we use the proper REQ_OP_WRITE_ZEROES operation everywhere we can
    kill this hack.

    Signed-off-by: Christoph Hellwig <hch@lst.de>
    Reviewed-by: Martin K. Petersen <martin.petersen@oracle.com>
    Reviewed-by: Hannes Reinecke <hare@suse.com>
    Signed-off-by: Jens Axboe <axboe@fb.com>

commit 98262f2762f0067375f83824d81ea929e37e6bfe
Author: Martin K. Petersen <martin.petersen@oracle.com>
Date:   Thu Dec 3 09:24:48 2009 +0100

    block: Allow devices to indicate whether discarded blocks are zeroed

    The discard ioctl is used by mkfs utilities to clear a block device
    prior to putting metadata down.  However, not all devices return zeroed
    blocks after a discard.  Some drives return stale data, potentially
    containing old superblocks.  It is therefore important to know whether
    discarded blocks are properly zeroed.

    Both ATA and SCSI drives have configuration bits that indicate whether
    zeroes are returned after a discard operation.  Implement a block level
    interface that allows this information to be bubbled up the stack and
    queried via a new block device ioctl.

    Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
    Signed-off-by: Jens Axboe <jens.axboe@oracle.com>
```

*** final resolution and current state***
```
diff --git a/Documentation/ABI/testing/sysfs-block b/Documentation/ABI/testing/sysfs-block
index 2da04ce6aeef..dea212db9df3 100644
--- a/Documentation/ABI/testing/sysfs-block
+++ b/Documentation/ABI/testing/sysfs-block
@@ -213,14 +213,8 @@ What:              /sys/block/<disk>/queue/discard_zeroes_data
 Date:          May 2011
 Contact:       Martin K. Petersen <martin.petersen@oracle.com>
 Description:
-               Devices that support discard functionality may return
-               stale or random data when a previously discarded block
-               is read back. This can cause problems if the filesystem
-               expects discarded blocks to be explicitly cleared. If a
-               device reports that it deterministically returns zeroes
-               when a discarded area is read the discard_zeroes_data
-               parameter will be set to one. Otherwise it will be 0 and
-               the result of reading a discarded area is undefined.
+               Will always return 0.  Don't rely on any specific behavior
+               for discards, and don't read this file.

 What:          /sys/block/<disk>/queue/write_same_max_bytes
 Date:          January 2012
```


**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
## current state ##
```
root@ip-10-38-33-54:~# pxctl v c --nodes LocalNode tvol1
Volume successfully created: 916298959430048538
root@ip-10-38-33-54:~# pxctl host attach tvol1
Volume successfully attached at: /dev/pxd/pxd916298959430048538
root@ip-10-38-33-54:~# lsblk -D /dev/pwx0/916298959430048538 /dev/pxd/pxd916298959430048538
NAME                      DISC-ALN DISC-GRAN DISC-MAX DISC-ZERO
pxd/pxd916298959430048538        0       64K       1M         0
pwx0-916298959430048538          0       64K      64M         0
root@ip-10-38-33-54:~# 
```

## enabling large discards for matching replica targets - does not still work ##
```
root@ip-10-38-33-54:~# pxctl host detach tvol1
Volume successfully detached
root@ip-10-38-33-54:~# pxctl cluster options update --runtime-options optimal_discard_size=$((2*1024*1024))
Successfully updated cluster-wide options
root@ip-10-38-33-54:~# pxctl v l
ID                      NAME    SIZE    HA      SHARED  ENCRYPTED       PROXY-VOLUME    IO_PRIORITY     STATUS          SNAP-ENABLED
916298959430048538      tvol1   1 GiB   1       no      no              no              LOW             up - detached   no
root@ip-10-38-33-54:~# pxctl host attach tvol1
Volume successfully attached at: /dev/pxd/pxd916298959430048538
root@ip-10-38-33-54:~# lsblk -D /dev/pwx0/916298959430048538 /dev/pxd/pxd916298959430048538
NAME                      DISC-ALN DISC-GRAN DISC-MAX DISC-ZERO
pxd/pxd916298959430048538        0       64K       1M         0
pwx0-916298959430048538          0       64K      64M         0
root@ip-10-38-33-54:~# 
```

# Test with fixes #

## revising discard to support max 10M ##
```
root@ip-10-38-33-54:/var/cores/px-fuse/px-fuse# pxctl host detach tvol1
Volume successfully detached
root@ip-10-38-33-54:/var/cores/px-fuse/px-fuse# pxctl cluster options update --runtime-options optimal_discard_size=$((10*1024*1024))
Successfully updated cluster-wide options
root@ip-10-38-33-54:/var/cores/px-fuse/px-fuse# pxctl host attach tvol1
Volume successfully attached at: /dev/pxd/pxd916298959430048538
root@ip-10-38-33-54:/var/cores/px-fuse/px-fuse# lsblk -D /dev/pwx0/916298959430048538 /dev/pxd/pxd916298959430048538
NAME                      DISC-ALN DISC-GRAN DISC-MAX DISC-ZERO
pxd/pxd916298959430048538        0        2M      10M         0
pwx0-916298959430048538          0       64K      64M         0
root@ip-10-38-33-54:/var/cores/px-fuse/px-fuse#
```


## bring it down requires px restart ##
```
root@ip-10-38-33-54:/var/cores/px-fuse/px-fuse# pxctl cluster options update --runtime-options optimal_discard_size=$((1*1024*1024))
Successfully updated cluster-wide options
root@ip-10-38-33-54:/var/cores/px-fuse/px-fuse# pxctl host attach tvol1
Volume successfully attached at: /dev/pxd/pxd916298959430048538
root@ip-10-38-33-54:/var/cores/px-fuse/px-fuse# lsblk -D /dev/pwx0/916298959430048538 /dev/pxd/pxd916298959430048538
NAME                      DISC-ALN DISC-GRAN DISC-MAX DISC-ZERO
pxd/pxd916298959430048538        0        2M      10M         0
pwx0-916298959430048538          0       64K      64M         0
root@ip-10-38-33-54:/var/cores/px-fuse/px-fuse#
root@ip-10-38-33-54:/var/cores/px-fuse/px-fuse# pxctl host detach tvol1
Volume successfully detached
root@ip-10-38-33-54:/var/cores/px-fuse/px-fuse# systemctl restart portworx
root@ip-10-38-33-54:/var/cores/px-fuse/px-fuse#
root@ip-10-38-33-54:/var/cores/px-fuse/px-fuse# pxctl host attach tvol1
Volume successfully attached at: /dev/pxd/pxd916298959430048538
root@ip-10-38-33-54:/var/cores/px-fuse/px-fuse# lsblk -D /dev/pwx0/916298959430048538 /dev/pxd/pxd916298959430048538
NAME                      DISC-ALN DISC-GRAN DISC-MAX DISC-ZERO
pxd/pxd916298959430048538        0        2M       2M         0
pwx0-916298959430048538          0       64K      64M         0
root@ip-10-38-33-54:/var/cores/px-fuse/px-fuse#
```
