### PR TITLE
PWX-42981

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -578,6 +578,7 @@ static int fuse_notify_add_ext(struct fuse_conn *conn, unsigned int size,
 		printk(KERN_ERR "%s: can't copy arg\n", __func__);
 		return -EFAULT;
 	}
+	trace_fuse_notify_add_ext(add.dev_id, add.size, add.queue_depth, add.discard_size, add.open_mode, add.enable_fp, add.paths.count);
 	return pxd_add(conn, &add);
 }
 

--- a/dev.c
+++ b/dev.c
@@ -245,6 +245,7 @@ void fuse_request_send_nowait(struct fuse_conn *fc, struct fuse_req *req)
 		len_args(req->in.numargs, (struct fuse_arg *)req->in.args);
 
 	req->in.h.unique = fuse_get_unique(fc);
+	trace_pxd_request(req->pxd_dev->dev_id, req->in.h.unique, req->pxd_rdwr_in.size, req->pxd_rdwr_in.offset, req->pxd_dev->minor, req->in.h.opcode, req->pxd_rdwr_in.flags);
 	fc->request_map[req->in.h.unique & (FUSE_MAX_REQUEST_IDS - 1)] = req;
 
 	/*

--- a/dev.c
+++ b/dev.c
@@ -26,6 +26,7 @@
 #include "pxd_compat.h"
 #include "pxd_fastpath.h"
 #include "pxd_core.h"
+#include "pxd_trace.h"
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)
 #define PAGE_CACHE_GET(page) get_page(page)
@@ -617,6 +618,7 @@ static int copy_in_read_data_iovec(struct iov_iter *iter,
 	int iovcnt;
 	size_t len;
 
+	trace_copy_in_read_data_iovec(read_data->unique, read_data->iovcnt, read_data->iovcnt - min(read_data->iovcnt, IOV_BUF_SIZE));
 	if (!read_data->iovcnt)
 		return -EFAULT;
 
@@ -627,6 +629,7 @@ static int copy_in_read_data_iovec(struct iov_iter *iter,
 		return -EFAULT;
 	}
 	read_data->iovcnt -= iovcnt;
+
 
 	iov_iter_init(data_iter, READ, iov, iovcnt, iov_length(iov, iovcnt));
 
@@ -653,13 +656,21 @@ static int __fuse_notify_read_data(struct fuse_conn *conn,
 	if (ret)
 		return ret;
 
+	trace_fuse_notify_read_data_request(req->pxd_dev->dev_id, read_data_p->unique, blk_rq_pos(req->rq) * SECTOR_SIZE,
+		blk_rq_bytes(req->rq), req->pxd_rdwr_in.offset, read_data_p->offset);
+
 	/* advance the iterator if data is unaligned */
-	if (unlikely(req->pxd_rdwr_in.offset & PXD_LBS_MASK))
+	if (unlikely(req->pxd_rdwr_in.offset & PXD_LBS_MASK)) {
 		iov_iter_advance(&data_iter,
 				 req->pxd_rdwr_in.offset & PXD_LBS_MASK);
+	}
 
 	rq_for_each_segment(bvec, req->rq, breq_iter) {
 		ssize_t len = BVEC(bvec).bv_len;
+
+		trace_fuse_notify_read_data_segment_info(req->pxd_dev->dev_id, read_data_p->unique,
+			BVEC(bvec).bv_offset,
+			BVEC(bvec).bv_len);
 		copied = 0;
 		if (skipped < read_data_p->offset) {
 			if (read_data_p->offset - skipped >= len) {
@@ -674,6 +685,10 @@ static int __fuse_notify_read_data(struct fuse_conn *conn,
 			size_t copy_this = copy_page_to_iter(BVEC(bvec).bv_page,
 				BVEC(bvec).bv_offset + copied,
 				len - copied, &data_iter);
+
+			trace_fuse_notify_read_data_copy(req->pxd_dev->dev_id, read_data_p->unique, copied, copy_this,
+				BVEC(bvec).bv_offset, BVEC(bvec).bv_offset + copied,
+				BVEC(bvec).bv_len, len - copied, iter->count);
 			if (copy_this != len - copied) {
 				if (!iter->count)
 					return 0;
@@ -687,6 +702,9 @@ static int __fuse_notify_read_data(struct fuse_conn *conn,
 				copied = copy_page_to_iter(BVEC(bvec).bv_page,
 					BVEC(bvec).bv_offset + copied + copy_this,
 					len, &data_iter);
+				trace_fuse_notify_read_data_finalcopy(req->pxd_dev->dev_id, read_data_p->unique, len, copied,
+					BVEC(bvec).bv_offset, BVEC(bvec).bv_offset + copied + copy_this,
+					BVEC(bvec).bv_len);
 				if (copied != len) {
 					printk(KERN_ERR "%s: copy failed new iovec, bio_vec : page = %p len = %d offset = %d\n",
 						__func__, BVEC(bvec).bv_page, BVEC(bvec).bv_len, BVEC(bvec).bv_offset);

--- a/dev.c
+++ b/dev.c
@@ -245,7 +245,7 @@ void fuse_request_send_nowait(struct fuse_conn *fc, struct fuse_req *req)
 		len_args(req->in.numargs, (struct fuse_arg *)req->in.args);
 
 	req->in.h.unique = fuse_get_unique(fc);
-	trace_pxd_request(req->pxd_dev->dev_id, req->in.h.unique, req->pxd_rdwr_in.size, req->pxd_rdwr_in.offset, req->pxd_dev->minor, req->in.h.opcode, req->pxd_rdwr_in.flags);
+	trace_pxd_request(req->pxd_dev->dev_id, req->in.h.unique, req->pxd_rdwr_in.size, req->pxd_rdwr_in.offset, req->pxd_dev->minor, req->rq != NULL ? req_op(req->rq): -1, req->rq != NULL ? req->rq->cmd_flags : -1, req->in.h.opcode, req->pxd_rdwr_in.flags);
 	fc->request_map[req->in.h.unique & (FUSE_MAX_REQUEST_IDS - 1)] = req;
 
 	/*

--- a/pxd.c
+++ b/pxd.c
@@ -910,6 +910,8 @@ bool pxd_process_ioswitch_complete(struct fuse_conn *fc, struct fuse_req *req,
 	printk("device %llu completed ioswitch %d with status %d\n",
 		pxd_dev->dev_id, req->in.h.opcode, status);
 
+	trace_pxd_ioswitch_complete(pxd_dev->dev_id, pxd_dev->minor, req->in.h.opcode);
+
 	if (req->in.h.opcode == PXD_FAILOVER_TO_USERSPACE) {
 		// if the status is successful, then reissue IO to userspace
 		// else fail IO to complete.
@@ -998,6 +1000,8 @@ int pxd_initiate_fallback(struct pxd_device *pxd_dev)
 	if (atomic_cmpxchg(&pxd_dev->fp.ioswitch_active, 0, 1) != 0) {
 		return -EBUSY;
 	}
+
+	trace_pxd_initiate_fallback(pxd_dev->dev_id, pxd_dev->minor);
 
 	rc = pxd_request_suspend_internal(pxd_dev, true, false);
 	if (rc) {

--- a/pxd.c
+++ b/pxd.c
@@ -487,6 +487,7 @@ void pxd_check_q_decongested(struct pxd_device *pxd_dev)
 
 static void pxd_request_complete(struct fuse_conn *fc, struct fuse_req *req, int status)
 {
+	trace_pxd_request_complete(req->pxd_dev->dev_id, req->pxd_dev->minor, req->in.h.unique, blk_rq_pos(req->rq) * SECTOR_SIZE, blk_rq_bytes(req->rq), req_op(req->rq), req->rq->cmd_flags, status);
 	atomic_dec(&req->pxd_dev->ncount);
 	pxd_check_q_decongested(req->pxd_dev);
 	pxd_printk("%s: receive reply to %px(%lld) at %lld err %d\n",
@@ -823,7 +824,7 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 			uint32_t minor, uint32_t op, uint32_t flags)
 {
 	int rc;
-	trace_pxd_request(req->in.h.unique, size, off, minor, op, flags);
+	trace_pxd_request(req->pxd_dev->dev_id, req->in.h.unique, size, off, minor, op, flags);
 
 	switch (op) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && (defined(__EL8__) || defined(__SUSE_EQ_SP5__)))
@@ -861,7 +862,7 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 	uint32_t minor, uint32_t flags)
 {
 	int rc;
-	trace_pxd_request(req->in.h.unique, size, off, minor, flags);
+	trace_pxd_request(req->pxd_dev->dev_id, req->in.h.unique, size, off, minor, flags, flags);
 
 	switch (flags & (REQ_WRITE | REQ_DISCARD | REQ_WRITE_SAME)) {
 	case REQ_WRITE:

--- a/pxd.c
+++ b/pxd.c
@@ -1172,7 +1172,7 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 
 	trace_pxd_queue_rq(pxd_dev->dev_id, pxd_dev->minor, rq_data_dir(rq),
 		req_op(rq), blk_rq_pos(rq) * SECTOR_SIZE, blk_rq_bytes(rq),
-		rq->nr_phys_segments, rq->cmd_flags, rq->bio, rq->biotail);
+		rq->nr_phys_segments, rq->cmd_flags, rq->bio, rq->biotail, rq->bio && rq->bio == rq->biotail, rq->bio ? BIO_SECTOR(rq->bio) * SECTOR_SIZE : -1);
 	if (BLK_RQ_IS_PASSTHROUGH(rq) || !READ_ONCE(fc->allow_disconnected))
 		return BLK_STS_IOERR;
 

--- a/pxd.c
+++ b/pxd.c
@@ -824,7 +824,6 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 			uint32_t minor, uint32_t op, uint32_t flags)
 {
 	int rc;
-	trace_pxd_request(req->pxd_dev->dev_id, req->in.h.unique, size, off, minor, op, flags);
 
 	switch (op) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && (defined(__EL8__) || defined(__SUSE_EQ_SP5__)))
@@ -862,7 +861,6 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 	uint32_t minor, uint32_t flags)
 {
 	int rc;
-	trace_pxd_request(req->pxd_dev->dev_id, req->in.h.unique, size, off, minor, flags, flags);
 
 	switch (flags & (REQ_WRITE | REQ_DISCARD | REQ_WRITE_SAME)) {
 	case REQ_WRITE:
@@ -1800,12 +1798,15 @@ ssize_t pxd_ioc_update_size(struct fuse_conn *fc, struct pxd_update_size *update
 	}
 	(void)get_device(&pxd_dev->dev);
 
+	trace_pxd_ioc_update_size(pxd_dev->dev_id, pxd_dev->minor, pxd_dev->size, update_size->size);
+
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
 	set_capacity(pxd_dev->disk, update_size->size / SECTOR_SIZE);
 #else
 	// set_capacity is sufficient for modifying disk size from 5.11 onwards
 	set_capacity_and_notify(pxd_dev->disk, update_size->size / SECTOR_SIZE);
 #endif
+	pxd_dev->size = update_size->size;
 	spin_unlock(&pxd_dev->lock);
 
 	// set_capacity is sufficient for modifying disk size from 5.11 onwards

--- a/pxd.c
+++ b/pxd.c
@@ -2466,6 +2466,7 @@ static int pxd_control_release(struct inode *inode, struct file *file)
 	schedule_delayed_work(&ctx->abort_work, pxd_timeout_secs * HZ);
 	spin_unlock(&ctx->lock);
 
+	trace_pxd_close_ctrl_fd(ctx->id);
 	printk(KERN_INFO "%s: pxd-control-%d(%lld) close OK\n", __func__, ctx->id,
 		ctx->open_seq);
 	return 0;

--- a/pxd.c
+++ b/pxd.c
@@ -1588,6 +1588,7 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 	}
 
 	spin_lock(&pxd_dev->lock);
+	trace_pxd_export(pxd_dev->dev_id, pxd_dev->minor, pxd_dev->exported);
 	if (pxd_dev->exported) {
 		spin_unlock(&pxd_dev->lock);
 		return 0;

--- a/pxd.c
+++ b/pxd.c
@@ -823,7 +823,7 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 			uint32_t minor, uint32_t op, uint32_t flags)
 {
 	int rc;
-	trace_pxd_request(req->in.h.unique, size, off, minor, flags);
+	trace_pxd_request(req->in.h.unique, size, off, minor, op, flags);
 
 	switch (op) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && (defined(__EL8__) || defined(__SUSE_EQ_SP5__)))
@@ -1084,6 +1084,9 @@ static void pxd_rq_fn(struct request_queue *q)
 		if (!rq)
 			break;
 
+		trace_pxd_rq_fn(pxd_dev->dev_id, pxd_dev->minor, rq_data_dir(rq),
+			req_op(rq), blk_rq_pos(rq) * SECTOR_SIZE, blk_rq_bytes(rq),
+			rq->nr_phys_segments, rq->cmd_flags);
 		/* Filter out block requests we don't understand. */
 		if (BLK_RQ_IS_PASSTHROUGH(rq) || !READ_ONCE(fc->allow_disconnected)) {
 			__blk_end_request_all(rq, 0);
@@ -1164,6 +1167,9 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 	struct fuse_req *req = blk_mq_rq_to_pdu(rq);
 	struct fuse_conn *fc = &pxd_dev->ctx->fc;
 
+	trace_pxd_queue_rq(pxd_dev->dev_id, pxd_dev->minor, rq_data_dir(rq),
+		req_op(rq), blk_rq_pos(rq) * SECTOR_SIZE, blk_rq_bytes(rq),
+		rq->nr_phys_segments, rq->cmd_flags, rq->bio, rq->biotail);
 	if (BLK_RQ_IS_PASSTHROUGH(rq) || !READ_ONCE(fc->allow_disconnected))
 		return BLK_STS_IOERR;
 

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -577,6 +577,7 @@ static void pxd_io_failover(struct kthread_work *work) {
         spin_unlock_irqrestore(&pxd_dev->fp.fail_lock, flags);
 
         if (cleanup) {
+                trace_pxd_initiate_failover(pxd_dev->dev_id, pxd_dev->minor, FAILOVER_REASON_IOFAILURE);
                 rc = pxd_initiate_failover(pxd_dev);
                 // If userspace cannot be informed of a failover event, force
                 // abort all IO.

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -226,6 +226,8 @@ void pxd_reissuefailQ(struct pxd_device *pxd_dev, struct list_head *ios,
                             "%s: pxd%llu: resuming IO in native path.\n",
                             __func__, pxd_dev->dev_id);
                         atomic_inc(&pxd_dev->fp.nslowPath);
+                        trace_pxd_reroute_slowpath_transition(pxd_dev->dev_id, pxd_dev->minor, TRANSITION_REISSUE_FAILQ, rq_data_dir(req->rq), req_op(req->rq),
+                                blk_rq_pos(req->rq) * SECTOR_SIZE, blk_rq_bytes(req->rq), req->rq->nr_phys_segments, req->rq->cmd_flags);
                         pxdmq_reroute_slowpath(req);
                         continue;
                 }
@@ -594,6 +596,9 @@ static void pxd_io_failover(struct kthread_work *work) {
                                    __func__, pxd_dev->dev_id);
                 atomic_inc(&pxd_dev->fp.nslowPath);
                 clone_cleanup(fproot);
+                trace_pxd_reroute_slowpath_transition(pxd_dev->dev_id, pxd_dev->minor, TRANSITION_PXD_IO_FAILOVER, rq_data_dir(fproot_to_request(fproot)), 
+                        req_op(fproot_to_request(fproot)), blk_rq_pos(fproot_to_request(fproot)) * SECTOR_SIZE, blk_rq_bytes(fproot_to_request(fproot)),
+                        fproot_to_request(fproot)->nr_phys_segments, fproot_to_request(fproot)->cmd_flags);
                 pxdmq_reroute_slowpath(fproot_to_fuse_request(fproot));
         }
 }
@@ -737,6 +742,7 @@ static void _end_clone_bio(struct kthread_work *work)
                 blkrc = -EIO;
 
         if (pxd_dev->fp.can_failover && (blkrc == -EIO)) {
+                trace_end_clone_bio(pxd_dev->dev_id, pxd_dev->minor, bio_op(bio), BIO_SECTOR(bio) * SECTOR_SIZE, BIO_SIZE(bio), req_op(rq), blk_rq_pos(rq) * SECTOR_SIZE, blk_rq_bytes(rq), blkrc, rq->bio, rq->biotail);
                 atomic_inc(&pxd_dev->fp.nerror);
                 pxd_failover_initiate(fproot);
                 return;

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -25,6 +25,7 @@
 #include "pxd_bio.h"
 #include "pxd_compat.h"
 #include "pxd_core.h"
+#include "pxd_trace.h"
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0) || defined(REQ_PREFLUSH)
 inline bool rq_is_special(struct request *rq) {
@@ -651,7 +652,7 @@ static void fp_handle_specialops(struct kthread_work *work) {
 	}
 #else
     // submit discard to replica
-    if (blk_queue_discard(q)) { // discard supported
+        if (blk_queue_discard(q)) { // discard supported
 	  r = blkdev_issue_discard(bdev, blk_rq_pos(rq),
 				   blk_rq_sectors(rq), GFP_NOIO, 0);
 	} else if (bdev_write_same(bdev)) {
@@ -669,6 +670,16 @@ static void fp_handle_specialops(struct kthread_work *work) {
 				 blk_rq_sectors(rq), GFP_NOIO);
 #endif
 	}
+#endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && !defined(BLKDEV_DISCARD_SECURE))  || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__SUSE_EQ_SP5__))
+	trace_fp_discard_reply(pxd_dev->dev_id, pxd_dev->minor, rq_data_dir(rq),
+		req_op(rq), blk_rq_pos(rq) * SECTOR_SIZE, blk_rq_bytes(rq),
+		rq->nr_phys_segments, bdev_max_discard_sectors(bdev), rq->cmd_flags, r);
+#else
+	trace_fp_discard_reply(pxd_dev->dev_id, pxd_dev->minor, rq_data_dir(rq),
+		req_op(rq), blk_rq_pos(rq) * SECTOR_SIZE, blk_rq_bytes(rq),
+		rq->nr_phys_segments, blk_queue_discard(q), rq->cmd_flags, r);
 #endif
 
 	BIO_ENDIO(&cc->clone, r);
@@ -730,6 +741,7 @@ static void _end_clone_bio(struct kthread_work *work)
                 pxd_failover_initiate(fproot);
                 return;
         }
+        trace_end_clone_bio(pxd_dev->dev_id, pxd_dev->minor, bio_op(bio), BIO_SECTOR(bio) * SECTOR_SIZE, BIO_SIZE(bio), req_op(rq), blk_rq_pos(rq) * SECTOR_SIZE, blk_rq_bytes(rq), blkrc, rq->bio, rq->biotail);
 
         // complete cleanup of all clones
         clone_cleanup(fproot);

--- a/pxd_bio_makereq.c
+++ b/pxd_bio_makereq.c
@@ -415,6 +415,7 @@ static void pxd_io_failover(struct work_struct *ws) {
         spin_unlock_irqrestore(&pxd_dev->fp.fail_lock, flags);
 
         if (cleanup) {
+                trace_pxd_initiate_failover(pxd_dev->dev_id, pxd_dev->minor, FAILOVER_REASON_IOFAILURE);
                 rc = pxd_initiate_failover(pxd_dev);
                 // If userspace cannot be informed of a failover event, force
                 // abort all IO.

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -18,6 +18,7 @@
 #include "pxd.h"
 #include "pxd_core.h"
 #include "pxd_compat.h"
+#include "pxd_trace.h"
 #include "kiolib.h"
 
 // global fastpath IO work queue
@@ -139,7 +140,7 @@ int fastpath_init(void)
 			}
 		}
 	}
-	// always confirm default 
+	// always confirm default
 	if (fpdefault == NULL) {
 		// fastpath init failed.
 		printk(KERN_ERR"found no online node with online cpus\n");
@@ -268,6 +269,7 @@ int pxd_request_ioswitch(struct pxd_device *pxd_dev, int code)
 		printk("device %llu initiated failover\n", pxd_dev->dev_id);
 		// IO path blocked, a future path refresh will take it to native path
 		// enqueue a failover request to userspace on this device.
+		trace_pxd_initiate_failover(pxd_dev->dev_id, pxd_dev->minor, FAILOVER_REASON_USERSPACE);
 		return pxd_initiate_failover(pxd_dev);
 	case PXD_FALLBACK_TO_KERNEL:
 		// IO path already routed to userspace.

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -705,6 +705,7 @@ void pxd_fastpath_reset_device(struct pxd_device *pxd_dev)
 	if (atomic_read(&fp->ioswitch_active)) {
 		req = request_find(fc, pxd_dev->fp.switch_uid);
 		if (!IS_ERR_OR_NULL(req)) {
+			trace_pxd_fastpath_reset_device(pxd_dev->dev_id, pxd_dev->minor, atomic_read(&fp->ioswitch_active), pxd_dev->fp.switch_uid);
 			// overwrite switch request to fail all pending IOs
 			req->in.h.opcode = PXD_FAILOVER_TO_USERSPACE;
 			req->out.h.error = -EIO; // force failure status
@@ -713,6 +714,8 @@ void pxd_fastpath_reset_device(struct pxd_device *pxd_dev)
 			pxd_dev->fp.switch_uid = 0;
 			atomic_set(&fp->ioswitch_active, 0);
 		}
+	} else {
+		trace_pxd_fastpath_reset_device(pxd_dev->dev_id, pxd_dev->minor, atomic_read(&fp->ioswitch_active), 0);
 	}
 
 	// resume from userspace IO suspends

--- a/pxd_trace.h
+++ b/pxd_trace.h
@@ -376,8 +376,8 @@ TRACE_EVENT(
 	),
 	TP_printk(
 		"dev_id %llu minor %d transition %d dir %d op %u offset %llu size %llu nr_phys_segments %u flags %x",
-		__entry->dev_id, __entry->minor, __entry->transition, __entry->dir, __entry->op,
-		__entry->offset, __entry->size, __entry->nr_phys_segments,
+		__entry->dev_id, __entry->minor, __entry->transition,
+		__entry->dir, __entry->op, __entry->offset, __entry->size, __entry->nr_phys_segments,
 		__entry->flags)
 );
 
@@ -576,6 +576,21 @@ TRACE_EVENT(
 	TP_printk(
 		"dev_id %llu minor %d opcode %d",
 		__entry->dev_id, __entry->minor, __entry->opcode)
+);
+
+TRACE_EVENT(
+	pxd_close_ctrl_fd,
+	TP_PROTO(int ctx_id),
+	TP_ARGS(ctx_id),
+	TP_STRUCT__entry(
+		__field(int, ctx_id)
+	),
+	TP_fast_assign(
+		__entry->ctx_id = ctx_id
+	),
+	TP_printk(
+		"closed control fd for px : %d",
+		__entry->ctx_id)
 );
 #endif /* _PXD_TP_H */
 

--- a/pxd_trace.h
+++ b/pxd_trace.h
@@ -31,6 +31,129 @@ TRACE_EVENT(
 );
 
 TRACE_EVENT(
+	copy_in_read_data_iovec,
+	TP_PROTO(uint64_t req_id, int prev_iovcnt, int curr_iovcnt),
+	TP_ARGS(req_id, prev_iovcnt, curr_iovcnt),
+	TP_STRUCT__entry(
+		__field(uint64_t, req_id)
+		__field(int, prev_iovcnt)
+		__field(int, curr_iovcnt)
+	),
+	TP_fast_assign(
+		__entry->req_id = req_id,
+		__entry->prev_iovcnt = prev_iovcnt,
+		__entry->curr_iovcnt = curr_iovcnt
+	),
+	TP_printk(
+		"req_id %llu prev_iovcnt %d curr_iovcnt %d",
+		__entry->req_id, __entry->prev_iovcnt, __entry->curr_iovcnt)
+);
+
+TRACE_EVENT(
+	fuse_notify_read_data_request,
+	TP_PROTO(uint64_t devid, uint64_t req_id,uint64_t rq_offset, uint64_t rq_size, uint64_t rdwr_offset, uint64_t read_data_p_offset),
+	TP_ARGS(devid, req_id, rq_offset, rq_size, rdwr_offset, read_data_p_offset),
+	TP_STRUCT__entry(
+		__field(uint64_t, devid)
+		__field(uint64_t, req_id)
+		__field(uint64_t, rq_offset)
+		__field(uint64_t, rq_size)
+		__field(uint64_t, rdwr_offset)
+		__field(uint64_t, read_data_p_offset)
+	),
+	TP_fast_assign(
+		__entry->devid = devid,
+		__entry->req_id = req_id,
+		__entry->rq_offset = rq_offset,
+		__entry->rq_size = rq_size,
+		__entry->rdwr_offset = rdwr_offset,
+		__entry->read_data_p_offset = read_data_p_offset
+	),
+	TP_printk(
+		"devid %llu req_id %llu rq_offset %llu rq_size %llu rdwr_offset %llu read_data_p_offset %llu",
+		__entry->devid, __entry->req_id, __entry->rq_offset, __entry->rq_size, __entry->rdwr_offset, __entry->read_data_p_offset)
+);
+
+TRACE_EVENT(
+	fuse_notify_read_data_segment_info,
+	TP_PROTO(uint64_t devid, uint64_t req_id, uint64_t bv_offset, uint64_t bv_len),
+	TP_ARGS(devid, req_id,bv_offset, bv_len),
+	TP_STRUCT__entry(
+		__field(uint64_t, devid)
+		__field(uint64_t, req_id)
+		__field(uint64_t, bv_offset)
+		__field(uint64_t, bv_len)
+	),
+	TP_fast_assign(
+		__entry->devid = devid,
+		__entry->req_id = req_id,
+		__entry->bv_offset = bv_offset,
+		__entry->bv_len = bv_len
+	),
+	TP_printk(
+		"devid %llu req_id %llu bv_offset %llu bv_len %llu",
+		__entry->devid, __entry->req_id, __entry->bv_offset, __entry->bv_len)
+);
+
+TRACE_EVENT(
+	fuse_notify_read_data_copy,
+	TP_PROTO(uint64_t devid, uint64_t req_id, size_t copied, size_t copy_this, uint64_t bv_offset, uint64_t offset, uint64_t bv_len, uint64_t len, uint64_t iter_count),
+	TP_ARGS(devid, req_id, copied, copy_this, bv_offset, offset, bv_len, len, iter_count),
+	TP_STRUCT__entry(
+		__field(uint64_t, devid)
+		__field(uint64_t, req_id)
+		__field(size_t, copied)
+		__field(size_t, copy_this)
+		__field(uint64_t, bv_offset)
+		__field(uint64_t, offset)
+		__field(uint64_t, bv_len)
+		__field(uint64_t, len)
+		__field(uint64_t, iter_count)
+	),
+	TP_fast_assign(
+		__entry->devid = devid,
+		__entry->req_id = req_id,
+		__entry->copied = copied,
+		__entry->copy_this = copy_this,
+		__entry->bv_offset = bv_offset,
+		__entry->offset = offset,
+		__entry->bv_len = bv_len,
+		__entry->len = len,
+		__entry->iter_count = iter_count
+	),
+	TP_printk(
+		"devid %llu req_id %llu copied %zu copy_this %zu bv_offset %llu offset %llu bv_len %llu len %llu iter_count %llu",
+		__entry->devid, __entry->req_id, __entry->copied, __entry->copy_this, __entry->bv_offset, __entry->offset, __entry->bv_len, __entry->len, __entry->iter_count)
+);
+
+TRACE_EVENT(
+	fuse_notify_read_data_finalcopy,
+	TP_PROTO(uint64_t devid, uint64_t req_id, uint64_t len, uint64_t copied, uint64_t bv_offset, uint64_t offset, uint64_t bv_len),
+	TP_ARGS(devid, req_id, len, copied, bv_offset, offset, bv_len),
+	TP_STRUCT__entry(
+		__field(uint64_t, devid)
+		__field(uint64_t, req_id)
+		__field(uint64_t, len)
+		__field(uint64_t, copied)
+		__field(uint64_t, bv_offset)
+		__field(uint64_t, offset)
+		__field(uint64_t, bv_len)
+	),
+	TP_fast_assign(
+		__entry->devid = devid,
+		__entry->req_id = req_id,
+		__entry->len = len,
+		__entry->copied = copied,
+		__entry->bv_offset = bv_offset,
+		__entry->offset = offset,
+		__entry->bv_len = bv_len
+	),
+	TP_printk(
+		"devid %llu req_id %llu len %llu copied %llu bv_offset %llu offset %llu bv_len %llu",
+		__entry->devid, __entry->req_id, __entry->len, __entry->copied, __entry->bv_offset, __entry->offset, __entry->bv_len)
+);
+
+TRACE_EVENT(
 	pxd_release,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(__RHEL_GT_94__) || defined(__SUSE_GTE_SP6__) || defined(__SLE_MICRO_GTE_6_0__)
 	TP_PROTO(uint64_t dev_id, int major, int minor),
@@ -99,16 +222,161 @@ TRACE_EVENT(
 );
 
 TRACE_EVENT(
+	pxd_queue_rq,
+	TP_PROTO(uint64_t dev_id, int minor, int dir, uint32_t op,
+		uint64_t offset, uint64_t size, unsigned short nr_phys_segments,
+		uint32_t flags, void *bio, void *bio_tail),
+	TP_ARGS(dev_id, minor, dir, op, offset, size, nr_phys_segments, flags, bio, bio_tail),
+	TP_STRUCT__entry(
+		__field(uint64_t, dev_id)
+		__field(int, minor)
+		__field(int, dir)
+		__field(uint32_t, op)
+		__field(uint64_t, offset)
+		__field(uint64_t, size)
+		__field(unsigned short, nr_phys_segments)
+		__field(uint32_t, flags)
+		__field(void *, bio)
+		__field(void *, bio_tail)
+	),
+	TP_fast_assign(
+		__entry->dev_id = dev_id,
+		__entry->minor = minor,
+		__entry->dir = dir,
+		__entry->op = op,
+		__entry->offset = offset,
+		__entry->size = size,
+		__entry->nr_phys_segments = nr_phys_segments,
+		__entry->flags = flags,
+		__entry->bio = bio,
+		__entry->bio_tail = bio_tail
+	),
+	TP_printk(
+		"dev_id %llu minor %d dir %d op %u offset %llu size %llu nr_phys_segments %u flags %x bio %p bio_tail %p",
+		__entry->dev_id, __entry->minor, __entry->dir, __entry->op,
+		__entry->offset, __entry->size, __entry->nr_phys_segments,
+		__entry->flags, __entry->bio, __entry->bio_tail)	
+);
+
+TRACE_EVENT(
+	fp_discard_reply,
+	TP_PROTO(uint64_t dev_id, int minor, int dir, uint32_t op,
+		uint64_t offset, uint64_t size, unsigned short nr_phys_segments,
+		bool discard, uint32_t flags, int status),
+	TP_ARGS(dev_id, minor, dir, op, offset, size, nr_phys_segments, discard, flags, status),
+	TP_STRUCT__entry(
+		__field(uint64_t, dev_id)
+		__field(int, minor)
+		__field(int, dir)
+		__field(uint32_t, op)
+		__field(uint64_t, offset)
+		__field(uint64_t, size)
+		__field(unsigned short, nr_phys_segments)
+		__field(bool, discard)
+		__field(uint32_t, flags)
+		__field(int, status)
+	),
+	TP_fast_assign(
+		__entry->dev_id = dev_id,
+		__entry->minor = minor,
+		__entry->dir = dir,
+		__entry->op = op,
+		__entry->offset = offset,
+		__entry->size = size,
+		__entry->nr_phys_segments = nr_phys_segments,
+		__entry->discard = discard,
+		__entry->flags = flags,
+		__entry->status = status
+	),
+	TP_printk(
+		"dev_id %llu minor %d dir %d op %u offset %llu size %llu nr_phys_segments %u discard = %d flags %x status %d",
+		__entry->dev_id, __entry->minor, __entry->dir, __entry->op,
+		__entry->offset, __entry->size, __entry->nr_phys_segments, __entry->discard,
+		__entry->flags, __entry->status)	
+);
+
+TRACE_EVENT(
+	end_clone_bio,
+	TP_PROTO(uint64_t dev_id, int minor, uint32_t bio_op, uint64_t bio_offset, uint64_t bio_size,
+	uint32_t rq_op, uint64_t rq_offset, uint64_t rq_size, int status, void* bio, void* biotail),
+	TP_ARGS(dev_id, minor, bio_op, bio_offset, bio_size, rq_op, rq_offset, rq_size, status, bio, biotail),
+	TP_STRUCT__entry(
+		__field(uint64_t, dev_id)
+		__field(int, minor)
+		__field(uint32_t, bio_op)
+		__field(uint64_t, bio_offset)
+		__field(uint64_t, bio_size)
+		__field(uint32_t, rq_op)
+		__field(uint64_t, rq_offset)
+		__field(uint64_t, rq_size)
+		__field(int, status)
+		__field(void*, bio)
+		__field(void*, biotail)
+	),
+	TP_fast_assign(
+		__entry->dev_id = dev_id,
+		__entry->minor = minor,
+		__entry->bio_op = bio_op,
+		__entry->bio_offset = bio_offset,
+		__entry->bio_size = bio_size,
+		__entry->rq_op = rq_op,
+		__entry->rq_offset = rq_offset,
+		__entry->rq_size = rq_size,
+		__entry->status = status,
+		__entry->bio = bio,
+		__entry->biotail = biotail
+	),
+	TP_printk(
+		"dev_id %llu minor %d bio_op %u bio_offset %llu bio_size %llu rq_op %u rq_offset %llu rq_size %llu status %d bio %p biotail %p",
+		__entry->dev_id, __entry->minor, __entry->bio_op, __entry->bio_offset, __entry->bio_size,
+		__entry->rq_op, __entry->rq_offset, __entry->rq_size, __entry->status, __entry->bio, __entry->biotail)
+);
+
+TRACE_EVENT(
+	pxd_rq_fn,
+	TP_PROTO(uint64_t dev_id, int minor, int dir, uint32_t op,
+		uint64_t offset, uint64_t size, unsigned short nr_phys_segments,
+		uint32_t flags),
+	TP_ARGS(dev_id, minor, dir, op, offset, size, nr_phys_segments, flags),
+	TP_STRUCT__entry(
+		__field(uint64_t, dev_id)
+		__field(int, minor)
+		__field(int, dir)
+		__field(uint32_t, op)
+		__field(uint64_t, offset)
+		__field(uint64_t, size)
+		__field(unsigned short, nr_phys_segments)
+		__field(uint32_t, flags)
+	),
+	TP_fast_assign(
+		__entry->dev_id = dev_id,
+		__entry->minor = minor,
+		__entry->dir = dir,
+		__entry->op = op,
+		__entry->offset = offset,
+		__entry->size = size,
+		__entry->nr_phys_segments = nr_phys_segments,
+		__entry->flags = flags
+	),
+	TP_printk(
+		"dev_id %llu minor %d dir %d op %u offset %llu size %llu nr_phys_segments %u flags %x",
+		__entry->dev_id, __entry->minor, __entry->dir, __entry->op,
+		__entry->offset, __entry->size, __entry->nr_phys_segments,
+		__entry->flags)	
+);
+
+TRACE_EVENT(
 	pxd_request,
 	TP_PROTO(
 		uint64_t unique, uint32_t size, uint64_t off,
-		uint32_t minor, uint32_t flags),
-	TP_ARGS(unique, size, off, minor, flags),
+		uint32_t minor, uint32_t op, uint32_t flags),
+	TP_ARGS(unique, size, off, minor, op, flags),
 	TP_STRUCT__entry(
 		__field(uint64_t, unique)
 		__field(uint32_t, size)
 		__field(uint64_t, off)
 		__field(uint32_t, minor)
+		__field(uint32_t, op)
 		__field(uint32_t, flags)
 	),
 	TP_fast_assign(
@@ -116,12 +384,13 @@ TRACE_EVENT(
 		__entry->size = size,
 		__entry->off = off,
 		__entry->minor = minor,
+		__entry->op = op,
 		__entry->flags = flags
 	),
 	TP_printk(
-		"unique %llu size %u off %llu minor %u flags %x",
+		"unique %llu size %u off %llu minor %u op %uflags %x",
 		__entry->unique, __entry->size, __entry->off,
-		__entry->minor, __entry->flags)
+		__entry->minor, __entry->op, __entry->flags)
 );
 
 TRACE_EVENT(

--- a/pxd_trace.h
+++ b/pxd_trace.h
@@ -225,8 +225,8 @@ TRACE_EVENT(
 	pxd_queue_rq,
 	TP_PROTO(uint64_t dev_id, int minor, int dir, uint32_t op,
 		uint64_t offset, uint64_t size, unsigned short nr_phys_segments,
-		uint32_t flags, void *bio, void *bio_tail),
-	TP_ARGS(dev_id, minor, dir, op, offset, size, nr_phys_segments, flags, bio, bio_tail),
+		uint32_t flags, void *bio, void *bio_tail, bool single_bio, uint64_t bio_offset),
+	TP_ARGS(dev_id, minor, dir, op, offset, size, nr_phys_segments, flags, bio, bio_tail, single_bio, bio_offset),
 	TP_STRUCT__entry(
 		__field(uint64_t, dev_id)
 		__field(int, minor)
@@ -238,6 +238,8 @@ TRACE_EVENT(
 		__field(uint32_t, flags)
 		__field(void *, bio)
 		__field(void *, bio_tail)
+		__field(bool, single_bio)
+		__field(uint64_t, bio_offset)
 	),
 	TP_fast_assign(
 		__entry->dev_id = dev_id,
@@ -249,13 +251,15 @@ TRACE_EVENT(
 		__entry->nr_phys_segments = nr_phys_segments,
 		__entry->flags = flags,
 		__entry->bio = bio,
-		__entry->bio_tail = bio_tail
+		__entry->bio_tail = bio_tail,
+		__entry->single_bio = single_bio,
+		__entry->bio_offset = bio_offset
 	),
 	TP_printk(
-		"dev_id %llu minor %d dir %d op %u offset %llu size %llu nr_phys_segments %u flags %x bio %p bio_tail %p",
+		"dev_id %llu minor %d dir %d op %u rq_offset %llu size %llu nr_phys_segments %u flags %x bio %p bio_tail %p single_bio %d bio_offset %llu",
 		__entry->dev_id, __entry->minor, __entry->dir, __entry->op,
 		__entry->offset, __entry->size, __entry->nr_phys_segments,
-		__entry->flags, __entry->bio, __entry->bio_tail)
+		__entry->flags, __entry->bio, __entry->bio_tail, __entry->single_bio, __entry->bio_offset)
 );
 
 TRACE_EVENT(

--- a/pxd_trace.h
+++ b/pxd_trace.h
@@ -332,6 +332,74 @@ TRACE_EVENT(
 		__entry->rq_op, __entry->rq_offset, __entry->rq_size, __entry->status, __entry->bio, __entry->biotail)
 );
 
+TRACE_EVENT(
+	pxd_fastpath_reset_device,
+	TP_PROTO(uint64_t dev_id, int minor, bool ioswitch_active, uint64_t switch_uid),
+	TP_ARGS(dev_id, minor, ioswitch_active, switch_uid),
+	TP_STRUCT__entry(
+		__field(uint64_t, dev_id)
+		__field(int, minor)
+		__field(bool, ioswitch_active)
+		__field(uint64_t, switch_uid)
+	),
+	TP_fast_assign(
+		__entry->dev_id = dev_id,
+		__entry->minor = minor,
+		__entry->ioswitch_active = ioswitch_active,
+		__entry->switch_uid = switch_uid
+	),
+	TP_printk(
+		"dev_id %llu minor %d ioswitch_active %d switch_uid %llu, action = %s",
+		__entry->dev_id, __entry->minor, __entry->ioswitch_active, __entry->switch_uid, __entry->ioswitch_active ? "abort IOs" : "no action")
+);
+
+TRACE_EVENT(
+	fuse_notify_add_ext,
+	TP_PROTO(uint64_t dev_id, size_t size, int32_t queue_depth, int32_t discard_size, mode_t open_mode, int enable_fp, int path_count),
+	TP_ARGS(dev_id, size, queue_depth, discard_size, open_mode, enable_fp, path_count),
+	TP_STRUCT__entry(
+		__field(uint64_t, dev_id)
+		__field(size_t, size)
+		__field(int32_t, queue_depth)
+		__field(int32_t, discard_size)
+		__field(mode_t, open_mode)
+		__field(int, enable_fp)
+		__field(int, path_count)
+	),
+	TP_fast_assign(
+		__entry->dev_id = dev_id,
+		__entry->size = size,
+		__entry->queue_depth = queue_depth,
+		__entry->discard_size = discard_size,
+		__entry->open_mode = open_mode,
+		__entry->enable_fp = enable_fp,
+		__entry->path_count = path_count
+	),
+	TP_printk(
+		"dev_id %llu size %zu queue_depth %d discard_size %d open_mode %x enable_fp %d path_count %d",
+		__entry->dev_id, __entry->size, __entry->queue_depth, __entry->discard_size,
+		__entry->open_mode, __entry->enable_fp, __entry->path_count)
+);
+
+TRACE_EVENT(
+	pxd_export,
+	TP_PROTO(uint64_t dev_id, int minor, bool exported),
+	TP_ARGS(dev_id, minor, exported),
+	TP_STRUCT__entry(
+		__field(uint64_t, dev_id)
+		__field(int, minor)
+		__field(bool, exported)
+	),
+	TP_fast_assign(
+		__entry->dev_id = dev_id,
+		__entry->minor = minor,
+		__entry->exported = exported
+	),
+	TP_printk(
+		"dev_id %llu minor %d exported %d",
+		__entry->dev_id, __entry->minor, __entry->exported)
+);
+
 #ifndef TRACE_ENUM_DEFINED
 #define TRACE_ENUM_DEFINED
 enum {

--- a/pxd_trace.h
+++ b/pxd_trace.h
@@ -513,6 +513,27 @@ TRACE_EVENT(
 );
 
 TRACE_EVENT(
+	pxd_ioc_update_size,
+	TP_PROTO(uint64_t dev_id, int minor, uint64_t old_size, uint64_t new_size),
+	TP_ARGS(dev_id, minor, old_size, new_size),
+	TP_STRUCT__entry(
+		__field(uint64_t, dev_id)
+		__field(int, minor)
+		__field(uint64_t, old_size)
+		__field(uint64_t, new_size)
+	),
+	TP_fast_assign(
+		__entry->dev_id = dev_id,
+		__entry->minor = minor,
+		__entry->old_size = old_size,
+		__entry->new_size = new_size
+	),
+	TP_printk(
+		"dev_id %llu minor %d old_size %llu new_size %llu",
+		__entry->dev_id, __entry->minor, __entry->old_size, __entry->new_size)
+);
+
+TRACE_EVENT(
 	pxd_request_complete,
 	TP_PROTO(uint64_t dev_id, int minor, uint64_t unique, uint64_t offset, uint64_t len, uint32_t op, uint32_t flags, int status),
 	TP_ARGS(dev_id, minor, unique, offset, len, op, flags, status),

--- a/pxd_trace.h
+++ b/pxd_trace.h
@@ -339,7 +339,14 @@ enum {
 	TRANSITION_REISSUE_FAILQ,
 	TRANSITION_PXD_IO_FAILOVER
 };
+
+enum {
+	FAILOVER_REASON_IOFAILURE = 0,
+	FAILOVER_REASON_USERSPACE
+};
 #endif /* TRACE_ENUM_DEFINED */
+
+
 
 TRACE_EVENT(
 	pxd_reroute_slowpath_transition,
@@ -514,6 +521,61 @@ TRACE_EVENT(
 	TP_printk(
 		"status %d eintr %d",
 		__entry->status, __entry->eintr)
+);
+
+TRACE_EVENT(
+	pxd_initiate_failover,
+	TP_PROTO(uint64_t dev_id, int minor, int reason),
+	TP_ARGS(dev_id, minor, reason),
+	TP_STRUCT__entry(
+		__field(uint64_t, dev_id)
+		__field(int, minor)
+		__field(int, reason)
+	),
+	TP_fast_assign(
+		__entry->dev_id = dev_id,
+		__entry->minor = minor,
+		__entry->reason = reason
+	),
+	TP_printk(
+		"dev_id %llu minor %d reason %d",
+		__entry->dev_id, __entry->minor, __entry->reason)
+);
+
+TRACE_EVENT(
+	pxd_initiate_fallback,
+	TP_PROTO(uint64_t dev_id, int minor),
+	TP_ARGS(dev_id, minor),
+	TP_STRUCT__entry(
+		__field(uint64_t, dev_id)
+		__field(int, minor)
+	),
+	TP_fast_assign(
+		__entry->dev_id = dev_id,
+		__entry->minor = minor
+	),
+	TP_printk(
+		"dev_id %llu minor %d",
+		__entry->dev_id, __entry->minor)
+);
+
+TRACE_EVENT(
+	pxd_ioswitch_complete,
+	TP_PROTO(uint64_t dev_id, int minor, int opcode),
+	TP_ARGS(dev_id, minor, opcode),
+	TP_STRUCT__entry(
+		__field(uint64_t, dev_id)
+		__field(int, minor)
+		__field(int, opcode)
+	),
+	TP_fast_assign(
+		__entry->dev_id = dev_id,
+		__entry->minor = minor,
+		__entry->opcode = opcode
+	),
+	TP_printk(
+		"dev_id %llu minor %d opcode %d",
+		__entry->dev_id, __entry->minor, __entry->opcode)
 );
 #endif /* _PXD_TP_H */
 

--- a/pxd_trace.h
+++ b/pxd_trace.h
@@ -486,30 +486,34 @@ TRACE_EVENT(
 	pxd_request,
 	TP_PROTO(
 		uint64_t dev_id, uint64_t unique, uint32_t size, uint64_t off,
-		uint32_t minor, uint32_t op, uint32_t flags),
-	TP_ARGS(dev_id, unique, size, off, minor, op, flags),
-	TP_STRUCT__entry(
-		__field(uint64_t, dev_id)
-		__field(uint64_t, unique)
-		__field(uint32_t, size)
-		__field(uint64_t, off)
-		__field(uint32_t, minor)
-		__field(uint32_t, op)
-		__field(uint32_t, flags)
-	),
-	TP_fast_assign(
-		__entry->dev_id = dev_id,
-		__entry->unique = unique,
-		__entry->size = size,
-		__entry->off = off,
-		__entry->minor = minor,
-		__entry->op = op,
-		__entry->flags = flags
-	),
-	TP_printk(
-		"dev_id %llu unique %llu size %u off %llu minor %u op %uflags %x",
-		__entry->dev_id, __entry->unique, __entry->size, __entry->off,
-		__entry->minor, __entry->op, __entry->flags)
+		uint32_t minor, uint32_t req_op, uint32_t req_flags, uint32_t pxd_op, uint32_t pxd_flags),
+		TP_ARGS(dev_id, unique, size, off, minor, req_op, req_flags, pxd_op, pxd_flags),
+		TP_STRUCT__entry(
+			__field(uint64_t, dev_id)
+			__field(uint64_t, unique)
+			__field(uint32_t, size)
+			__field(uint64_t, off)
+			__field(uint32_t, minor)
+			__field(uint32_t, req_op)
+			__field(uint32_t, req_flags)
+			__field(uint32_t, pxd_op)
+			__field(uint32_t, pxd_flags)
+		),
+		TP_fast_assign(
+			__entry->dev_id = dev_id;
+			__entry->unique = unique;
+			__entry->size = size;
+			__entry->off = off;
+			__entry->minor = minor;
+			__entry->req_op = req_op;
+			__entry->req_flags = req_flags;
+			__entry->pxd_op = pxd_op;
+			__entry->pxd_flags = pxd_flags;
+		),
+		TP_printk(
+			"dev_id %llu unique %llu size %u off %llu minor %u req_op %u req_flags %x pxd_op %u pxd_flags %x",
+			__entry->dev_id, __entry->unique, __entry->size, __entry->off,
+			__entry->minor, __entry->req_op, __entry->req_flags, __entry->pxd_op, __entry->pxd_flags)
 );
 
 TRACE_EVENT(


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Adds the following traces

```
fastpath request/reply
nativepath request/reply, along with copying data from px-fuse to px-storage
fallback start and end
failover start and end
reroute to native path (there are multiple places where this can happen)
```
**Which issue(s) this PR fixes** (optional)
Closes # PWX-42981

**Special notes for your reviewer**:

