### PR TITLE
PWX-43068: use PXD_MAX_IO for discard size instead of SEGMENT_SIZE

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1494,7 +1494,7 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 	}
 
 	if (add->discard_size < SECTOR_SIZE)
-		pxd_dev->discard_size = SEGMENT_SIZE;
+		pxd_dev->discard_size = PXD_MAX_IO;
 	else
 		pxd_dev->discard_size = add->discard_size;
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Part of PWX-43068, updates discard size correctly
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

