### PR TITLE
PWX-42357, PWX-42656, PWX-42637 and PWX-42628

### DIFF
--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -214,10 +214,11 @@ void __pxd_abortfailQ(struct pxd_device *pxd_dev) {
 // no locking needed, @ios is a local list of IO to be reissued.
 void pxd_reissuefailQ(struct pxd_device *pxd_dev, struct list_head *ios,
                       int status) {
-        while (!list_empty(ios)) {
-                struct fp_root_context *fproot = list_first_entry(
-                    &pxd_dev->fp.failQ, struct fp_root_context, wait);
-                struct fuse_req *req = fproot_to_fuse_request(fproot);
+        struct fp_root_context *fproot;
+        struct fp_root_context *tmp;
+
+        list_for_each_entry_safe(fproot, tmp, ios, wait) {
+                struct fuse_req* req = fproot_to_fuse_request(fproot);
                 BUG_ON(fproot->magic != FP_ROOT_MAGIC);
                 list_del(&fproot->wait);
                 clone_cleanup(fproot);

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -50,8 +50,14 @@ struct pxd_device {
 	unsigned int discard_size;
 
 #define PXD_ACTIVE(pxd_dev)  (atomic_read(&pxd_dev->ncount))
+	// [global] total active requests
+	// usually, this is incremented on submitting IO and decremented on
+	// successful IO completion. But, say the iopath is remote fastpath
+	// and the IO fails => retry IO in native path. native path also
+	// increments/decrements the ncount => ncount should be decremented
+	// even on IO failure in fastpath.
+	atomic_t ncount;
 	// congestion handling
-	atomic_t ncount; // [global] total active requests, always modify with pxd_dev.lock
 	unsigned int qdepth;
 	atomic_t congested;
 	bool exported;

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -280,12 +280,48 @@ int pxd_request_ioswitch(struct pxd_device *pxd_dev, int code)
 	}
 }
 
+#define SYNC_TIMEOUT (60000)
+static int wait_for_sync(struct pxd_device *pxd_dev, bool skipsync)
+{
+        struct pxd_fastpath_extension *fp = &pxd_dev->fp;
+        int i;
+        // assumes fastpath_enabled() is true
+        // and IO is already suspended
+        BUG_ON(!fastpath_enabled(pxd_dev));
+        BUG_ON(!atomic_read(&fp->suspend));
+
+        if (skipsync) return 0;
+
+        if (pxd_sync_work_pending(pxd_dev)) {
+                printk(KERN_INFO "device %llu sync work pending\n", pxd_dev->dev_id);
+                return -EBUSY;
+        }
+
+        atomic_set(&fp->sync_done, MAX_PXD_BACKING_DEVS);
+        reinit_completion(&fp->sync_complete);
+        for (i = 0; i < MAX_PXD_BACKING_DEVS; i++) {
+                queue_work(fastpath_workqueue(), &fp->syncwi[i].ws);
+        }
+
+        if (!wait_for_completion_timeout(&fp->sync_complete,
+                                                msecs_to_jiffies(SYNC_TIMEOUT))) {
+                // suspend aborted as sync timedout
+                return -EBUSY;
+        }
+
+        for (i = 0; i < MAX_PXD_BACKING_DEVS; i++) {
+                // capture first failure
+                if (fp->syncwi[i].rc) return fp->syncwi[i].rc;
+        }
+
+        return 0;
+}
+
 // shall be called internally during iopath switching.
 int pxd_request_suspend_internal(struct pxd_device *pxd_dev,
 		bool skip_flush, bool coe)
 {
 	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
-	int i;
 	int rc;
 
 	if (!fastpath_enabled(pxd_dev)) {
@@ -301,28 +337,9 @@ int pxd_request_suspend_internal(struct pxd_device *pxd_dev,
 
 	if (skip_flush || !fp->fastpath) return 0;
 
-	atomic_set(&fp->sync_done, MAX_PXD_BACKING_DEVS);
-	reinit_completion(&fp->sync_complete);
-	for (i = 0; i < MAX_PXD_BACKING_DEVS; i++) {
-		queue_work(fastpath_workqueue(), &fp->syncwi[i].ws);
-	}
-
-#define SYNC_TIMEOUT (60000)
-	rc = 0;
-	if (!wait_for_completion_timeout(&fp->sync_complete,
-						msecs_to_jiffies(SYNC_TIMEOUT))) {
-		// suspend aborted as sync timedout
-		rc = -EBUSY;
+	rc = wait_for_sync(pxd_dev, skip_flush);
+	if (rc)
 		goto fail;
-	}
-
-	// consolidate responses
-	for (i = 0; i < MAX_PXD_BACKING_DEVS; i++) {
-		// capture first failure
-		rc = fp->syncwi[i].rc;
-		if (rc) goto fail;
-	}
-
 	printk(KERN_NOTICE"device %llu suspended IO from userspace\n", pxd_dev->dev_id);
 	return 0;
 fail:
@@ -500,14 +517,17 @@ void disableFastPath(struct pxd_device *pxd_dev, bool skipsync)
 			__func__, pxd_dev->dev_id, PXD_ACTIVE(pxd_dev));
 	}
 
+	if (!skipsync) {
+		int rc;
+		rc = wait_for_sync(pxd_dev, skipsync);
+		if (unlikely(rc) && rc != -EINVAL && rc != -EIO) {
+			printk(KERN_ERR"device %llu sync failed %d, continuing with disable\n",
+					pxd_dev->dev_id, rc);
+		}
+	}
+
 	for (i = 0; i < nfd; i++) {
-		if (fp->file[i]) {
-			if (!skipsync) {
-				int ret = vfs_fsync(fp->file[i], 0);
-				if (unlikely(ret && ret != -EINVAL && ret != -EIO)) {
-					printk(KERN_WARNING"device %llu fsync failed with %d\n", pxd_dev->dev_id, ret);
-				}
-			}
+		if (fp->file[i] != NULL) {
 			filp_close(fp->file[i], NULL);
 			fp->file[i] = NULL;
 		}

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -487,7 +487,7 @@ void disableFastPath(struct pxd_device *pxd_dev, bool skipsync)
 
 	if (!fastpath_enabled(pxd_dev) || !pxd_dev->fp.nfd ||
 			!fastpath_active(pxd_dev)) {
-		pxd_dev->fp.active_failover = false;
+		pxd_dev->fp.nfd = 0;
 		pxd_dev->fp.fastpath = false;
 		return;
 	}
@@ -514,7 +514,6 @@ void disableFastPath(struct pxd_device *pxd_dev, bool skipsync)
 	}
 	fp->nfd = 0;
 	pxd_dev->fp.fastpath = false;
-	pxd_dev->fp.can_failover = false;
 
 	pxd_resume_io(pxd_dev);
 }


### PR DESCRIPTION
This PR has fixes for PWX-42357, PWX-42656, PWX-42637 and PWX-42628 since I don't have a UT that validates only one.

**UT notes for PWX-42357**

**Without fix**
```
./t --gtest_filter=*IoFailureTriggeredFailoverNoScale*
Note: Google Test filter = *IoFailureTriggeredFailoverNoScale*
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from FailoverTest
[ RUN      ] FailoverTest.IoFailureTriggeredFailoverNoScale
25600+0 records in
25600+0 records out
104857600 bytes (105 MB, 100 MiB) copied, 0.407803 s, 257 MB/s
mke2fs 1.44.1 (24-Mar-2018)
Discarding device blocks: done                            
Creating filesystem with 25600 4k blocks and 25600 inodes

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (1024 blocks): done
Writing superblocks and filesystem accounting information: done

Executing: sudo dmsetup create flakey_test_loop13 < /tmp/dm_table_B1iOiI
Executing: sudo dmsetup create delay_test_loop13 < /tmp/dm_table_GCOiuH
Added device /dev/mapper/delay_test_loop13 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
executing cmd sudo dd if=/dev/zero of=/dev/pxd/pxd1234 bs=4K count=1 seek=12800
1+0 records in
1+0 records out
4096 bytes (4.1 kB, 4.0 KiB) copied, 7.5672e-05 s, 54.1 MB/s
epoll_wait returned 1
got event from kernel
Processing request opcode: 8208 minor: 1 num_volumes: 1
active_idx : 0
Got failover request
Added device /dev/mapper/flakey_test_loop13 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
sending reply for opcode : 8208 unique: 262144
```

```
[Wed Apr  9 20:18:48 2025] kernel BUG at /root/fuse/px-fuse/pxd_bio_blkmq.c:221!
[Wed Apr  9 20:18:48 2025] invalid opcode: 0000 [#1] SMP PTI
[Wed Apr  9 20:18:48 2025] CPU: 7 PID: 2079287 Comm: t Tainted: G           OE     5.4.0-212-generic #232-Ubuntu
[Wed Apr  9 20:18:48 2025] Hardware name: VMware, Inc. VMware Virtual Platform/440BX Desktop Reference Platform, BIOS 6.00 11/12/2020
[Wed Apr  9 20:18:48 2025] RIP: 0010:pxd_reissuefailQ+0xcb/0xd0 [px]
[Wed Apr  9 20:18:48 2025] Code: 00 00 f0 41 ff 84 24 c4 05 00 00 49 8d be f8 fe ff ff e8 28 c1 ff ff 48 8b 03 48 39 c3 75 89 5b 41 5c 41 5d 41 5e 41 5f 5d c3 <0f> 0b c3 66 90 0f 1f 44 00 00 55 48 89 e5 41 57 41 56 41 55 41 54
[Wed Apr  9 20:18:49 2025] RSP: 0018:ffffae10c17cfca0 EFLAGS: 00010217
[Wed Apr  9 20:18:49 2025] RAX: ffff92d4f4b906a8 RBX: ffffae10c17cfcd8 RCX: 0000000000000006
[Wed Apr  9 20:18:49 2025] RDX: 0000000000000000 RSI: ffffae10c17cfcd8 RDI: ffff92d8588263d8
[Wed Apr  9 20:18:49 2025] RBP: ffffae10c17cfcc8 R08: 000000000002bd05 R09: 0000000000000004
[Wed Apr  9 20:18:49 2025] R10: 0000000000000000 R11: 0000000000000001 R12: ffff92d858826000
[Wed Apr  9 20:18:49 2025] R13: 0000000000000000 R14: ffff92d858826418 R15: dead000000000100
[Wed Apr  9 20:18:49 2025] FS:  00007f0ced84b700(0000) GS:ffff92d85f9c0000(0000) knlGS:0000000000000000
[Wed Apr  9 20:18:49 2025] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[Wed Apr  9 20:18:49 2025] CR2: 00007f0ced849d70 CR3: 00000006062ba001 CR4: 00000000003606e0
[Wed Apr  9 20:18:49 2025] Call Trace:
[Wed Apr  9 20:18:49 2025]  ? show_regs.cold+0x1a/0x1f
[Wed Apr  9 20:18:49 2025]  ? __die+0x90/0xd9
[Wed Apr  9 20:18:49 2025]  ? die+0x30/0x50
[Wed Apr  9 20:18:49 2025]  ? do_trap+0x85/0xf0
[Wed Apr  9 20:18:49 2025]  ? do_error_trap+0x7c/0xc0
[Wed Apr  9 20:18:49 2025]  ? pxd_reissuefailQ+0xcb/0xd0 [px]
[Wed Apr  9 20:18:49 2025]  ? do_invalid_op+0x3c/0x50
[Wed Apr  9 20:18:49 2025]  ? pxd_reissuefailQ+0xcb/0xd0 [px]
[Wed Apr  9 20:18:49 2025]  ? invalid_op+0x1e/0x30
[Wed Apr  9 20:18:49 2025]  ? pxd_reissuefailQ+0xcb/0xd0 [px]
[Wed Apr  9 20:18:49 2025]  pxd_process_ioswitch_complete.cold+0xca/0xd4 [px]
[Wed Apr  9 20:18:49 2025]  request_end+0x74/0x160 [px]
[Wed Apr  9 20:18:49 2025]  fuse_dev_write_iter+0x293/0x5d0 [px]
[Wed Apr  9 20:18:49 2025]  new_sync_write+0x125/0x1c0
[Wed Apr  9 20:18:49 2025]  __vfs_write+0x29/0x40
[Wed Apr  9 20:18:49 2025]  vfs_write+0xb9/0x1a0
[Wed Apr  9 20:18:49 2025]  ksys_write+0x67/0xe0
[Wed Apr  9 20:18:49 2025]  __x64_sys_write+0x1a/0x20
[Wed Apr  9 20:18:49 2025]  do_syscall_64+0x57/0x190
[Wed Apr  9 20:18:49 2025]  entry_SYSCALL_64_after_hwframe+0x61/0xc6
[Wed Apr  9 20:18:49 2025] RIP: 0033:0x7f0cf48df32f
[Wed Apr  9 20:18:49 2025] Code: 89 54 24 18 48 89 74 24 10 89 7c 24 08 e8 29 fd ff ff 48 8b 54 24 18 48 8b 74 24 10 41 89 c0 8b 7c 24 08 b8 01 00 00 00 0f 05 <48> 3d 00 f0 ff ff 77 2d 44 89 c7 48 89 44 24 08 e8 5c fd ff ff 48
[Wed Apr  9 20:18:49 2025] RSP: 002b:00007f0ced84a7c0 EFLAGS: 00000293 ORIG_RAX: 0000000000000001
[Wed Apr  9 20:18:49 2025] RAX: ffffffffffffffda RBX: 0000558c37cd17e0 RCX: 00007f0cf48df32f
[Wed Apr  9 20:18:49 2025] RDX: 0000000000000010 RSI: 00007f0ced84a8a0 RDI: 0000000000000004
[Wed Apr  9 20:18:49 2025] RBP: 00007ffe14cac340 R08: 0000000000000000 R09: 00007f0ced84a700
[Wed Apr  9 20:18:49 2025] R10: cccccccccccccccd R11: 0000000000000293 R12: 00007f0ced84a910
[Wed Apr  9 20:18:49 2025] R13: 0000558c37cd17e0 R14: 00007f0ced84a8a0 R15: 0000000000000001
```

**After fix**

```
./t --gtest_filter=*IoFailureTriggeredFailoverNoScale*
Note: Google Test filter = *IoFailureTriggeredFailoverNoScale*
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from FailoverTest
[ RUN      ] FailoverTest.IoFailureTriggeredFailoverNoScale
25600+0 records in
25600+0 records out
104857600 bytes (105 MB, 100 MiB) copied, 0.36986 s, 284 MB/s
mke2fs 1.44.1 (24-Mar-2018)
Discarding device blocks: done                            
Creating filesystem with 25600 4k blocks and 25600 inodes

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (1024 blocks): done
Writing superblocks and filesystem accounting information: done

Executing: sudo dmsetup create flakey_test_loop10 < /tmp/dm_table_n0ZS0L
Executing: sudo dmsetup create delay_test_loop10 < /tmp/dm_table_K7T91O
Added device /dev/mapper/delay_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
executing cmd sudo dd if=/dev/zero of=/dev/pxd/pxd1234 bs=4K count=1 seek=12800
1+0 records in
1+0 records out
4096 bytes (4.1 kB, 4.0 KiB) copied, 7.5213e-05 s, 54.5 MB/s
epoll_wait returned 1
got event from kernel
Processing request opcode: 8208 minor: 1 num_volumes: 1
active_idx : 0
Got failover request
Added device /dev/mapper/flakey_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
sending reply for opcode : 8208 unique: 262144
epoll_wait returned 1
got event from kernel
Processing request opcode: 8193 minor: 1 num_volumes: 1
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 2
sending reply for opcode : 8193 unique: 262272
...skip
```

and no kernel panic in dmesg.


**UT notes for PWX-42628**

**Without fix** 

```
./t --gtest_filter=*IoFailureTriggeredFailoverNoScale*
Note: Google Test filter = *IoFailureTriggeredFailoverNoScale*
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from FailoverTest
[ RUN      ] FailoverTest.IoFailureTriggeredFailoverNoScale
25600+0 records in
25600+0 records out
104857600 bytes (105 MB, 100 MiB) copied, 0.36986 s, 284 MB/s
mke2fs 1.44.1 (24-Mar-2018)
Discarding device blocks: done                            
Creating filesystem with 25600 4k blocks and 25600 inodes

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (1024 blocks): done
Writing superblocks and filesystem accounting information: done

Executing: sudo dmsetup create flakey_test_loop10 < /tmp/dm_table_n0ZS0L
Executing: sudo dmsetup create delay_test_loop10 < /tmp/dm_table_K7T91O
Added device /dev/mapper/delay_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
executing cmd sudo dd if=/dev/zero of=/dev/pxd/pxd1234 bs=4K count=1 seek=12800
1+0 records in
1+0 records out
4096 bytes (4.1 kB, 4.0 KiB) copied, 7.5213e-05 s, 54.5 MB/s
epoll_wait returned 1
got event from kernel
Processing request opcode: 8208 minor: 1 num_volumes: 1
active_idx : 0
Got failover request
Added device /dev/mapper/flakey_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
sending reply for opcode : 8208 unique: 262144
epoll_wait returned 1
got event from kernel
Processing request opcode: 8193 minor: 1 num_volumes: 1
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 2
sending reply for opcode : 8193 unique: 262272
epoll_wait returned 1
got event from kernel
Processing request opcode: 8209 minor: 1 num_volumes: 1
active_idx : 0
Added device /dev/mapper/delay_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
sending reply for opcode : 8209 unique: 262400
epoll_wait returned 1
done with the control thread
time="2025-04-09 20:22:54Z" level=INFO msg="nr_failover_to_userspace : 0, nr_fallback_to_kernel : 0, nr_unknown : 0"
gdsd/test/pxd_test.cc:862: Failure
Value of: PxdUtil::active_io_count(expected[i].minor) == 0
  Actual: false
Expected: true
rmmod: ERROR: Module px is in use
gdsd/test/pxd_test.cc:582: Failure
      Expected: 0
To be equal to: px::system("sudo rmmod px_fuse/px.ko")
      Which is: 256
[  FAILED  ] FailoverTest.IoFailureTriggeredFailoverNoScale (1690 ms)
[----------] 1 test from FailoverTest (1690 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (1691 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] FailoverTest.IoFailureTriggeredFailoverNoScale

 1 FAILED TEST
time="2025-04-09 20:22:55Z" level=INFO msg="Shutting down System Monitor"
```

**After fix**

```
./t --gtest_filter=*IoFailureTriggeredFailoverNoScale*
Note: Google Test filter = *IoFailureTriggeredFailoverNoScale*
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from FailoverTest
[ RUN      ] FailoverTest.IoFailureTriggeredFailoverNoScale
25600+0 records in
25600+0 records out
104857600 bytes (105 MB, 100 MiB) copied, 0.370039 s, 283 MB/s
mke2fs 1.44.1 (24-Mar-2018)
Discarding device blocks: done                            
Creating filesystem with 25600 4k blocks and 25600 inodes

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (1024 blocks): done
Writing superblocks and filesystem accounting information: done

Executing: sudo dmsetup create flakey_test_loop10 < /tmp/dm_table_5M1POM
Executing: sudo dmsetup create delay_test_loop10 < /tmp/dm_table_BHrDCL
Added device /dev/mapper/delay_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
executing cmd sudo dd if=/dev/zero of=/dev/pxd/pxd1234 bs=4K count=1 seek=12800
1+0 records in
1+0 records out
4096 bytes (4.1 kB, 4.0 KiB) copied, 7.8756e-05 s, 52.0 MB/s
epoll_wait returned 1
got event from kernel
Processing request opcode: 8208 minor: 1 num_volumes: 1
active_idx : 0
Got failover request
Added device /dev/mapper/flakey_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
sending reply for opcode : 8208 unique: 262144
epoll_wait returned 1
got event from kernel
Processing request opcode: 8193 minor: 1 num_volumes: 1
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 1
sending reply for opcode : 8193 unique: 262272
epoll_wait returned 1
got event from kernel
Processing request opcode: 8209 minor: 1 num_volumes: 1
active_idx : 0
Added device /dev/mapper/delay_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
sending reply for opcode : 8209 unique: 262400
epoll_wait returned 1
done with the control thread
time="2025-04-09 20:35:14Z" level=INFO msg="nr_failover_to_userspace : 0, nr_fallback_to_kernel : 0, nr_unknown : 0"
[       OK ] FailoverTest.IoFailureTriggeredFailoverNoScale (1799 ms)
[----------] 1 test from FailoverTest (1799 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (1800 ms total)
[  PASSED  ] 1 test.
time="2025-04-09 20:35:14Z" level=INFO msg="Shutting down System Monitor"
```


**UT notes for PWX-42656**

**Before fix**
```
./t --gtest_filter=*NodeDownTriggerFailoverWithMultipleIOs*
Note: Google Test filter = *NodeDownTriggerFailoverWithMultipleIOs*
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from FailoverTest
[ RUN      ] FailoverTest.NodeDownTriggerFailoverWithMultipleIOsNoScale_
25600+0 records in
25600+0 records out
104857600 bytes (105 MB, 100 MiB) copied, 0.38183 s, 275 MB/s
mke2fs 1.44.1 (24-Mar-2018)
Discarding device blocks: done                            
Creating filesystem with 25600 4k blocks and 25600 inodes

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (1024 blocks): done
Writing superblocks and filesystem accounting information: done

Executing: sudo dmsetup create flakey_test_loop10 < /tmp/dm_table_9tRZn9
Executing: sudo dmsetup create delay_test_loop10 < /tmp/dm_table_4JKsR6
Added device /dev/mapper/delay_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
executing cmd sudo fio --name=test --filename=/dev/pxd/pxd1234 --ioengine=libaio --rw=write --bs=4k --offset=52428800 --size=4k --direct=1 --iodepth=256 --numjobs=2
test: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
...
fio-3.1
Starting 2 processes
[failover] Sent PXD_FAILOVER_TO_USERSPACE.
epoll_wait returned 1
got event from kernel
Processing request opcode: 8208 minor: 1 num_volumes: 8
active_idx : 0
Got failover request
Added device /dev/mapper/flakey_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
sending reply for opcode : 8208 unique: 262144
fio: io_u error on file /dev/pxd/pxd1234: Input/output error: write offset=52428800, buflen=4096
test: No I/O performed by libaio, perhaps try --debug=io option for details?
fio: pid=165, err=5/file:io_u.c:1756, func=io_u error, error=Input/output error
fio: io_u error on file /dev/pxd/pxd1234: Input/output error: write offset=52428800, buflen=4096
test: No I/O performed by libaio, perhaps try --debug=io option for details?
fio: pid=164, err=5/file:io_u.c:1756, func=io_u error, error=Input/output error
Jobs: 2 (f=0): [f(2)][-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
test: (groupid=0, jobs=1): err= 5 (file:io_u.c:1756, func=io_u error, error=Input/output error): pid=164: Wed Apr  9 20:42:29 2025
  cpu          : usr=0.02%, sys=0.00%, ctx=1, majf=0, minf=20
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 5 (file:io_u.c:1756, func=io_u error, error=Input/output error): pid=165: Wed Apr  9 20:42:29 2025
  cpu          : usr=0.05%, sys=0.00%, ctx=1, majf=0, minf=18
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256

Run status group 0 (all jobs):

Disk stats (read/write):
  pxd!pxd1234: ios=0/0, merge=0/0, ticks=0/0, in_queue=0, util=0.10%
gdsd/test/pxd_test.cc:1049: Failure
      Expected: 0
To be equal to: px::system(cmd.c_str())
      Which is: 512
gdsd/test/pxd_test.cc:1072: Failure
Value of: px::test::wait_for(2s, [&]() -> bool { return ios_done_[i].load(); })
  Actual: false
Expected: true
terminate called without an active exception
```

**After fix**

```
./t --gtest_filter=*NodeDownTriggerFailoverWithMultipleIOs*
Note: Google Test filter = *NodeDownTriggerFailoverWithMultipleIOs*
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from FailoverTest
[ RUN      ] FailoverTest.NodeDownTriggerFailoverWithMultipleIOsNoScale_
25600+0 records in
25600+0 records out
104857600 bytes (105 MB, 100 MiB) copied, 0.373721 s, 281 MB/s
mke2fs 1.44.1 (24-Mar-2018)
Discarding device blocks: done                            
Creating filesystem with 25600 4k blocks and 25600 inodes

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (1024 blocks): done
Writing superblocks and filesystem accounting information: done

Executing: sudo dmsetup create flakey_test_loop10 < /tmp/dm_table_ci9esM
Executing: sudo dmsetup create delay_test_loop10 < /tmp/dm_table_hGGT9O
Added device /dev/mapper/delay_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
executing cmd sudo fio --name=test --filename=/dev/pxd/pxd1234 --ioengine=libaio --rw=write --bs=4k --offset=52428800 --size=4k --direct=1 --iodepth=256 --numjobs=2
test: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
...
fio-3.1
Starting 2 processes
[failover] Sent PXD_FAILOVER_TO_USERSPACE.
epoll_wait returned 1
got event from kernel
Processing request opcode: 8208 minor: 1 num_volumes: 8
active_idx : 0
Got failover request
Added device /dev/mapper/flakey_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
sending reply for opcode : 8208 unique: 262144
epoll_wait returned 1[-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
got event from kernel
Processing request opcode: 8193 minor: 1 num_volumes: 8
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 2
sending reply for opcode : 8193 unique: 262272
Processing request opcode: 8193 minor: 1 num_volumes: 8
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 1
sending reply for opcode : 8193 unique: 262273

test: (groupid=0, jobs=1): err= 0: pid=122: Wed Apr  9 20:46:24 2025
  write: IOPS=0, BW=993B/s (993B/s)(4096B/4123msec)
    slat (nsec): min=168727, max=168727, avg=168727.00, stdev= 0.00
    clat (nsec): min=4121.0M, max=4121.0M, avg=4121970355.00, stdev= 0.00
     lat (nsec): min=4122.1M, max=4122.1M, avg=4122140192.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 4111],  5.00th=[ 4111], 10.00th=[ 4111], 20.00th=[ 4111],
     | 30.00th=[ 4111], 40.00th=[ 4111], 50.00th=[ 4111], 60.00th=[ 4111],
     | 70.00th=[ 4111], 80.00th=[ 4111], 90.00th=[ 4111], 95.00th=[ 4111],
     | 99.00th=[ 4111], 99.50th=[ 4111], 99.90th=[ 4111], 99.95th=[ 4111],
     | 99.99th=[ 4111]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.02%, sys=0.00%, ctx=3, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=123: Wed Apr  9 20:46:24 2025
  write: IOPS=0, BW=993B/s (993B/s)(4096B/4123msec)
    slat (nsec): min=83949, max=83949, avg=83949.00, stdev= 0.00
    clat (nsec): min=4122.2M, max=4122.2M, avg=4122219472.00, stdev= 0.00
     lat (nsec): min=4122.3M, max=4122.3M, avg=4122304909.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 4111],  5.00th=[ 4111], 10.00th=[ 4111], 20.00th=[ 4111],
     | 30.00th=[ 4111], 40.00th=[ 4111], 50.00th=[ 4111], 60.00th=[ 4111],
     | 70.00th=[ 4111], 80.00th=[ 4111], 90.00th=[ 4111], 95.00th=[ 4111],
     | 99.00th=[ 4111], 99.50th=[ 4111], 99.90th=[ 4111], 99.95th=[ 4111],
     | 99.99th=[ 4111]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.02%, ctx=1, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256

Run status group 0 (all jobs):
  WRITE: bw=1986B/s (1986B/s), 993B/s-993B/s (993B/s-993B/s), io=8192B (8192B), run=4123-4123msec

Disk stats (read/write):
  pxd!pxd1234: ios=0/0, merge=0/0, ticks=0/0, in_queue=0, util=0.09%
epoll_wait returned 1
got event from kernel
Processing request opcode: 8209 minor: 1 num_volumes: 8
active_idx : 0
Added device /dev/mapper/delay_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
sending reply for opcode : 8209 unique: 262400
epoll_wait returned 1
done with the control thread
time="2025-04-09 20:46:24Z" level=INFO msg="nr_failover_to_userspace : 0, nr_fallback_to_kernel : 0, nr_unknown : 0"
[       OK ] FailoverTest.NodeDownTriggerFailoverWithMultipleIOsNoScale_ (6451 ms)
[ RUN      ] FailoverTest.Scale_NodeDownTriggerFailoverWithMultipleIOs
25600+0 records in
25600+0 records out
104857600 bytes (105 MB, 100 MiB) copied, 0.383983 s, 273 MB/s
mke2fs 1.44.1 (24-Mar-2018)
Discarding device blocks: done                            
Creating filesystem with 25600 4k blocks and 25600 inodes

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (1024 blocks): done
Writing superblocks and filesystem accounting information: done

Executing: sudo dmsetup create flakey_test_loop10 < /tmp/dm_table_DQEmZL
Executing: sudo dmsetup create delay_test_loop10 < /tmp/dm_table_czYnUO
25600+0 records in
25600+0 records out
104857600 bytes (105 MB, 100 MiB) copied, 0.361137 s, 290 MB/s
mke2fs 1.44.1 (24-Mar-2018)
Discarding device blocks: done                            
Creating filesystem with 25600 4k blocks and 25600 inodes

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (1024 blocks): done
Writing superblocks and filesystem accounting information: done

Executing: sudo dmsetup create flakey_test_loop11 < /tmp/dm_table_ZU53bP
Executing: sudo dmsetup create delay_test_loop11 < /tmp/dm_table_EM1LcN
25600+0 records in
25600+0 records out
104857600 bytes (105 MB, 100 MiB) copied, 0.382805 s, 274 MB/s
mke2fs 1.44.1 (24-Mar-2018)
Discarding device blocks: done                            
Creating filesystem with 25600 4k blocks and 25600 inodes

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (1024 blocks): done
Writing superblocks and filesystem accounting information: done

Executing: sudo dmsetup create flakey_test_loop12 < /tmp/dm_table_IYOquM
Executing: sudo dmsetup create delay_test_loop12 < /tmp/dm_table_MmqmdM
25600+0 records in
25600+0 records out
104857600 bytes (105 MB, 100 MiB) copied, 0.361074 s, 290 MB/s
mke2fs 1.44.1 (24-Mar-2018)
Discarding device blocks: done                            
Creating filesystem with 25600 4k blocks and 25600 inodes

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (1024 blocks): done
Writing superblocks and filesystem accounting information: done

Executing: sudo dmsetup create flakey_test_loop13 < /tmp/dm_table_p31lIP
Executing: sudo dmsetup create delay_test_loop13 < /tmp/dm_table_l2MNSM
25600+0 records in
25600+0 records out
104857600 bytes (105 MB, 100 MiB) copied, 0.364984 s, 287 MB/s
mke2fs 1.44.1 (24-Mar-2018)
Discarding device blocks: done                            
Creating filesystem with 25600 4k blocks and 25600 inodes

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (1024 blocks): done
Writing superblocks and filesystem accounting information: done

Executing: sudo dmsetup create flakey_test_loop14 < /tmp/dm_table_6FMg9N
Executing: sudo dmsetup create delay_test_loop14 < /tmp/dm_table_dFv0kO
25600+0 records in
25600+0 records out
104857600 bytes (105 MB, 100 MiB) copied, 0.357989 s, 293 MB/s
mke2fs 1.44.1 (24-Mar-2018)
Discarding device blocks: done                            
Creating filesystem with 25600 4k blocks and 25600 inodes

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (1024 blocks): done
Writing superblocks and filesystem accounting information: done

Executing: sudo dmsetup create flakey_test_loop15 < /tmp/dm_table_AqQMKP
Executing: sudo dmsetup create delay_test_loop15 < /tmp/dm_table_rbXyAN
25600+0 records in
25600+0 records out
104857600 bytes (105 MB, 100 MiB) copied, 0.377335 s, 278 MB/s
mke2fs 1.44.1 (24-Mar-2018)
Discarding device blocks: done                            
Creating filesystem with 25600 4k blocks and 25600 inodes

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (1024 blocks): done
Writing superblocks and filesystem accounting information: done

Executing: sudo dmsetup create flakey_test_loop16 < /tmp/dm_table_XEYL7O
Executing: sudo dmsetup create delay_test_loop16 < /tmp/dm_table_OUqylM
25600+0 records in
25600+0 records out
104857600 bytes (105 MB, 100 MiB) copied, 0.380784 s, 275 MB/s
mke2fs 1.44.1 (24-Mar-2018)
Discarding device blocks: done                            
Creating filesystem with 25600 4k blocks and 25600 inodes

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (1024 blocks): done
Writing superblocks and filesystem accounting information: done

Executing: sudo dmsetup create flakey_test_loop17 < /tmp/dm_table_weTlsL
Executing: sudo dmsetup create delay_test_loop17 < /tmp/dm_table_VxzMEN
Added device /dev/mapper/delay_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
Added device /dev/mapper/delay_test_loop11 minor 2 dev_id 1235
Pxd path /dev/pxd/pxd1235
Added device /dev/mapper/delay_test_loop12 minor 3 dev_id 1236
Pxd path /dev/pxd/pxd1236
Added device /dev/mapper/delay_test_loop13 minor 4 dev_id 1237
Pxd path /dev/pxd/pxd1237
Added device /dev/mapper/delay_test_loop14 minor 5 dev_id 1238
Pxd path /dev/pxd/pxd1238
Added device /dev/mapper/delay_test_loop15 minor 6 dev_id 1239
Pxd path /dev/pxd/pxd1239
Added device /dev/mapper/delay_test_loop16 minor 7 dev_id 1240
Pxd path /dev/pxd/pxd1240
Added device /dev/mapper/delay_test_loop17 minor 8 dev_id 1241
Pxd path /dev/pxd/pxd1241
executing cmd sudo fio --name=test --filename=/dev/pxd/pxd1234 --ioengine=libaio --rw=write --bs=4k --offset=52428800 --size=4k --direct=1 --iodepth=256 --numjobs=2
executing cmd sudo fio --name=test --filename=/dev/pxd/pxd1236 --ioengine=libaio --rw=write --bs=4k --offset=52428800 --size=4k --direct=1 --iodepth=256 --numjobs=2
executing cmd sudo fio --name=test --filename=/dev/pxd/pxd1237 --ioengine=libaio --rw=write --bs=4k --offset=52428800 --size=4k --direct=1 --iodepth=256 --numjobs=2
executing cmd sudo fio --name=test --filename=/dev/pxd/pxd1235 --ioengine=libaio --rw=write --bs=4k --offset=52428800 --size=4k --direct=1 --iodepth=256 --numjobs=2
executing cmd sudo fio --name=test --filename=/dev/pxd/pxd1238 --ioengine=libaio --rw=write --bs=4k --offset=52428800 --size=4k --direct=1 --iodepth=256 --numjobs=2
executing cmd sudo fio --name=test --filename=/dev/pxd/pxd1239 --ioengine=libaio --rw=write --bs=4k --offset=52428800 --size=4k --direct=1 --iodepth=256 --numjobs=2
executing cmd sudo fio --name=test --filename=/dev/pxd/pxd1240 --ioengine=libaio --rw=write --bs=4k --offset=52428800 --size=4k --direct=1 --iodepth=256 --numjobs=2
executing cmd sudo fio --name=test --filename=/dev/pxd/pxd1241 --ioengine=libaio --rw=write --bs=4k --offset=52428800 --size=4k --direct=1 --iodepth=256 --numjobs=2
test: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
...
fio-3.1
test: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
...
fio-3.1
test: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
...
fio-3.1
test: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
...
fio-3.1
test: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
...
fio-3.1
test: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
...
fio-3.1
test: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
...
fio-3.1
test: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
...
fio-3.1
Starting 2 processes
Starting 2 processes
Starting 2 processes
Starting 2 processes
Starting 2 processes
Starting 2 processes
Starting 2 processes
Starting 2 processes
[failover] Sent PXD_FAILOVER_TO_USERSPACE.
epoll_wait returned 1
got event from kernel
Processing request opcode: 8208 minor: 3 num_volumes: [failover] Sent PXD_FAILOVER_TO_USERSPACE.
[failover] Sent PXD_FAILOVER_TO_USERSPACE.
8
active_idx : [failover] Sent PXD_FAILOVER_TO_USERSPACE.
[failover] Sent PXD_FAILOVER_TO_USERSPACE.
[failover] Sent PXD_FAILOVER_TO_USERSPACE.
2
Got failover request
sending reply for opcode : 8208 unique: 262144
Processing request opcode: 8208 minor: 5 num_volumes: 8
active_idx : 4
Got failover request
sending reply for opcode : 8208 unique: 262272
Processing request opcode: 8208 minor: 2 num_volumes: 8
active_idx : 1
Got failover request
[failover] Sent PXD_FAILOVER_TO_USERSPACE.
sending reply for opcode : 8208 unique: 262400
epoll_wait returned 1
got event from kernel
Processing request opcode: 8208 minor: 6 num_volumes: 8
active_idx : 5
Got failover request
sending reply for opcode : 8208 unique: 262528
Processing request opcode: 8208 minor: 7 num_volumes: 8
active_idx : 6
Got failover request
sending reply for opcode : 8208 unique: 262656
Processing request opcode: 8208 minor: 4 num_volumes: 8
active_idx : 3
Got failover request
sending reply for opcode : 8208 unique: 262784
Processing request opcode: 8208 minor: 8 num_volumes: 8
active_idx : 7
Got failover request
sending reply for opcode : 8208 unique: 262785
[failover] Sent PXD_FAILOVER_TO_USERSPACE.
epoll_wait returned 1
got event from kernel
Processing request opcode: 8208 minor: 1 num_volumes: 8
active_idx : 0
Got failover request
Added device /dev/mapper/flakey_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
sending reply for opcode : 8208 unique: 262912
epoll_wait returned 1[-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
got event from kernel
Processing request opcode: 8193 minor: 2 num_volumes: 8
active_idx : 1
Got write request - offset: 52428800 length: 4096 active_io_count 1
sending reply for opcode : 8193 unique: 263040
epoll_wait returned 1
got event from kernel
Processing request opcode: 8193 minor: 8 num_volumes: 8
active_idx : 7
Got write request - offset: 52428800 length: 4096 active_io_count 1
sending reply for opcode : 8193 unique: 263168
Processing request opcode: 8193 minor: 2 num_volumes: 8
active_idx : 1
Got write request - offset: 52428800 length: 4096 active_io_count 1
sending reply for opcode : 8193 unique: 263041
epoll_wait returned 1
got event from kernel
Processing request opcode: 8193 minor: 8 num_volumes: 8
active_idx : 7
Got write request - offset: 52428800 length: 4096 active_io_count 1
sending reply for opcode : 8193 unique: 263169

test: (groupid=0, jobs=1): err= 0: pid=445: Wed Apr  9 20:46:37 2025
  write: IOPS=0, BW=1022B/s (1022B/s)(4096B/4005msec)
    slat (nsec): min=33410, max=33410, avg=33410.00, stdev= 0.00
    clat (nsec): min=4003.9M, max=4003.9M, avg=4003922709.00, stdev= 0.00
     lat (nsec): min=4003.0M, max=4003.0M, avg=4003961642.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 4010],  5.00th=[ 4010], 10.00th=[ 4010], 20.00th=[ 4010],
     | 30.00th=[ 4010], 40.00th=[ 4010], 50.00th=[ 4010], 60.00th=[ 4010],
     | 70.00th=[ 4010], 80.00th=[ 4010], 90.00th=[ 4010], 95.00th=[ 4010],
     | 99.00th=[ 4010], 99.50th=[ 4010], 99.90th=[ 4010], 99.95th=[ 4010],
     | 99.99th=[ 4010]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.02%, sys=0.00%, ctx=2, majf=0, minf=12
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=448: Wed Apr  9 20:46:37 2025
  write: IOPS=0, BW=1022B/s (1022B/s)(4096B/4005msec)
    slat (nsec): min=105150, max=105150, avg=105150.00, stdev= 0.00
    clat (nsec): min=4004.2M, max=4004.2M, avg=4004160082.00, stdev= 0.00
     lat (nsec): min=4004.3M, max=4004.3M, avg=4004272933.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 4010],  5.00th=[ 4010], 10.00th=[ 4010], 20.00th=[ 4010],
     | 30.00th=[ 4010], 40.00th=[ 4010], 50.00th=[ 4010], 60.00th=[ 4010],
     | 70.00th=[ 4010], 80.00th=[ 4010], 90.00th=[ 4010], 95.00th=[ 4010],
     | 99.00th=[ 4010], 99.50th=[ 4010], 99.90th=[ 4010], 99.95th=[ 4010],
     | 99.99th=[ 4010]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.05%, sys=0.00%, ctx=1, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256

Run status group 0 (all jobs):
  WRITE: bw=2045B/s (2045B/s), 1022B/s-1022B/s (1022B/s-1022B/s), io=8192B (8192B), run=4005-4005msec

Disk stats (read/write):
  pxd!pxd1235: ios=0/0, merge=0/0, ticks=0/0, in_queue=0, util=0.10%

test: (groupid=0, jobs=1): err= 0: pid=427: Wed Apr  9 20:46:37 2025
  write: IOPS=0, BW=1017B/s (1017B/s)(4096B/4024msec)
    slat (nsec): min=108981, max=108981, avg=108981.00, stdev= 0.00
    clat (nsec): min=4023.5M, max=4023.5M, avg=4023487188.00, stdev= 0.00
     lat (nsec): min=4023.6M, max=4023.6M, avg=4023597344.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 4010],  5.00th=[ 4010], 10.00th=[ 4010], 20.00th=[ 4010],
     | 30.00th=[ 4010], 40.00th=[ 4010], 50.00th=[ 4010], 60.00th=[ 4010],
     | 70.00th=[ 4010], 80.00th=[ 4010], 90.00th=[ 4010], 95.00th=[ 4010],
     | 99.00th=[ 4010], 99.50th=[ 4010], 99.90th=[ 4010], 99.95th=[ 4010],
     | 99.99th=[ 4010]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=1, majf=0, minf=11
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=428: Wed Apr  9 20:46:37 2025
  write: IOPS=0, BW=1017B/s (1017B/s)(4096B/4024msec)
    slat (nsec): min=87157, max=87157, avg=87157.00, stdev= 0.00
    clat (nsec): min=4023.3M, max=4023.3M, avg=4023302066.00, stdev= 0.00
     lat (nsec): min=4023.4M, max=4023.4M, avg=4023391431.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 4010],  5.00th=[ 4010], 10.00th=[ 4010], 20.00th=[ 4010],
     | 30.00th=[ 4010], 40.00th=[ 4010], 50.00th=[ 4010], 60.00th=[ 4010],
     | 70.00th=[ 4010], 80.00th=[ 4010], 90.00th=[ 4010], 95.00th=[ 4010],
     | 99.00th=[ 4010], 99.50th=[ 4010], 99.90th=[ 4010], 99.95th=[ 4010],
     | 99.99th=[ 4010]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=2, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256

Run status group 0 (all jobs):
  WRITE: bw=2035B/s (2035B/s), 1017B/s-1017B/s (1017B/s-1017B/s), io=8192B (8192B), run=4024-4024msec

Disk stats (read/write):
  pxd!pxd1241: ios=0/0, merge=0/0, ticks=0/0, in_queue=0, util=0.10%
epoll_wait returned 1[-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
got event from kernel
Processing request opcode: 8193 minor: 6 num_volumes: 8
active_idx : 5
Got write request - offset: 52428800 length: 4096 active_io_count 1
sending reply for opcode : 8193 unique: 263170
Processing request opcode: 8193 minor: 7 num_volumes: 8
active_idx : 6
Got write request - offset: 52428800 length: 4096 active_io_count 2
sending reply for opcode : 8193 unique: 262273
Processing request opcode: 8193 minor: 7 num_volumes: 8
active_idx : 6
Got write request - offset: 52428800 length: 4096 active_io_count 1
sending reply for opcode : 8193 unique: 262274
Processing request opcode: 8193 minor: 1 num_volumes: 8
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 2
sending reply for opcode : 8193 unique: 262275
epoll_wait returned 1
got event from kernel
Processing request opcode: 8193 minor: 1 num_volumes: 8
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 1
sending reply for opcode : 8193 unique: 525313
Processing request opcode: 8193 minor: 5 num_volumes: 8
active_idx : 4
Got write request - offset: 52428800 length: 4096 active_io_count 2
sending reply for opcode : 8193 unique: 525185
Processing request opcode: 8193 minor: 5 num_volumes: 8
active_idx : 4
Got write request - offset: 52428800 length: 4096 active_io_count 1
sending reply for opcode : 8193 unique: 525312
Processing request opcode: 8193 minor: 4 num_volumes: 8
active_idx : 3
Got write request - offset: 52428800 length: 4096 active_io_count 2
sending reply for opcode : 8193 unique: 263042
epoll_wait returned 1
got event from kernel
Processing request opcode: 8193 minor: 3 num_volumes: 8
active_idx : 2
Got write request - offset: 52428800 length: 4096 active_io_count 2
sending reply for opcode : 8193 unique: 263043
Processing request opcode: 8193 minor: 4 num_volumes: 8
active_idx : 3
Got write request - offset: 52428800 length: 4096 active_io_count 1
sending reply for opcode : 8193 unique: 263044
Processing request opcode: 8193 minor: 3 num_volumes: 8
active_idx : 2
Got write request - offset: 52428800 length: 4096 active_io_count 1
sending reply for opcode : 8193 unique: 263045
Processing request opcode: 8193 minor: 6 num_volumes: 8
active_idx : 5
Got write request - offset: 52428800 length: 4096 active_io_count 1
sending reply for opcode : 8193 unique: 263171

test: (groupid=0, jobs=1): err= 0: pid=452: Wed Apr  9 20:46:37 2025
  write: IOPS=0, BW=998B/s (998B/s)(4096B/4103msec)
    slat (nsec): min=41252, max=41252, avg=41252.00, stdev= 0.00
    clat (nsec): min=4102.7M, max=4102.7M, avg=4102656888.00, stdev= 0.00
     lat (nsec): min=4102.7M, max=4102.7M, avg=4102699879.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 4111],  5.00th=[ 4111], 10.00th=[ 4111], 20.00th=[ 4111],
     | 30.00th=[ 4111], 40.00th=[ 4111], 50.00th=[ 4111], 60.00th=[ 4111],
     | 70.00th=[ 4111], 80.00th=[ 4111], 90.00th=[ 4111], 95.00th=[ 4111],
     | 99.00th=[ 4111], 99.50th=[ 4111], 99.90th=[ 4111], 99.95th=[ 4111],
     | 99.99th=[ 4111]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.02%, ctx=1, majf=0, minf=11
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=453: Wed Apr  9 20:46:37 2025
  write: IOPS=0, BW=998B/s (998B/s)(4096B/4103msec)
    slat (nsec): min=95991, max=95991, avg=95991.00, stdev= 0.00
    clat (nsec): min=4102.6M, max=4102.6M, avg=4102571324.00, stdev= 0.00
     lat (nsec): min=4102.7M, max=4102.7M, avg=4102668321.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 4111],  5.00th=[ 4111], 10.00th=[ 4111], 20.00th=[ 4111],
     | 30.00th=[ 4111], 40.00th=[ 4111], 50.00th=[ 4111], 60.00th=[ 4111],
     | 70.00th=[ 4111], 80.00th=[ 4111], 90.00th=[ 4111], 95.00th=[ 4111],
     | 99.00th=[ 4111], 99.50th=[ 4111], 99.90th=[ 4111], 99.95th=[ 4111],
     | 99.99th=[ 4111]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.02%, ctx=1, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256

Run status group 0 (all jobs):
  WRITE: bw=1996B/s (1996B/s), 998B/s-998B/s (998B/s-998B/s), io=8192B (8192B), run=4103-4103msec

Disk stats (read/write):
  pxd!pxd1234: ios=0/0, merge=0/0, ticks=0/0, in_queue=0, util=0.10%

test: (groupid=0, jobs=1): err= 0: pid=458: Wed Apr  9 20:46:37 2025
  write: IOPS=0, BW=1006B/s (1006B/s)(4096B/4068msec)
    slat (nsec): min=91059, max=91059, avg=91059.00, stdev= 0.00
    clat (nsec): min=4067.1M, max=4067.1M, avg=4067135532.00, stdev= 0.00
     lat (nsec): min=4067.2M, max=4067.2M, avg=4067227853.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 4077],  5.00th=[ 4077], 10.00th=[ 4077], 20.00th=[ 4077],
     | 30.00th=[ 4077], 40.00th=[ 4077], 50.00th=[ 4077], 60.00th=[ 4077],
     | 70.00th=[ 4077], 80.00th=[ 4077], 90.00th=[ 4077], 95.00th=[ 4077],
     | 99.00th=[ 4077], 99.50th=[ 4077], 99.90th=[ 4077], 99.95th=[ 4077],
     | 99.99th=[ 4077]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=1, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
  
test: (groupid=0, jobs=1): err= 0: pid=460: Wed Apr  9 20:46:37 2025
  write: IOPS=0, BW=1009B/s (1009B/s)(4096B/4058msec)
    slat (nsec): min=93332, max=93332, avg=93332.00, stdev= 0.00
    clat (nsec): min=4056.9M, max=4056.9M, avg=4056880513.00, stdev= 0.00
     lat (nsec): min=4056.0M, max=4056.0M, avg=4056975210.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 4044],  5.00th=[ 4044], 10.00th=[ 4044], 20.00th=[ 4044],
     | 30.00th=[ 4044], 40.00th=[ 4044], 50.00th=[ 4044], 60.00th=[ 4044],
     | 70.00th=[ 4044], 80.00th=[ 4044], 90.00th=[ 4044], 95.00th=[ 4044],
     | 99.00th=[ 4044], 99.50th=[ 4044], 99.90th=[ 4044], 99.95th=[ 4044],
     | 99.99th=[ 4044]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.02%, ctx=1, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
      issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=459: Wed Apr  9 20:46:37 2025
  write: IOPS=0, BW=1006B/s (1006B/s)(4096B/4069msec)
    slat (nsec): min=32154, max=32154, avg=32154.00, stdev= 0.00
    clat (nsec): min=4067.0M, max=4067.0M, avg=4067983643.00, stdev= 0.00
     lat (nsec): min=4068.0M, max=4068.0M, avg=4068017013.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 4077],  5.00th=[ 4077], 10.00th=[ 4077], 20.00th=[ 4077],
     | 30.00th=[ 4077], 40.00th=[ 4077], 50.00th=[ 4077], 60.00th=[ 4077],
     | 70.00th=[ 4077], 80.00th=[ 4077], 90.00th=[ 4077], 95.00th=[ 4077],
     | 99.00th=[ 4077], 99.50th=[ 4077], 99.90th=[ 4077], 99.95th=[ 4077],
     | 99.99th=[ 4077]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=1, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%  issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=461: Wed Apr  9 20:46:37 2025
  write: IOPS=0, BW=1009B/s (1009B/s)(4096B/4058msec)
    slat (nsec): min=51981, max=51981, avg=51981.00, stdev= 0.00
    clat (nsec): min=4056.8M, max=4056.8M, avg=4056788823.00, stdev= 0.00
     lat (nsec): min=4056.8M, max=4056.8M, avg=4056841916.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 4044],  5.00th=[ 4044], 10.00th=[ 4044], 20.00th=[ 4044],
     | 30.00th=[ 4044], 40.00th=[ 4044], 50.00th=[ 4044], 60.00th=[ 4044],
     | 70.00th=[ 4044], 80.00th=[ 4044], 90.00th=[ 4044], 95.00th=[ 4044],
     | 99.00th=[ 4044], 99.50th=[ 4044], 99.90th=[ 4044], 99.95th=[ 4044],
     | 99.99th=[ 4044]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.02%, sys=0.00%, ctx=2, majf=0, minf=8
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, , 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
     latency   : target=0, window=0, percentile=100.00%, depth=256


Run status group 0 (all jobs):
Run status group 0 (all jobs):
  WRITE: bw=2013B/s (2013B/s), 1006B/s-1006B/s (1006B/s-1006B/s), io=8192B (8192B), run=4068-4069msec

Disk stats (read/write):
  WRITE: bw=2018B/s (2018B/s), 1009B/s-1009B/s (1009B/s-1009B/s), io=8192B (8192B), run=4058-4058msec
  pxd!pxd1239: ios=0/0, merge=0/0, ticks=0/0, in_queue=0, util=0.10%

Disk stats (read/write):
  pxd!pxd1240: ios=0/0, merge=0/0, ticks=0/0, in_queue=0, util=0.10%

test: (groupid=0, jobs=1): err= 0: pid=454: Wed Apr  9 20:46:37 2025
  write: IOPS=0, BW=999B/s (999B/s)(4096B/4097msec)
    slat (nsec): min=84864, max=84864, avg=84864.00, stdev= 0.00
    clat (nsec): min=4096.5M, max=4096.5M, avg=4096547106.00, stdev= 0.00
     lat (nsec): min=4096.6M, max=4096.6M, avg=4096632954.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 4111],  5.00th=[ 4111], 10.00th=[ 4111], 20.00th=[ 4111],
     | 30.00th=[ 4111], 40.00th=[ 4111], 50.00th=[ 4111], 60.00th=[ 4111],
     | 70.00th=[ 4111], 80.00th=[ 4111], 90.00th=[ 4111], 95.00th=[ 4111],
     | 99.00th=[ 4111], 99.50th=[ 4111], 99.90th=[ 4111], 99.95th=[ 4111],
     | 99.99th=[ 4111]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.02%, sys=0.00%, ctx=1, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=455: Wed Apr  9 20:46:37 2025
  write: IOPS=0, BW=999B/s (999B/s)(4096B/4097msec)
    slat (nsec): min=39383, max=39383, avg=39383.00, stdev= 0.00
    clat (nsec): min=4096.7M, max=4096.7M, avg=4096669037.00, stdev= 0.00
     lat (nsec): min=4096.7M, max=4096.7M, avg=4096709643.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 4111],  5.00th=[ 4111], 10.00th=[ 4111], 20.00th=[ 4111],
     | 30.00th=[ 4111], 40.00th=[ 4111], 50.00th=[ 4111], 60.00th=[ 4111],
     | 70.00th=[ 4111], 80.00th=[ 4111], 90.00th=[ 4111], 95.00th=[ 4111],
     | 99.00th=[ 4111], 99.50th=[ 4111], 99.90th=[ 4111], 99.95th=[ 4111],
     | 99.99th=[ 4111]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.02%, sys=0.00%, ctx=1, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256

Run status group 0 (all jobs):
  WRITE: bw=1999B/s (1999B/s), 999B/s-999B/s (999B/s-999B/s), io=8192B (8192B), run=4097-4097msec

Disk stats (read/write):
  pxd!pxd1236: ios=0/0, merge=0/0, ticks=0/0, in_queue=0, util=0.10%

test: (groupid=0, jobs=1): err= 0: pid=450: Wed Apr  9 20:46:37 2025
  write: IOPS=0, BW=997B/s (997B/s)(4096B/4107msec)
    slat (nsec): min=96203, max=96203, avg=96203.00, stdev= 0.00
    clat (nsec): min=4105.8M, max=4105.8M, avg=4105783886.00, stdev= 0.00
     lat (nsec): min=4105.9M, max=4105.9M, avg=4105888280.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 4111],  5.00th=[ 4111], 10.00th=[ 4111], 20.00th=[ 4111],
     | 30.00th=[ 4111], 40.00th=[ 4111], 50.00th=[ 4111], 60.00th=[ 4111],
     | 70.00th=[ 4111], 80.00th=[ 4111], 90.00th=[ 4111], 95.00th=[ 4111],
     | 99.00th=[ 4111], 99.50th=[ 4111], 99.90th=[ 4111], 99.95th=[ 4111],
     | 99.99th=[ 4111]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.02%, sys=0.00%, ctx=1, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=451: Wed Apr  9 20:46:37 2025
  write: IOPS=0, BW=997B/s (997B/s)(4096B/4106msec)
    slat (nsec): min=46308, max=46308, avg=46308.00, stdev= 0.00
    clat (nsec): min=4105.7M, max=4105.7M, avg=4105710976.00, stdev= 0.00
     lat (nsec): min=4105.8M, max=4105.8M, avg=4105763730.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 4111],  5.00th=[ 4111], 10.00th=[ 4111], 20.00th=[ 4111],
     | 30.00th=[ 4111], 40.00th=[ 4111], 50.00th=[ 4111], 60.00th=[ 4111],
     | 70.00th=[ 4111], 80.00th=[ 4111], 90.00th=[ 4111], 95.00th=[ 4111],
     | 99.00th=[ 4111], 99.50th=[ 4111], 99.90th=[ 4111], 99.95th=[ 4111],
     | 99.99th=[ 4111]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=2, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256

Run status group 0 (all jobs):
  WRITE: bw=1994B/s (1994B/s), 997B/s-997B/s (997B/s-997B/s), io=8192B (8192B), run=4106-4107msec

Disk stats (read/write):
  pxd!pxd1238: ios=0/0, merge=0/0, ticks=0/0, in_queue=0, util=0.10%

test: (groupid=0, jobs=1): err= 0: pid=456: Wed Apr  9 20:46:37 2025
  write: IOPS=0, BW=1004B/s (1004B/s)(4096B/4079msec)
    slat (nsec): min=72911, max=72911, avg=72911.00, stdev= 0.00
    clat (nsec): min=4078.7M, max=4078.7M, avg=4078726918.00, stdev= 0.00
     lat (nsec): min=4078.8M, max=4078.8M, avg=4078806936.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 4077],  5.00th=[ 4077], 10.00th=[ 4077], 20.00th=[ 4077],
     | 30.00th=[ 4077], 40.00th=[ 4077], 50.00th=[ 4077], 60.00th=[ 4077],
     | 70.00th=[ 4077], 80.00th=[ 4077], 90.00th=[ 4077], 95.00th=[ 4077],
     | 99.00th=[ 4077], 99.50th=[ 4077], 99.90th=[ 4077], 99.95th=[ 4077],
     | 99.99th=[ 4077]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=2, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=457: Wed Apr  9 20:46:37 2025
  write: IOPS=0, BW=1003B/s (1003B/s)(4096B/4080msec)
    slat (nsec): min=81466, max=81466, avg=81466.00, stdev= 0.00
    clat (nsec): min=4079.1M, max=4079.1M, avg=4079083293.00, stdev= 0.00
     lat (nsec): min=4079.2M, max=4079.2M, avg=4079170819.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 4077],  5.00th=[ 4077], 10.00th=[ 4077], 20.00th=[ 4077],
     | 30.00th=[ 4077], 40.00th=[ 4077], 50.00th=[ 4077], 60.00th=[ 4077],
     | 70.00th=[ 4077], 80.00th=[ 4077], 90.00th=[ 4077], 95.00th=[ 4077],
     | 99.00th=[ 4077], 99.50th=[ 4077], 99.90th=[ 4077], 99.95th=[ 4077],
     | 99.99th=[ 4077]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=1, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256

Run status group 0 (all jobs):
  WRITE: bw=2007B/s (2007B/s), 1003B/s-1004B/s (1003B/s-1004B/s), io=8192B (8192B), run=4079-4080msec

Disk stats (read/write):
  pxd!pxd1237: ios=0/0, merge=0/0, ticks=0/0, in_queue=0, util=0.10%
epoll_wait returned 1
got event from kernel
Processing request opcode: 8209 minor: 1 num_volumes: 8
active_idx : 0
Added device /dev/mapper/delay_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
sending reply for opcode : 8209 unique: 262786
epoll_wait returned 1
got event from kernel
Processing request opcode: 8209 minor: 2 num_volumes: 8
active_idx : 1
sending reply for opcode : 8209 unique: 262787
epoll_wait returned 1
got event from kernel
Processing request opcode: 8209 minor: 3 num_volumes: 8
active_idx : 2
sending reply for opcode : 8209 unique: 262788
epoll_wait returned 1
got event from kernel
Processing request opcode: 8209 minor: 4 num_volumes: 8
active_idx : 3
sending reply for opcode : 8209 unique: 262789
epoll_wait returned 1
got event from kernel
Processing request opcode: 8209 minor: 5 num_volumes: 8
active_idx : 4
sending reply for opcode : 8209 unique: 262790
epoll_wait returned 1
got event from kernel
Processing request opcode: 8209 minor: 6 num_volumes: 8
active_idx : 5
sending reply for opcode : 8209 unique: 262791
epoll_wait returned 1
got event from kernel
Processing request opcode: 8209 minor: 7 num_volumes: 8
active_idx : 6
sending reply for opcode : 8209 unique: 262792
epoll_wait returned 1
got event from kernel
Processing request opcode: 8209 minor: 8 num_volumes: 8
active_idx : 7
sending reply for opcode : 8209 unique: 262793
epoll_wait returned 1
done with the control thread
time="2025-04-09 20:46:38Z" level=INFO msg="nr_failover_to_userspace : 0, nr_fallback_to_kernel : 0, nr_unknown : 0"
time="2025-04-09 20:46:38Z" level=INFO msg="nr_failover_to_userspace : 0, nr_fallback_to_kernel : 0, nr_unknown : 0"
time="2025-04-09 20:46:38Z" level=INFO msg="nr_failover_to_userspace : 0, nr_fallback_to_kernel : 0, nr_unknown : 0"
time="2025-04-09 20:46:38Z" level=INFO msg="nr_failover_to_userspace : 0, nr_fallback_to_kernel : 0, nr_unknown : 0"
time="2025-04-09 20:46:38Z" level=INFO msg="nr_failover_to_userspace : 0, nr_fallback_to_kernel : 0, nr_unknown : 0"
time="2025-04-09 20:46:38Z" level=INFO msg="nr_failover_to_userspace : 0, nr_fallback_to_kernel : 0, nr_unknown : 0"
time="2025-04-09 20:46:38Z" level=INFO msg="nr_failover_to_userspace : 0, nr_fallback_to_kernel : 0, nr_unknown : 0"
time="2025-04-09 20:46:38Z" level=INFO msg="nr_failover_to_userspace : 0, nr_fallback_to_kernel : 0, nr_unknown : 0"
[       OK ] FailoverTest.Scale_NodeDownTriggerFailoverWithMultipleIOs (15337 ms)
[----------] 2 tests from FailoverTest (21788 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (21789 ms total)
[  PASSED  ] 2 tests.
time="2025-04-09 20:46:39Z" level=INFO msg="Shutting down System Monitor"
```

** UT notes for PWX-42637 **
the delay for sync is via dm-delay device with a extremely long sync time

** Before fix **
```
./t --gtest_filter=*VfsFsyncFinish*                         
Note: Google Test filter = *VfsFsyncFinish*
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from FailoverTest
[ RUN      ] FailoverTest.VfsFsyncFinishWithFailover
25600+0 records in
25600+0 records out
104857600 bytes (105 MB, 100 MiB) copied, 0.371331 s, 282 MB/s
mke2fs 1.44.1 (24-Mar-2018)
Discarding device blocks: done                            
Creating filesystem with 25600 4k blocks and 25600 inodes

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (1024 blocks): done
Writing superblocks and filesystem accounting information: done

Executing: sudo dmsetup create flakey_test_loop10 < /tmp/dm_table_Ohkta3
Executing: sudo dmsetup create delay_test_loop10 < /tmp/dm_table_bRfqEZ
Added device /dev/mapper/delay_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
[fio] executing: sudo fio --name=test --filename=/dev/pxd/pxd1234 --ioengine=libaio --rw=write --bs=4k --offset=52428800 --size=4k --direct=1 --iodepth=256 --numjobs=16
test: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
...
fio-3.1
Starting 16 processes
[failover] Sent PXD_FAILOVER_TO_USERSPACE.0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
epoll_wait returned 1
got event from kernel
Processing request opcode: 8208 minor: 1 num_volumes: 1
active_idx : 0
Got failover request
Jobs: 16 (f=16): [W(16)][-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
Jobs: 16 (f=16): [W(16)][-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
^Cbs: 16 (f=16): [W(16)][-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
```

** After fix **
 
 ```
 ./t --gtest_filter=*VfsFsyncFinish*   
Note: Google Test filter = *VfsFsyncFinish*
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from FailoverTest
[ RUN      ] FailoverTest.VfsFsyncFinishWithFailover
25600+0 records in
25600+0 records out
104857600 bytes (105 MB, 100 MiB) copied, 0.377019 s, 278 MB/s
mke2fs 1.44.1 (24-Mar-2018)
Discarding device blocks: done                            
Creating filesystem with 25600 4k blocks and 25600 inodes

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (1024 blocks): done
Writing superblocks and filesystem accounting information: done

Executing: sudo dmsetup create flakey_test_loop10 < /tmp/dm_table_YNH85M
Executing: sudo dmsetup create delay_test_loop10 < /tmp/dm_table_tyfMeM
Added device /dev/mapper/delay_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
[fio] executing: sudo fio --name=test --filename=/dev/pxd/pxd1234 --ioengine=libaio --rw=write --bs=4k --offset=52428800 --size=4k --direct=1 --iodepth=256 --numjobs=16
test: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
...
fio-3.1
Starting 16 processes
epoll_wait returned [failover] Sent PXD_FAILOVER_TO_USERSPACE.][eta 00m:00s]
1
got event from kernel
Processing request opcode: 8208 minor: 1 num_volumes: 1
active_idx : 0
Got failover request
Added device /dev/mapper/flakey_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
sending reply for opcode : 8208 unique: 262144
epoll_wait returned 16)][-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
got event from kernel
Processing request opcode: 8193 minor: 1 num_volumes: 1
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 4
sending reply for opcode : 8193 unique: 262145
Processing request opcode: 8193 minor: 1 num_volumes: 1
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 5
sending reply for opcode : 8193 unique: 262146
epoll_wait returned 1
got event from kernel
Processing request opcode: 8193 minor: 1 num_volumes: 1
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 4
sending reply for opcode : 8193 unique: 262272
Processing request opcode: 8193 minor: 1 num_volumes: 1
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 4
sending reply for opcode : 8193 unique: 262400
Processing request opcode: 8193 minor: 1 num_volumes: 1
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 4
sending reply for opcode : 8193 unique: 262273
Processing request opcode: 8193 minor: 1 num_volumes: 1
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 8
sending reply for opcode : 8193 unique: 262401
epoll_wait returned 1
got event from kernel
Processing request opcode: 8193 minor: 1 num_volumes: 1
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 7
sending reply for opcode : 8193 unique: 262274
Processing request opcode: 8193 minor: 1 num_volumes: 1
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 6
sending reply for opcode : 8193 unique: 262402
Processing request opcode: 8193 minor: 1 num_volumes: 1
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 8
sending reply for opcode : 8193 unique: 262275
Processing request opcode: 8193 minor: 1 num_volumes: 1
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 7
sending reply for opcode : 8193 unique: 262276
epoll_wait returned 1
got event from kernel
Processing request opcode: 8193 minor: 1 num_volumes: 1
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 6
sending reply for opcode : 8193 unique: 262277
Processing request opcode: 8193 minor: 1 num_volumes: 1
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 5
sending reply for opcode : 8193 unique: 262278
Processing request opcode: 8193 minor: 1 num_volumes: 1
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 4
sending reply for opcode : 8193 unique: 262279
Processing request opcode: 8193 minor: 1 num_volumes: 1
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 3
sending reply for opcode : 8193 unique: 262403
epoll_wait returned 1
got event from kernel
Processing request opcode: 8193 minor: 1 num_volumes: 1
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 2
sending reply for opcode : 8193 unique: 262404
Processing request opcode: 8193 minor: 1 num_volumes: 1
active_idx : 0
Got write request - offset: 52428800 length: 4096 active_io_count 1
sending reply for opcode : 8193 unique: 262405
Jobs: 16 (f=0): [f(16)][-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
test: (groupid=0, jobs=1): err= 0: pid=122: Wed Apr  9 21:13:00 2025
  write: IOPS=0, BW=58B/s (58B/s)(4096B/70469msec)
    slat (nsec): min=28376, max=28376, avg=28376.00, stdev= 0.00
    clat (nsec): min=70469M, max=70469M, avg=70468509269.00, stdev= 0.00
     lat (nsec): min=70469M, max=70469M, avg=70468538570.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[17113],  5.00th=[17113], 10.00th=[17113], 20.00th=[17113],
     | 30.00th=[17113], 40.00th=[17113], 50.00th=[17113], 60.00th=[17113],
     | 70.00th=[17113], 80.00th=[17113], 90.00th=[17113], 95.00th=[17113],
     | 99.00th=[17113], 99.50th=[17113], 99.90th=[17113], 99.95th=[17113],
     | 99.99th=[17113]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=1, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=123: Wed Apr  9 21:13:00 2025
  write: IOPS=0, BW=58B/s (58B/s)(4096B/70471msec)
    slat (nsec): min=225483, max=225483, avg=225483.00, stdev= 0.00
    clat (nsec): min=70469M, max=70469M, avg=70469213462.00, stdev= 0.00
     lat (nsec): min=70469M, max=70469M, avg=70469439900.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[17113],  5.00th=[17113], 10.00th=[17113], 20.00th=[17113],
     | 30.00th=[17113], 40.00th=[17113], 50.00th=[17113], 60.00th=[17113],
     | 70.00th=[17113], 80.00th=[17113], 90.00th=[17113], 95.00th=[17113],
     | 99.00th=[17113], 99.50th=[17113], 99.90th=[17113], 99.95th=[17113],
     | 99.99th=[17113]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=3, majf=0, minf=8
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=124: Wed Apr  9 21:13:00 2025
  write: IOPS=0, BW=58B/s (58B/s)(4096B/70470msec)
    slat (nsec): min=46278, max=46278, avg=46278.00, stdev= 0.00
    clat (nsec): min=70469M, max=70469M, avg=70469208349.00, stdev= 0.00
     lat (nsec): min=70469M, max=70469M, avg=70469255662.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[17113],  5.00th=[17113], 10.00th=[17113], 20.00th=[17113],
     | 30.00th=[17113], 40.00th=[17113], 50.00th=[17113], 60.00th=[17113],
     | 70.00th=[17113], 80.00th=[17113], 90.00th=[17113], 95.00th=[17113],
     | 99.00th=[17113], 99.50th=[17113], 99.90th=[17113], 99.95th=[17113],
     | 99.99th=[17113]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=4, majf=0, minf=7
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=125: Wed Apr  9 21:13:00 2025
  write: IOPS=0, BW=58B/s (58B/s)(4096B/70470msec)
    slat (nsec): min=88818, max=88818, avg=88818.00, stdev= 0.00
    clat (nsec): min=70469M, max=70469M, avg=70468993619.00, stdev= 0.00
     lat (nsec): min=70469M, max=70469M, avg=70469086304.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[17113],  5.00th=[17113], 10.00th=[17113], 20.00th=[17113],
     | 30.00th=[17113], 40.00th=[17113], 50.00th=[17113], 60.00th=[17113],
     | 70.00th=[17113], 80.00th=[17113], 90.00th=[17113], 95.00th=[17113],
     | 99.00th=[17113], 99.50th=[17113], 99.90th=[17113], 99.95th=[17113],
     | 99.99th=[17113]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=2, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=126: Wed Apr  9 21:13:00 2025
  write: IOPS=0, BW=58B/s (58B/s)(4096B/70471msec)
    slat (nsec): min=24493, max=24493, avg=24493.00, stdev= 0.00
    clat (nsec): min=70470M, max=70470M, avg=70470297333.00, stdev= 0.00
     lat (nsec): min=70470M, max=70470M, avg=70470323455.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[17113],  5.00th=[17113], 10.00th=[17113], 20.00th=[17113],
     | 30.00th=[17113], 40.00th=[17113], 50.00th=[17113], 60.00th=[17113],
     | 70.00th=[17113], 80.00th=[17113], 90.00th=[17113], 95.00th=[17113],
     | 99.00th=[17113], 99.50th=[17113], 99.90th=[17113], 99.95th=[17113],
     | 99.99th=[17113]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=1, majf=0, minf=8
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=127: Wed Apr  9 21:13:00 2025
  write: IOPS=0, BW=58B/s (58B/s)(4096B/70470msec)
    slat (nsec): min=27621, max=27621, avg=27621.00, stdev= 0.00
    clat (nsec): min=70470M, max=70470M, avg=70469718934.00, stdev= 0.00
     lat (nsec): min=70470M, max=70470M, avg=70469747733.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[17113],  5.00th=[17113], 10.00th=[17113], 20.00th=[17113],
     | 30.00th=[17113], 40.00th=[17113], 50.00th=[17113], 60.00th=[17113],
     | 70.00th=[17113], 80.00th=[17113], 90.00th=[17113], 95.00th=[17113],
     | 99.00th=[17113], 99.50th=[17113], 99.90th=[17113], 99.95th=[17113],
     | 99.99th=[17113]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=1, majf=0, minf=7
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=128: Wed Apr  9 21:13:00 2025
  write: IOPS=0, BW=58B/s (58B/s)(4096B/70469msec)
    slat (nsec): min=31365, max=31365, avg=31365.00, stdev= 0.00
    clat (nsec): min=70469M, max=70469M, avg=70468679967.00, stdev= 0.00
     lat (nsec): min=70469M, max=70469M, avg=70468712642.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[17113],  5.00th=[17113], 10.00th=[17113], 20.00th=[17113],
     | 30.00th=[17113], 40.00th=[17113], 50.00th=[17113], 60.00th=[17113],
     | 70.00th=[17113], 80.00th=[17113], 90.00th=[17113], 95.00th=[17113],
     | 99.00th=[17113], 99.50th=[17113], 99.90th=[17113], 99.95th=[17113],
     | 99.99th=[17113]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=1, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=129: Wed Apr  9 21:13:00 2025
  write: IOPS=0, BW=58B/s (58B/s)(4096B/70471msec)
    slat (nsec): min=28511, max=28511, avg=28511.00, stdev= 0.00
    clat (nsec): min=70470M, max=70470M, avg=70469828014.00, stdev= 0.00
     lat (nsec): min=70470M, max=70470M, avg=70469857477.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[17113],  5.00th=[17113], 10.00th=[17113], 20.00th=[17113],
     | 30.00th=[17113], 40.00th=[17113], 50.00th=[17113], 60.00th=[17113],
     | 70.00th=[17113], 80.00th=[17113], 90.00th=[17113], 95.00th=[17113],
     | 99.00th=[17113], 99.50th=[17113], 99.90th=[17113], 99.95th=[17113],
     | 99.99th=[17113]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=1, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=130: Wed Apr  9 21:13:00 2025
  write: IOPS=0, BW=58B/s (58B/s)(4096B/70470msec)
    slat (nsec): min=38888, max=38888, avg=38888.00, stdev= 0.00
    clat (nsec): min=70470M, max=70470M, avg=70469757702.00, stdev= 0.00
     lat (nsec): min=70470M, max=70470M, avg=70469798114.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[17113],  5.00th=[17113], 10.00th=[17113], 20.00th=[17113],
     | 30.00th=[17113], 40.00th=[17113], 50.00th=[17113], 60.00th=[17113],
     | 70.00th=[17113], 80.00th=[17113], 90.00th=[17113], 95.00th=[17113],
     | 99.00th=[17113], 99.50th=[17113], 99.90th=[17113], 99.95th=[17113],
     | 99.99th=[17113]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=1, majf=0, minf=7
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=131: Wed Apr  9 21:13:00 2025
  write: IOPS=0, BW=58B/s (58B/s)(4096B/70470msec)
    slat (nsec): min=29805, max=29805, avg=29805.00, stdev= 0.00
    clat (nsec): min=70469M, max=70469M, avg=70469311997.00, stdev= 0.00
     lat (nsec): min=70469M, max=70469M, avg=70469342875.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[17113],  5.00th=[17113], 10.00th=[17113], 20.00th=[17113],
     | 30.00th=[17113], 40.00th=[17113], 50.00th=[17113], 60.00th=[17113],
     | 70.00th=[17113], 80.00th=[17113], 90.00th=[17113], 95.00th=[17113],
     | 99.00th=[17113], 99.50th=[17113], 99.90th=[17113], 99.95th=[17113],
     | 99.99th=[17113]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=5, majf=0, minf=8
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=132: Wed Apr  9 21:13:00 2025
  write: IOPS=0, BW=58B/s (58B/s)(4096B/70470msec)
    slat (nsec): min=31527, max=31527, avg=31527.00, stdev= 0.00
    clat (nsec): min=70469M, max=70469M, avg=70469164656.00, stdev= 0.00
     lat (nsec): min=70469M, max=70469M, avg=70469197171.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[17113],  5.00th=[17113], 10.00th=[17113], 20.00th=[17113],
     | 30.00th=[17113], 40.00th=[17113], 50.00th=[17113], 60.00th=[17113],
     | 70.00th=[17113], 80.00th=[17113], 90.00th=[17113], 95.00th=[17113],
     | 99.00th=[17113], 99.50th=[17113], 99.90th=[17113], 99.95th=[17113],
     | 99.99th=[17113]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=1, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=133: Wed Apr  9 21:13:00 2025
  write: IOPS=0, BW=58B/s (58B/s)(4096B/70470msec)
    slat (nsec): min=27393, max=27393, avg=27393.00, stdev= 0.00
    clat (nsec): min=70469M, max=70469M, avg=70469061960.00, stdev= 0.00
     lat (nsec): min=70469M, max=70469M, avg=70469090198.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[17113],  5.00th=[17113], 10.00th=[17113], 20.00th=[17113],
     | 30.00th=[17113], 40.00th=[17113], 50.00th=[17113], 60.00th=[17113],
     | 70.00th=[17113], 80.00th=[17113], 90.00th=[17113], 95.00th=[17113],
     | 99.00th=[17113], 99.50th=[17113], 99.90th=[17113], 99.95th=[17113],
     | 99.99th=[17113]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=1, majf=0, minf=8
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=134: Wed Apr  9 21:13:00 2025
  write: IOPS=0, BW=58B/s (58B/s)(4096B/70470msec)
    slat (nsec): min=29672, max=29672, avg=29672.00, stdev= 0.00
    clat (nsec): min=70469M, max=70469M, avg=70468874445.00, stdev= 0.00
     lat (nsec): min=70469M, max=70469M, avg=70468905200.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[17113],  5.00th=[17113], 10.00th=[17113], 20.00th=[17113],
     | 30.00th=[17113], 40.00th=[17113], 50.00th=[17113], 60.00th=[17113],
     | 70.00th=[17113], 80.00th=[17113], 90.00th=[17113], 95.00th=[17113],
     | 99.00th=[17113], 99.50th=[17113], 99.90th=[17113], 99.95th=[17113],
     | 99.99th=[17113]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=2, majf=0, minf=7
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=135: Wed Apr  9 21:13:00 2025
  write: IOPS=0, BW=58B/s (58B/s)(4096B/70470msec)
    slat (nsec): min=209706, max=209706, avg=209706.00, stdev= 0.00
    clat (nsec): min=70469M, max=70469M, avg=70469210583.00, stdev= 0.00
     lat (nsec): min=70469M, max=70469M, avg=70469424301.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[17113],  5.00th=[17113], 10.00th=[17113], 20.00th=[17113],
     | 30.00th=[17113], 40.00th=[17113], 50.00th=[17113], 60.00th=[17113],
     | 70.00th=[17113], 80.00th=[17113], 90.00th=[17113], 95.00th=[17113],
     | 99.00th=[17113], 99.50th=[17113], 99.90th=[17113], 99.95th=[17113],
     | 99.99th=[17113]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=2, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=136: Wed Apr  9 21:13:00 2025
  write: IOPS=0, BW=58B/s (58B/s)(4096B/70468msec)
    slat (nsec): min=28220, max=28220, avg=28220.00, stdev= 0.00
    clat (nsec): min=70467M, max=70467M, avg=70466993563.00, stdev= 0.00
     lat (nsec): min=70467M, max=70467M, avg=70467022463.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[17113],  5.00th=[17113], 10.00th=[17113], 20.00th=[17113],
     | 30.00th=[17113], 40.00th=[17113], 50.00th=[17113], 60.00th=[17113],
     | 70.00th=[17113], 80.00th=[17113], 90.00th=[17113], 95.00th=[17113],
     | 99.00th=[17113], 99.50th=[17113], 99.90th=[17113], 99.95th=[17113],
     | 99.99th=[17113]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=1, majf=0, minf=8
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=137: Wed Apr  9 21:13:00 2025
  write: IOPS=0, BW=58B/s (58B/s)(4096B/70468msec)
    slat (nsec): min=26759, max=26759, avg=26759.00, stdev= 0.00
    clat (nsec): min=70467M, max=70467M, avg=70467297536.00, stdev= 0.00
     lat (nsec): min=70467M, max=70467M, avg=70467324975.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[17113],  5.00th=[17113], 10.00th=[17113], 20.00th=[17113],
     | 30.00th=[17113], 40.00th=[17113], 50.00th=[17113], 60.00th=[17113],
     | 70.00th=[17113], 80.00th=[17113], 90.00th=[17113], 95.00th=[17113],
     | 99.00th=[17113], 99.50th=[17113], 99.90th=[17113], 99.95th=[17113],
     | 99.99th=[17113]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=2, majf=0, minf=7
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256

Run status group 0 (all jobs):
  WRITE: bw=929B/s (929B/s), 58B/s-58B/s (58B/s-58B/s), io=64.0KiB (65.5kB), run=70468-70471msec

Disk stats (read/write):
  pxd!pxd1234: ios=0/0, merge=0/0, ticks=0/0, in_queue=0, util=0.01%
[fio] completed.
epoll_wait returned 1
got event from kernel
Processing request opcode: 8209 minor: 1 num_volumes: 1
active_idx : 0
Added device /dev/mapper/delay_test_loop10 minor 1 dev_id 1234
Pxd path /dev/pxd/pxd1234
sending reply for opcode : 8209 unique: 262528
table file = /tmp/dm_table_Ow0UcL
Executing: sudo dmsetup suspend delay_test_loop10
Executing: sudo dmsetup reload delay_test_loop10 < /tmp/dm_table_Ow0UcL
Executing: sudo dmsetup resume delay_test_loop10
success = 1
epoll_wait returned 1
done with the control thread
time="2025-04-09 21:13:00Z" level=INFO msg="nr_failover_to_userspace : 0, nr_fallback_to_kernel : 0, nr_unknown : 0"
[       OK ] FailoverTest.VfsFsyncFinishWithFailover (72949 ms)
[----------] 1 test from FailoverTest (72949 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (72949 ms total)
[  PASSED  ] 1 test.
time="2025-04-09 21:13:00Z" level=INFO msg="Shutting down System Monitor"
```

**What this PR does / why we need it**:
On failover, use entries from ios instead of failQ since all the entries from the failQ are moved to ios.
Fix ncount inc/dec
proper handling of `fp.can_failover` and `fp.active_failover`
vfs_fsync with a timeout 
**Which issue(s) this PR fixes** (optional)
Closes # PWX-42357, PWX-42628, PWX-42637 and PWX-42656

**Special notes for your reviewer**:

