### PR TITLE
PWX-43148: cherrypick fastpath fix to comcast branch

### DIFF
--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -26,6 +26,10 @@
 #include "pxd_compat.h"
 #include "pxd_core.h"
 
+#ifdef CONFIG_BLK_CGROUP
+#include <linux/blk-cgroup.h>
+#endif
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0) || defined(REQ_PREFLUSH)
 inline bool rq_is_special(struct request *rq) {
         return (req_op(rq) == REQ_OP_DISCARD);

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -412,8 +412,13 @@ static struct bio *clone_root(struct fp_root_context *fproot, int i) {
         clone_bio->bi_end_io = end_clone_bio;
 
 #ifdef CONFIG_BLK_CGROUP
-        clone_bio->bi_blkg = NULL;
-        bio_associate_blkg_from_css(clone_bio, blkcg_root_css);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0) && defined(__EL8__))
+        if (clone_bio->bi_blkg == NULL)
+        	bio_associate_blkg_from_css(clone_bio, blkcg_root_css);
+#else
+        if (clone_bio->bi_css == NULL)
+        	bio_associate_blkcg(clone_bio, blkcg_root_css);
+#endif
 #endif
 
         atomic_inc(&nclones);

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -411,6 +411,11 @@ static struct bio *clone_root(struct fp_root_context *fproot, int i) {
         clone_bio->bi_private = fproot;
         clone_bio->bi_end_io = end_clone_bio;
 
+#ifdef CONFIG_BLK_CGROUP
+        clone_bio->bi_blkg = NULL;
+        bio_associate_blkg_from_css(clone_bio, blkcg_root_css);
+#endif
+
         atomic_inc(&nclones);
         return clone_bio;
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # PWX-43148

**Special notes for your reviewer**:

```
[root@ip-10-38-35-103 px-fuse]# KERNELPATH=/usr/src/kernels/$(uname -r) make
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
make  -C /usr/src/kernels/5.14.0-284.30.1.el9_2.x86_64  M=/root/px-fuse modules
make[1]: Entering directory '/usr/src/kernels/5.14.0-284.30.1.el9_2.x86_64'
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
  CC [M]  /root/px-fuse/pxd.o
  CC [M]  /root/px-fuse/dev.o
  CC [M]  /root/px-fuse/iov_iter.o
  CC [M]  /root/px-fuse/px_version.o
  CC [M]  /root/px-fuse/kiolib.o
  CC [M]  /root/px-fuse/pxd_bio_makereq.o
  CC [M]  /root/px-fuse/pxd_bio_blkmq.o
  CC [M]  /root/px-fuse/pxd_fastpath.o
  LD [M]  /root/px-fuse/px.o
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
  MODPOST /root/px-fuse/Module.symvers
  CC [M]  /root/px-fuse/px.mod.o
  LD [M]  /root/px-fuse/px.ko
  BTF [M] /root/px-fuse/px.ko
Skipping BTF generation for /root/px-fuse/px.ko due to unavailability of vmlinux
make[1]: Leaving directory '/usr/src/kernels/5.14.0-284.30.1.el9_2.x86_64'
```
Px came up fine with the kernel module


```
[root@ip-10-38-35-103 ~]# pxctl status 
Status: PX is operational
Telemetry: Disabled or Unhealthy
Metering: Disabled or Unhealthy
License: Trial (expires in 24 days)
Node ID: f6cb37a1-1234-411b-aea3-ba85d9871ee6
	IP: 10.38.35.103 
 	Local Storage Pool: 1 pool
	POOL	IO_PRIORITY	RAID_LEVEL	USABLE	USED	STATUS	ZONE	REGION
	0	HIGH		raid0		370 GiB	76 MiB	Online	default	default
	Local Storage Devices: 3 devices
	Device	Path		Media Type		Size		Last-Scan
	0:0	/dev/sdc	STORAGE_MEDIUM_SSD	128 GiB		08 Apr 25 03:49 CDT
	0:1	/dev/sde	STORAGE_MEDIUM_SSD	128 GiB		08 Apr 25 03:49 CDT
	0:2	/dev/sdf	STORAGE_MEDIUM_SSD	128 GiB		08 Apr 25 03:49 CDT
	total			-			384 GiB
	Cache Devices:
	 * No cache devices
	Kvdb Device:
	Device Path	Size
	/dev/sdb	64 GiB
	 * Internal kvdb on this node is using this dedicated kvdb device to store its data.
	Metadata Device: 
	1	/dev/sdd	STORAGE_MEDIUM_SSD	64 GiB
Cluster Summary
	Cluster ID: vpatidar-152
	Cluster UUID: aabcc6c1-6dbe-4946-9f0c-cb26fae5c7d0
	Scheduler: kubernetes
	Total Nodes: 3 node(s) with storage (2 online)
	IP		ID					SchedulerNodeName			Auth		StorageNode	Used		Capacity	Status	StorageStatus	Version		Kernel				OS
	10.38.35.103	f6cb37a1-1234-411b-aea3-ba85d9871ee6	ip-10-38-35-103.pwx.purestorage.com	Disabled	Yes(PX-StoreV2)	76 MiB		370 GiB		Online	Up (This node)	3.0.3-comcast-772c326	5.14.0-284.30.1.el9_2.x86_64	Rocky Linux 9.2 (Blue Onyx)
```

Fastpath vol got created and active after attach
```
[root@ip-10-38-35-103 ~]# pxctl v c --fastpath --nodes LocalNode vol1 
Volume successfully created: 1037701688788529268
[root@ip-10-38-35-103 ~]# pxctl v l
ID			NAME	SIZE	HA	SHARED	ENCRYPTED	PROXY-VOLUME	IO_PRIORITY	STATUS		SNAP-ENABLED	
1037701688788529268	vol1	1 GiB	1	no	no		no		LOW		up - detached	no
[root@ip-10-38-35-103 ~]# pxctl host attach vol1
Volume successfully attached at: /dev/pxd/pxd1037701688788529268
[root@ip-10-38-35-103 ~]# pxctl v i vol1 -j | jq '.[].fpConfig'
{
  "setup_on": 2,
  "promote": true,
  "status": "FASTPATH_ACTIVE",
  "replicas": [
    {
      "dev_id": "1037701688788529268",
      "node_id": 2,
      "protocol": "FASTPATH_PROTO_LOCAL",
      "acl": true,
      "exported_device": "/dev/pwx0/1037701688788529268",
      "block": true,
      "target": "/dev/pwx0/1037701688788529268",
      "exported": true,
      "imported": true,
      "devpath": "/dev/pwx0/1037701688788529268",
      "node_uuid": "f6cb37a1-1234-411b-aea3-ba85d9871ee6"
    }
  ],
  "dirty": false,
  "coord_uuid": "f6cb37a1-1234-411b-aea3-ba85d9871ee6",
  "force_failover": false
}
```

