### PR TITLE
PWX-43070: fix race condition in fastpath failover

### DIFF
--- a/pxd.h
+++ b/pxd.h
@@ -21,6 +21,9 @@
 
 /// @file px_fuse/pxd.h
 
+// fastpath specific UT enable flag
+#define TEST_FP_RACE 0
+
 #define PXD_POISON (0xdeadbeef)
 #define PXD_CONTROL_DEV "/dev/pxd/pxd-control"	/**< control device prefix */
 #define PXD_DEV  	"pxd/pxd"		/**< block device prefix */

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -565,7 +565,7 @@ static void pxd_io_failover(struct kthread_work *work) {
 
         spin_lock_irqsave(&pxd_dev->fp.fail_lock, flags);
         if (!pxd_dev->fp.active_failover) {
-                if (pxd_dev->fp.fastpath) {
+                if (atomic_read(&pxd_dev->fp.fastpath)) {
                         pxd_dev->fp.active_failover = true;
                         list_add_tail(&fproot->wait, &pxd_dev->fp.failQ);
                         cleanup = true;
@@ -778,10 +778,40 @@ void fp_handle_io(struct kthread_work *work) {
 #else
         blk_status_t r;
 #endif
+        // ensure that fastpath is still active, otherwise
+        // reroute to native path
+        // the order of operations matter here
+        // 1. disableFastPath sets pxd_dev->fp.fastpath to false
+        // 2. disableFastPath calls fastpath_flush_work()
+        // If the IO is in a state where it checked pxd_dev->fp.fastpath to true
+        // in pxd_queue_rq but before it calls fastpath_queue_work, the following
+        // scenarios can happen (and in all scenarios, the IO would be rerouted to native path)
+        // 1. disableFastPath completes, the IO on getting queued to fastpath
+        // kthread would be rerouted
+        // 2. disableFastPath doesn't complete the flush and the IO gets scheduled
+        // on a kthread that hasn't yet been flushed => IO would be rerouted to
+        // native path
+        // 3. disableFastPath doesn't complete the flush and the IO gets scheduled
+        // on a kthread that has been flushed => IO would be rerouted to native path
+        if (!atomic_read(&pxd_dev->fp.fastpath)) {
+                pxdmq_reroute_slowpath(fproot_to_fuse_request(fproot));
+                return;
+        }
+
+        // if an IO is here at the time of disableFastPath
+        // i.e it has read that pxd_dev->fp.fastpath is true
+        // then it is okay for it to be continued via fastpath
+        // since the fastpath fd would still be valid until this IO completes
+        // as part of fastpath_flush_work()
 
         BUG_ON(fproot->magic != FP_ROOT_MAGIC);
         BUG_ON(pxd_dev->magic != PXD_DEV_MAGIC);
 
+#if TEST_FP_RACE
+        // increase the race window
+        printk(KERN_INFO "sleeping for 6 seconds after reading pxd->fp.fastpath as true in %s\n", __func__);
+        msleep(6000);
+#endif
         r = clone_and_map(fproot);
 #ifndef __PX_BLKMQ__
         if (r != 0) {

--- a/pxd_bio_makereq.c
+++ b/pxd_bio_makereq.c
@@ -401,7 +401,7 @@ static void pxd_io_failover(struct work_struct *ws) {
 
         spin_lock_irqsave(&pxd_dev->fp.fail_lock, flags);
         if (!pxd_dev->fp.active_failover) {
-                if (pxd_dev->fp.fastpath) {
+                if (atomic_read(&pxd_dev->fp.fastpath)) {
                         pxd_dev->fp.active_failover = true;
                         __pxd_add2failQ(pxd_dev, head);
                         cleanup = true;
@@ -748,7 +748,7 @@ void pxd_bio_make_request_entryfn(struct request_queue *q, struct bio *bio)
 
         pxd_check_q_congested(pxd_dev);
         read_lock(&pxd_dev->fp.suspend_lock);
-        if (!pxd_dev->fp.fastpath) {
+        if (!atomic_read(&pxd_dev->fp.fastpath)) {
                 atomic_inc(&pxd_dev->fp.nslowPath);
                 pxd_reroute_slowpath(q, bio);
                 read_unlock(&pxd_dev->fp.suspend_lock);

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -82,7 +82,7 @@ bool fastpath_enabled(struct pxd_device *pxd_dev) {
 // current IO status - fastpath vs nativepath
 static inline
 bool fastpath_active(struct pxd_device *pxd_dev) {
-	return pxd_dev->fp.fastpath;
+	return atomic_read(&pxd_dev->fp.fastpath);
 }
 
 void pxd_check_q_congested(struct pxd_device *pxd_dev);

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -13,6 +13,7 @@
 #include <linux/genhd.h>
 #endif
 #include <linux/workqueue.h>
+#include <linux/smp.h>
 
 #include "pxd_bio.h"
 #include "pxd.h"
@@ -259,7 +260,7 @@ int pxd_request_ioswitch(struct pxd_device *pxd_dev, int code)
 	// incompat device
 	if (!fastpath_enabled(pxd_dev)) {
 		printk("device %llu ioswitch request failed (fpenabled %d, fastpath %d)\n",
-			   pxd_dev->dev_id, fastpath_enabled(pxd_dev), fp->fastpath);
+			   pxd_dev->dev_id, fastpath_enabled(pxd_dev), atomic_read(&fp->fastpath));
 		return -EINVAL;
 	}
 
@@ -335,7 +336,7 @@ int pxd_request_suspend_internal(struct pxd_device *pxd_dev,
 
 	pxd_suspend_io(pxd_dev);
 
-	if (skip_flush || !fp->fastpath) return 0;
+	if (skip_flush || !atomic_read(&fp->fastpath)) return 0;
 
 	rc = wait_for_sync(pxd_dev, skip_flush);
 	if (rc)
@@ -414,7 +415,7 @@ void enableFastPath(struct pxd_device *pxd_dev, bool force)
 	char modestr[32];
 
 	if (!fastpath_enabled(pxd_dev) || !pxd_dev->fp.nfd) {
-		pxd_dev->fp.fastpath = false;
+		atomic_set(&pxd_dev->fp.fastpath, 0);
 		return;
 	}
 
@@ -462,11 +463,11 @@ void enableFastPath(struct pxd_device *pxd_dev, bool force)
 		}
 	}
 
-	pxd_dev->fp.fastpath = true;
+	atomic_set(&pxd_dev->fp.fastpath, 1);
 	pxd_resume_io(pxd_dev);
 
 	printk(KERN_INFO"pxd_dev %llu fastpath %d mode %#x setting up with %d backing volumes, [%px,%px,%px]\n",
-		pxd_dev->dev_id, fp->fastpath, mode, fp->nfd,
+		pxd_dev->dev_id, atomic_read(&fp->fastpath), mode, fp->nfd,
 		fp->file[0], fp->file[1], fp->file[2]);
 
 	return;
@@ -479,7 +480,7 @@ out_file_failed:
 	memset(fp->file, 0, sizeof(fp->file));
 	memset(fp->device_path, 0, sizeof(fp->device_path));
 
-	pxd_dev->fp.fastpath = false;
+	atomic_set(&pxd_dev->fp.fastpath, 0);
 	/// volume still remains suspended waiting for CLEANUP request to reopen IO.
 	printk(KERN_INFO"%s: Device %llu no backing volume setup, will take slow path\n",
 		__func__, pxd_dev->dev_id);
@@ -505,11 +506,16 @@ void disableFastPath(struct pxd_device *pxd_dev, bool skipsync)
 	if (!fastpath_enabled(pxd_dev) || !pxd_dev->fp.nfd ||
 			!fastpath_active(pxd_dev)) {
 		pxd_dev->fp.nfd = 0;
-		pxd_dev->fp.fastpath = false;
+		atomic_set(&pxd_dev->fp.fastpath, 0);
 		return;
 	}
 
 	pxd_suspend_io(pxd_dev);
+	// set fastpath to false and then flush
+	// order matters, fp.pathpath must be cleared
+	// before calling fastpath_flush_work
+	atomic_set(&pxd_dev->fp.fastpath, 0);
+	smp_mb();
 	fastpath_flush_work();
 
 	if (PXD_ACTIVE(pxd_dev)) {
@@ -533,7 +539,6 @@ void disableFastPath(struct pxd_device *pxd_dev, bool skipsync)
 		}
 	}
 	fp->nfd = 0;
-	pxd_dev->fp.fastpath = false;
 
 	pxd_resume_io(pxd_dev);
 }
@@ -622,7 +627,7 @@ int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_
 	enableFastPath(pxd_dev, true);
 	pxd_resume_io(pxd_dev);
 
-	if (!pxd_dev->fp.fastpath) goto out_file_failed;
+	if (!atomic_read(&pxd_dev->fp.fastpath)) goto out_file_failed;
 	printk("dev%llu completed setting up %d paths\n", pxd_dev->dev_id, pxd_dev->fp.nfd);
 	return 0;
 out_file_failed:
@@ -756,7 +761,7 @@ int pxd_debug_switch_fastpath(struct pxd_device* pxd_dev)
 
 int pxd_debug_switch_nativepath(struct pxd_device* pxd_dev)
 {
-	if (pxd_dev->fp.fastpath) {
+	if (atomic_read(&pxd_dev->fp.fastpath)) {
 		printk(KERN_WARNING"pxd_dev %llu in fastpath, forcing failover\n",
 				pxd_dev->dev_id);
 		pxd_dev->fp.force_fail = true;

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -36,7 +36,7 @@ struct pxd_fastpath_extension {
 #else
 	rwlock_t suspend_lock;
 #endif
-	bool fastpath;
+	atomic_t fastpath;
 	int nfd;
 	struct file *file[MAX_PXD_BACKING_DEVS];
 	struct pxd_sync_ws syncwi[MAX_PXD_BACKING_DEVS];


### PR DESCRIPTION
** UT notes **

To run UT, define `TEST_FP_RACE` to 1 in `pxd.h`,
 

 
 ** Before fix - IOs gets stuck **
 ```
 ./t --gtest_filter=*FastpathRace*
Note: Google Test filter = *FastpathRace*
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from FailoverTest
[ RUN      ] FailoverTest.FastpathRace
25600+0 records in
25600+0 records out
104857600 bytes (105 MB, 100 MiB) copied, 0.397286 s, 264 MB/s
mke2fs 1.44.1 (24-Mar-2018)
Discarding device blocks: done                            
Creating filesystem with 25600 4k blocks and 25600 inodes

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (1024 blocks): done
Writing superblocks and filesystem accounting information: done

time="2025-04-10 18:07:39Z" level=INFO msg="Executing: sudo dmsetup create flakey_test_loop10 < /tmp/dm_table_sJvGdz"
time="2025-04-10 18:07:39Z" level=INFO msg="Executing: sudo dmsetup create delay_test_loop10 < /tmp/dm_table_IjNEqx"
time="2025-04-10 18:07:39Z" level=INFO msg="Added device /dev/mapper/delay_test_loop10 minor 1 dev_id 1234"
time="2025-04-10 18:07:39Z" level=INFO msg="Pxd path /dev/pxd/pxd1234"
time="2025-04-10 18:07:39Z" level=INFO msg="[fio] executing: sudo fio --name=test --filename=/dev/pxd/pxd1234 --ioengine=libaio --rw=write --bs=4k --offset=52428800 --size=4k --direct=1 --iodepth=256 --numjobs=16"
test: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
...
fio-3.1
Starting 16 processes
time="2025-04-10 18:07:46Z" level=INFO msg="[fio] executing: sudo fio --name=test --filename=/dev/pxd/pxd1234 --ioengine=libaio --rw=write --bs=4k --offset=52428800 --size=4k --direct=1 --iodepth=256 --numjobs=16"
test: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
...
fio-3.1
Starting 16 processes
time="2025-04-10 18:07:47Z" level=INFO msg="wb = 24"0,w=0 IOPS][eta 00m:00s]
time="2025-04-10 18:07:47Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:07:47Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:07:47Z" level=INFO msg="Processing request opcode: 8208 minor: 1 num_volumes: 1"
time="2025-04-10 18:07:47Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:07:47Z" level=INFO msg="Got failover request"
Jobs: 16 (f=16): [W(16)][-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
Jobs: 16 (f=16): [W(16)][-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
Jobs: 16 (f=16): [W(16)][-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
Jobs: 16 (f=16): [W(16)][-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
Jobs: 16 (f=16): [W(16)][-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
Jobs: 16 (f=16): [W(16)][-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
Jobs: 16 (f=16): [W(16)][-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
Jobs: 16 (f=16): [W(16)][-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
Jobs: 16 (f=16): [W(16)][-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
Jobs: 16 (f=16): [W(16)][-.-%][r=0KiB/s,w=0KiB/s][r=0,w=0 IOPS][eta 00m:00s]
```
 

 ** After fix **
 
 ```
 ./t --gtest_filter=*FastpathRace*
Note: Google Test filter = *FastpathRace*
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from FailoverTest
[ RUN      ] FailoverTest.FastpathRace
25600+0 records in
25600+0 records out
104857600 bytes (105 MB, 100 MiB) copied, 0.421346 s, 249 MB/s
mke2fs 1.44.1 (24-Mar-2018)
Discarding device blocks: done                            
Creating filesystem with 25600 4k blocks and 25600 inodes

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (1024 blocks): done
Writing superblocks and filesystem accounting information: done

time="2025-04-10 18:01:06Z" level=INFO msg="Executing: sudo dmsetup create flakey_test_loop10 < /tmp/dm_table_X78f7W"
time="2025-04-10 18:01:06Z" level=INFO msg="Executing: sudo dmsetup create delay_test_loop10 < /tmp/dm_table_9SOnTU"
time="2025-04-10 18:01:06Z" level=INFO msg="Added device /dev/mapper/delay_test_loop10 minor 1 dev_id 1234"
time="2025-04-10 18:01:06Z" level=INFO msg="Pxd path /dev/pxd/pxd1234"
time="2025-04-10 18:01:06Z" level=INFO msg="[fio] executing: sudo fio --name=test --filename=/dev/pxd/pxd1234 --ioengine=libaio --rw=write --bs=4k --offset=52428800 --size=4k --direct=1 --iodepth=256 --numjobs=16"
test: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
...
fio-3.1
Starting 16 processes
time="2025-04-10 18:01:13Z" level=INFO msg="[fio] executing: sudo fio --name=test --filename=/dev/pxd/pxd1234 --ioengine=libaio --rw=write --bs=4k --offset=52428800 --size=4k --direct=1 --iodepth=256 --numjobs=16"
test: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
...
fio-3.1
Starting 16 processes
time="2025-04-10 18:01:14Z" level=INFO msg="wb = 24"0,w=0 IOPS][eta 00m:00s]
time="2025-04-10 18:01:14Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:14Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:14Z" level=INFO msg="Processing request opcode: 8208 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:14Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:14Z" level=INFO msg="Got failover request"
time="2025-04-10 18:01:19Z" level=INFO msg="Added device /dev/mapper/flakey_test_loop10 minor 1 dev_id 1234"
time="2025-04-10 18:01:19Z" level=INFO msg="Pxd path /dev/pxd/pxd1234"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8208 unique: 262144"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 17"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8193 unique: 262272"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 16"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8193 unique: 262273"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 15"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8193 unique: 262274"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 14"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8193 unique: 262275"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 13"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8193 unique: 262276"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 12"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8193 unique: 262400"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 11"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8193 unique: 262528"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 10"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8193 unique: 262656"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 9"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8193 unique: 262401"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 8"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8193 unique: 262529"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 7"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8193 unique: 262402"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 6"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8193 unique: 262657"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 5"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8193 unique: 262530"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 4"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8193 unique: 262531"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 3"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8193 unique: 262403"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 2"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8193 unique: 262658"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104849408 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262277"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 0 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262278"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 4096 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262279"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104853504 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262280"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104722432 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262281"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104824832 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262282"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104726528 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262283"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104652800 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262284"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104554496 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262285"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104509440 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262286"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104480768 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262287"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104390656 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262288"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104357888 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262289"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104349696 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262290"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104370176 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262291"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 103276544 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262292"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 16384 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262293"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 32768 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262294"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 65536 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262295"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 131072 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262296"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 262144 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262297"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 524288 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262298"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 1048576 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262299"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 2097152 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262300"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 4194304 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262301"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 12288 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262302"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 28672 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262303"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 61440 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262304"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 8192 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262305"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 20480 length: 8192"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262306"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 36864 length: 24576"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262307"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 69632 length: 61440"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262308"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 135168 length: 126976"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262309"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 266240 length: 258048"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262310"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104333312 length: 16384"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262311"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104353792 length: 4096"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262312"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104361984 length: 8192"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262313"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104374272 length: 16384"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262314"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104394752 length: 86016"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262315"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104484864 length: 24576"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262316"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104513536 length: 40960"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262317"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104558592 length: 36864"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262318"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104595456 length: 57344"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262319"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104656896 length: 65536"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262320"
time="2025-04-10 18:01:19Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:19Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104730624 length: 61440"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262321"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104796160 length: 28672"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262322"
time="2025-04-10 18:01:19Z" level=INFO msg="Processing request opcode: 8194 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:19Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:19Z" level=INFO msg="Got read request - offset: 104828928 length: 20480"
time="2025-04-10 18:01:19Z" level=INFO msg="sending reply for opcode : 8194 unique: 262323"
Jobs: 15 (f=0): [f(7),_(1),f(8)][-.-%][r=0KiB/s,w=5KiB/s][r=0,w=1 IOPS][eta 00m:00s]
test: (groupid=0, jobs=1): err= 0: pid=200: Thu Apr 10 18:01:19 2025
  write: IOPS=0, BW=333B/s (333B/s)(4096B/12293msec)
    slat (nsec): min=6144.3M, max=6144.3M, avg=6144276247.00, stdev= 0.00
    clat (nsec): min=6146.9M, max=6146.9M, avg=6146920419.00, stdev= 0.00
     lat (nsec): min=12291M, max=12291M, avg=12291200163.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 6141],  5.00th=[ 6141], 10.00th=[ 6141], 20.00th=[ 6141],
     | 30.00th=[ 6141], 40.00th=[ 6141], 50.00th=[ 6141], 60.00th=[ 6141],
     | 70.00th=[ 6141], 80.00th=[ 6141], 90.00th=[ 6141], 95.00th=[ 6141],
     | 99.00th=[ 6141], 99.50th=[ 6141], 99.90th=[ 6141], 99.95th=[ 6141],
     | 99.99th=[ 6141]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=5, majf=0, minf=11
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=201: Thu Apr 10 18:01:19 2025
  write: IOPS=0, BW=333B/s (333B/s)(4096B/12294msec)
    slat (nsec): min=6144.4M, max=6144.4M, avg=6144380352.00, stdev= 0.00
    clat (nsec): min=6147.5M, max=6147.5M, avg=6147539055.00, stdev= 0.00
     lat (nsec): min=12292M, max=12292M, avg=12291921904.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 6141],  5.00th=[ 6141], 10.00th=[ 6141], 20.00th=[ 6141],
     | 30.00th=[ 6141], 40.00th=[ 6141], 50.00th=[ 6141], 60.00th=[ 6141],
     | 70.00th=[ 6141], 80.00th=[ 6141], 90.00th=[ 6141], 95.00th=[ 6141],
     | 99.00th=[ 6141], 99.50th=[ 6141], 99.90th=[ 6141], 99.95th=[ 6141],
     | 99.99th=[ 6141]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.01%, ctx=5, majf=0, minf=12
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=202: Thu Apr 10 18:01:19 2025
  write: IOPS=0, BW=333B/s (333B/s)(4096B/12292msec)
    slat (nsec): min=6144.0M, max=6144.0M, avg=6144976365.00, stdev= 0.00
    clat (nsec): min=6146.5M, max=6146.5M, avg=6146476598.00, stdev= 0.00
     lat (nsec): min=12291M, max=12291M, avg=12291456118.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 6141],  5.00th=[ 6141], 10.00th=[ 6141], 20.00th=[ 6141],
     | 30.00th=[ 6141], 40.00th=[ 6141], 50.00th=[ 6141], 60.00th=[ 6141],
     | 70.00th=[ 6141], 80.00th=[ 6141], 90.00th=[ 6141], 95.00th=[ 6141],
     | 99.00th=[ 6141], 99.50th=[ 6141], 99.90th=[ 6141], 99.95th=[ 6141],
     | 99.99th=[ 6141]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=6, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=203: Thu Apr 10 18:01:19 2025
  write: IOPS=0, BW=333B/s (333B/s)(4096B/12293msec)
    slat (nsec): min=6144.5M, max=6144.5M, avg=6144497548.00, stdev= 0.00
    clat (nsec): min=6146.5M, max=6146.5M, avg=6146537889.00, stdev= 0.00
     lat (nsec): min=12291M, max=12291M, avg=12291054320.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 6141],  5.00th=[ 6141], 10.00th=[ 6141], 20.00th=[ 6141],
     | 30.00th=[ 6141], 40.00th=[ 6141], 50.00th=[ 6141], 60.00th=[ 6141],
     | 70.00th=[ 6141], 80.00th=[ 6141], 90.00th=[ 6141], 95.00th=[ 6141],
     | 99.00th=[ 6141], 99.50th=[ 6141], 99.90th=[ 6141], 99.95th=[ 6141],
     | 99.99th=[ 6141]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.01%, sys=0.00%, ctx=5, majf=0, minf=12
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=204: Thu Apr 10 18:01:19 2025
  write: IOPS=0, BW=333B/s (333B/s)(4096B/12292msec)
    slat (nsec): min=6144.6M, max=6144.6M, avg=6144563090.00, stdev= 0.00
    clat (nsec): min=6146.2M, max=6146.2M, avg=6146181617.00, stdev= 0.00
     lat (nsec): min=12291M, max=12291M, avg=12290747626.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 6141],  5.00th=[ 6141], 10.00th=[ 6141], 20.00th=[ 6141],
     | 30.00th=[ 6141], 40.00th=[ 6141], 50.00th=[ 6141], 60.00th=[ 6141],
     | 70.00th=[ 6141], 80.00th=[ 6141], 90.00th=[ 6141], 95.00th=[ 6141],
     | 99.00th=[ 6141], 99.50th=[ 6141], 99.90th=[ 6141], 99.95th=[ 6141],
     | 99.99th=[ 6141]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=5, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=205: Thu Apr 10 18:01:19 2025
  write: IOPS=0, BW=333B/s (333B/s)(4096B/12293msec)
    slat (nsec): min=6144.7M, max=6144.7M, avg=6144746881.00, stdev= 0.00
    clat (nsec): min=6146.9M, max=6146.9M, avg=6146907681.00, stdev= 0.00
     lat (nsec): min=12292M, max=12292M, avg=12291657493.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 6141],  5.00th=[ 6141], 10.00th=[ 6141], 20.00th=[ 6141],
     | 30.00th=[ 6141], 40.00th=[ 6141], 50.00th=[ 6141], 60.00th=[ 6141],
     | 70.00th=[ 6141], 80.00th=[ 6141], 90.00th=[ 6141], 95.00th=[ 6141],
     | 99.00th=[ 6141], 99.50th=[ 6141], 99.90th=[ 6141], 99.95th=[ 6141],
     | 99.99th=[ 6141]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.01%, ctx=5, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=206: Thu Apr 10 18:01:19 2025
  write: IOPS=0, BW=333B/s (333B/s)(4096B/12292msec)
    slat (nsec): min=6143.5M, max=6143.5M, avg=6143490910.00, stdev= 0.00
    clat (nsec): min=6148.1M, max=6148.1M, avg=6148073402.00, stdev= 0.00
     lat (nsec): min=12292M, max=12292M, avg=12291567528.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 6141],  5.00th=[ 6141], 10.00th=[ 6141], 20.00th=[ 6141],
     | 30.00th=[ 6141], 40.00th=[ 6141], 50.00th=[ 6141], 60.00th=[ 6141],
     | 70.00th=[ 6141], 80.00th=[ 6141], 90.00th=[ 6141], 95.00th=[ 6141],
     | 99.00th=[ 6141], 99.50th=[ 6141], 99.90th=[ 6141], 99.95th=[ 6141],
     | 99.99th=[ 6141]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=3, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=207: Thu Apr 10 18:01:19 2025
  write: IOPS=0, BW=333B/s (333B/s)(4096B/12292msec)
    slat (nsec): min=6144.8M, max=6144.8M, avg=6144808104.00, stdev= 0.00
    clat (nsec): min=6146.4M, max=6146.4M, avg=6146417315.00, stdev= 0.00
     lat (nsec): min=12291M, max=12291M, avg=12291228573.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 6141],  5.00th=[ 6141], 10.00th=[ 6141], 20.00th=[ 6141],
     | 30.00th=[ 6141], 40.00th=[ 6141], 50.00th=[ 6141], 60.00th=[ 6141],
     | 70.00th=[ 6141], 80.00th=[ 6141], 90.00th=[ 6141], 95.00th=[ 6141],
     | 99.00th=[ 6141], 99.50th=[ 6141], 99.90th=[ 6141], 99.95th=[ 6141],
     | 99.99th=[ 6141]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.01%, ctx=6, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=208: Thu Apr 10 18:01:19 2025
  write: IOPS=0, BW=333B/s (333B/s)(4096B/12293msec)
    slat (nsec): min=6145.1M, max=6145.1M, avg=6145112022.00, stdev= 0.00
    clat (nsec): min=6147.3M, max=6147.3M, avg=6147267128.00, stdev= 0.00
     lat (nsec): min=12292M, max=12292M, avg=12292391976.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 6141],  5.00th=[ 6141], 10.00th=[ 6141], 20.00th=[ 6141],
     | 30.00th=[ 6141], 40.00th=[ 6141], 50.00th=[ 6141], 60.00th=[ 6141],
     | 70.00th=[ 6141], 80.00th=[ 6141], 90.00th=[ 6141], 95.00th=[ 6141],
     | 99.00th=[ 6141], 99.50th=[ 6141], 99.90th=[ 6141], 99.95th=[ 6141],
     | 99.99th=[ 6141]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.01%, sys=0.00%, ctx=4, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=209: Thu Apr 10 18:01:19 2025
  write: IOPS=0, BW=333B/s (333B/s)(4096B/12293msec)
    slat (nsec): min=6144.8M, max=6144.8M, avg=6144753356.00, stdev= 0.00
    clat (nsec): min=6147.2M, max=6147.2M, avg=6147159105.00, stdev= 0.00
     lat (nsec): min=12292M, max=12292M, avg=12291914856.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 6141],  5.00th=[ 6141], 10.00th=[ 6141], 20.00th=[ 6141],
     | 30.00th=[ 6141], 40.00th=[ 6141], 50.00th=[ 6141], 60.00th=[ 6141],
     | 70.00th=[ 6141], 80.00th=[ 6141], 90.00th=[ 6141], 95.00th=[ 6141],
     | 99.00th=[ 6141], 99.50th=[ 6141], 99.90th=[ 6141], 99.95th=[ 6141],
     | 99.99th=[ 6141]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.01%, ctx=4, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=210: Thu Apr 10 18:01:19 2025
  write: IOPS=0, BW=333B/s (333B/s)(4096B/12293msec)
    slat (nsec): min=6144.2M, max=6144.2M, avg=6144188145.00, stdev= 0.00
    clat (nsec): min=6147.9M, max=6147.9M, avg=6147911890.00, stdev= 0.00
     lat (nsec): min=12292M, max=12292M, avg=12292102994.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 6141],  5.00th=[ 6141], 10.00th=[ 6141], 20.00th=[ 6141],
     | 30.00th=[ 6141], 40.00th=[ 6141], 50.00th=[ 6141], 60.00th=[ 6141],
     | 70.00th=[ 6141], 80.00th=[ 6141], 90.00th=[ 6141], 95.00th=[ 6141],
     | 99.00th=[ 6141], 99.50th=[ 6141], 99.90th=[ 6141], 99.95th=[ 6141],
     | 99.99th=[ 6141]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=6, majf=0, minf=11
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=211: Thu Apr 10 18:01:19 2025
  write: IOPS=0, BW=333B/s (333B/s)(4096B/12293msec)
    slat (nsec): min=6145.1M, max=6145.1M, avg=6145080758.00, stdev= 0.00
    clat (nsec): min=6147.3M, max=6147.3M, avg=6147312838.00, stdev= 0.00
     lat (nsec): min=12292M, max=12292M, avg=12292396785.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 6141],  5.00th=[ 6141], 10.00th=[ 6141], 20.00th=[ 6141],
     | 30.00th=[ 6141], 40.00th=[ 6141], 50.00th=[ 6141], 60.00th=[ 6141],
     | 70.00th=[ 6141], 80.00th=[ 6141], 90.00th=[ 6141], 95.00th=[ 6141],
     | 99.00th=[ 6141], 99.50th=[ 6141], 99.90th=[ 6141], 99.95th=[ 6141],
     | 99.99th=[ 6141]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=5, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=212: Thu Apr 10 18:01:19 2025
  write: IOPS=0, BW=333B/s (333B/s)(4096B/12294msec)
    slat (nsec): min=6144.6M, max=6144.6M, avg=6144619279.00, stdev= 0.00
    clat (nsec): min=6147.7M, max=6147.7M, avg=6147721955.00, stdev= 0.00
     lat (nsec): min=12292M, max=12292M, avg=12292344168.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 6141],  5.00th=[ 6141], 10.00th=[ 6141], 20.00th=[ 6141],
     | 30.00th=[ 6141], 40.00th=[ 6141], 50.00th=[ 6141], 60.00th=[ 6141],
     | 70.00th=[ 6141], 80.00th=[ 6141], 90.00th=[ 6141], 95.00th=[ 6141],
     | 99.00th=[ 6141], 99.50th=[ 6141], 99.90th=[ 6141], 99.95th=[ 6141],
     | 99.99th=[ 6141]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.01%, ctx=5, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=213: Thu Apr 10 18:01:19 2025
  write: IOPS=0, BW=333B/s (333B/s)(4096B/12293msec)
    slat (nsec): min=6144.9M, max=6144.9M, avg=6144851382.00, stdev= 0.00
    clat (nsec): min=6147.3M, max=6147.3M, avg=6147281251.00, stdev= 0.00
     lat (nsec): min=12292M, max=12292M, avg=12292147200.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 6141],  5.00th=[ 6141], 10.00th=[ 6141], 20.00th=[ 6141],
     | 30.00th=[ 6141], 40.00th=[ 6141], 50.00th=[ 6141], 60.00th=[ 6141],
     | 70.00th=[ 6141], 80.00th=[ 6141], 90.00th=[ 6141], 95.00th=[ 6141],
     | 99.00th=[ 6141], 99.50th=[ 6141], 99.90th=[ 6141], 99.95th=[ 6141],
     | 99.99th=[ 6141]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=4, majf=0, minf=11
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=214: Thu Apr 10 18:01:19 2025
  write: IOPS=0, BW=333B/s (333B/s)(4096B/12293msec)
    slat (nsec): min=6144.9M, max=6144.9M, avg=6144873552.00, stdev= 0.00
    clat (nsec): min=6147.1M, max=6147.1M, avg=6147104438.00, stdev= 0.00
     lat (nsec): min=12292M, max=12292M, avg=12291981825.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 6141],  5.00th=[ 6141], 10.00th=[ 6141], 20.00th=[ 6141],
     | 30.00th=[ 6141], 40.00th=[ 6141], 50.00th=[ 6141], 60.00th=[ 6141],
     | 70.00th=[ 6141], 80.00th=[ 6141], 90.00th=[ 6141], 95.00th=[ 6141],
     | 99.00th=[ 6141], 99.50th=[ 6141], 99.90th=[ 6141], 99.95th=[ 6141],
     | 99.99th=[ 6141]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=5, majf=0, minf=11
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=215: Thu Apr 10 18:01:19 2025
  write: IOPS=0, BW=333B/s (333B/s)(4096B/12292msec)
    slat (nsec): min=6143.4M, max=6143.4M, avg=6143360684.00, stdev= 0.00
    clat (nsec): min=6147.6M, max=6147.6M, avg=6147583843.00, stdev= 0.00
     lat (nsec): min=12291M, max=12291M, avg=12290948390.00, stdev= 0.00
    clat percentiles (msec):
     |  1.00th=[ 6141],  5.00th=[ 6141], 10.00th=[ 6141], 20.00th=[ 6141],
     | 30.00th=[ 6141], 40.00th=[ 6141], 50.00th=[ 6141], 60.00th=[ 6141],
     | 70.00th=[ 6141], 80.00th=[ 6141], 90.00th=[ 6141], 95.00th=[ 6141],
     | 99.00th=[ 6141], 99.50th=[ 6141], 99.90th=[ 6141], 99.95th=[ 6141],
     | 99.99th=[ 6141]
  lat (msec)   : >=2000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=3, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256

Run status group 0 (all jobs):
  WRITE: bw=5330B/s (5330B/s), 333B/s-333B/s (333B/s-333B/s), io=64.0KiB (65.5kB), run=12292-12294msec

Disk stats (read/write):
  pxd!pxd1234: ios=1/0, merge=0/0, ticks=12286/0, in_queue=12284, util=37.60%
time="2025-04-10 18:01:19Z" level=INFO msg="[fio] completed."S][eta 00m:00s]
time="2025-04-10 18:01:20Z" level=INFO msg="epoll_wait returned 1"a 00m:00s]
time="2025-04-10 18:01:20Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:20Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:20Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:20Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 16"
time="2025-04-10 18:01:20Z" level=INFO msg="sending reply for opcode : 8193 unique: 262324"
time="2025-04-10 18:01:20Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:20Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:20Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 15"
time="2025-04-10 18:01:20Z" level=INFO msg="sending reply for opcode : 8193 unique: 262325"
time="2025-04-10 18:01:20Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:20Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:20Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 14"
time="2025-04-10 18:01:20Z" level=INFO msg="sending reply for opcode : 8193 unique: 262532"
time="2025-04-10 18:01:20Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:20Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:20Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 13"
time="2025-04-10 18:01:20Z" level=INFO msg="sending reply for opcode : 8193 unique: 262533"
time="2025-04-10 18:01:20Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:20Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:20Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:20Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:20Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 12"
time="2025-04-10 18:01:20Z" level=INFO msg="sending reply for opcode : 8193 unique: 262326"
time="2025-04-10 18:01:20Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:20Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:20Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 11"
time="2025-04-10 18:01:20Z" level=INFO msg="sending reply for opcode : 8193 unique: 262327"
time="2025-04-10 18:01:20Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:20Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:20Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 10"
time="2025-04-10 18:01:20Z" level=INFO msg="sending reply for opcode : 8193 unique: 262404"
time="2025-04-10 18:01:20Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:20Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:20Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 9"
time="2025-04-10 18:01:20Z" level=INFO msg="sending reply for opcode : 8193 unique: 262659"
time="2025-04-10 18:01:20Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:20Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:20Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:20Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:20Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 8"
time="2025-04-10 18:01:20Z" level=INFO msg="sending reply for opcode : 8193 unique: 262660"
time="2025-04-10 18:01:20Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:20Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:20Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 7"
time="2025-04-10 18:01:20Z" level=INFO msg="sending reply for opcode : 8193 unique: 262661"
time="2025-04-10 18:01:20Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:20Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:20Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 6"
time="2025-04-10 18:01:20Z" level=INFO msg="sending reply for opcode : 8193 unique: 262534"
time="2025-04-10 18:01:20Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:20Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:20Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 5"
time="2025-04-10 18:01:20Z" level=INFO msg="sending reply for opcode : 8193 unique: 262405"
time="2025-04-10 18:01:20Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:20Z" level=INFO msg="got event from kernel"
time="2025-04-10 18:01:20Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:20Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:20Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 4"
time="2025-04-10 18:01:20Z" level=INFO msg="sending reply for opcode : 8193 unique: 262662"
time="2025-04-10 18:01:20Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:20Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:20Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 3"
time="2025-04-10 18:01:20Z" level=INFO msg="sending reply for opcode : 8193 unique: 262663"
time="2025-04-10 18:01:20Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:20Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:20Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 2"
time="2025-04-10 18:01:20Z" level=INFO msg="sending reply for opcode : 8193 unique: 262664"
time="2025-04-10 18:01:20Z" level=INFO msg="Processing request opcode: 8193 minor: 1 num_volumes: 1"
time="2025-04-10 18:01:20Z" level=INFO msg="active_idx : 0"
time="2025-04-10 18:01:20Z" level=INFO msg="Got write request - offset: 52428800 length: 4096 active_io_count 1"
time="2025-04-10 18:01:20Z" level=INFO msg="sending reply for opcode : 8193 unique: 262535"

test: (groupid=0, jobs=1): err= 0: pid=238: Thu Apr 10 18:01:20 2025
  write: IOPS=0, BW=670B/s (670B/s)(4096B/6113msec)
    slat (nsec): min=6111.4M, max=6111.4M, avg=6111378336.00, stdev= 0.00
    clat (nsec): min=1048.7k, max=1048.7k, avg=1048682.00, stdev= 0.00
     lat (nsec): min=6112.4M, max=6112.4M, avg=6112429912.00, stdev= 0.00
    clat percentiles (usec):
     |  1.00th=[ 1057],  5.00th=[ 1057], 10.00th=[ 1057], 20.00th=[ 1057],
     | 30.00th=[ 1057], 40.00th=[ 1057], 50.00th=[ 1057], 60.00th=[ 1057],
     | 70.00th=[ 1057], 80.00th=[ 1057], 90.00th=[ 1057], 95.00th=[ 1057],
     | 99.00th=[ 1057], 99.50th=[ 1057], 99.90th=[ 1057], 99.95th=[ 1057],
     | 99.99th=[ 1057]
  lat (msec)   : 2=100.00%
  cpu          : usr=0.03%, sys=0.00%, ctx=5, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=239: Thu Apr 10 18:01:20 2025
  write: IOPS=0, BW=670B/s (670B/s)(4096B/6113msec)
    slat (nsec): min=6109.2M, max=6109.2M, avg=6109164956.00, stdev= 0.00
    clat (nsec): min=990642, max=990642, avg=990642.00, stdev= 0.00
     lat (nsec): min=6110.2M, max=6110.2M, avg=6110159071.00, stdev= 0.00
    clat percentiles (usec):
     |  1.00th=[  988],  5.00th=[  988], 10.00th=[  988], 20.00th=[  988],
     | 30.00th=[  988], 40.00th=[  988], 50.00th=[  988], 60.00th=[  988],
     | 70.00th=[  988], 80.00th=[  988], 90.00th=[  988], 95.00th=[  988],
     | 99.00th=[  988], 99.50th=[  988], 99.90th=[  988], 99.95th=[  988],
     | 99.99th=[  988]
  lat (usec)   : 1000=100.00%
  cpu          : usr=0.02%, sys=0.00%, ctx=5, majf=0, minf=7
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=240: Thu Apr 10 18:01:20 2025
  write: IOPS=0, BW=670B/s (670B/s)(4096B/6113msec)
    slat (nsec): min=6109.4M, max=6109.4M, avg=6109448914.00, stdev= 0.00
    clat (nsec): min=1348.8k, max=1348.8k, avg=1348819.00, stdev= 0.00
     lat (nsec): min=6110.8M, max=6110.8M, avg=6110800712.00, stdev= 0.00
    clat percentiles (usec):
     |  1.00th=[ 1352],  5.00th=[ 1352], 10.00th=[ 1352], 20.00th=[ 1352],
     | 30.00th=[ 1352], 40.00th=[ 1352], 50.00th=[ 1352], 60.00th=[ 1352],
     | 70.00th=[ 1352], 80.00th=[ 1352], 90.00th=[ 1352], 95.00th=[ 1352],
     | 99.00th=[ 1352], 99.50th=[ 1352], 99.90th=[ 1352], 99.95th=[ 1352],
     | 99.99th=[ 1352]
  lat (msec)   : 2=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=4, majf=0, minf=7
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=241: Thu Apr 10 18:01:20 2025
  write: IOPS=0, BW=670B/s (670B/s)(4096B/6112msec)
    slat (nsec): min=6109.2M, max=6109.2M, avg=6109162724.00, stdev= 0.00
    clat (nsec): min=293014, max=293014, avg=293014.00, stdev= 0.00
     lat (nsec): min=6109.5M, max=6109.5M, avg=6109473896.00, stdev= 0.00
    clat percentiles (usec):
     |  1.00th=[  293],  5.00th=[  293], 10.00th=[  293], 20.00th=[  293],
     | 30.00th=[  293], 40.00th=[  293], 50.00th=[  293], 60.00th=[  293],
     | 70.00th=[  293], 80.00th=[  293], 90.00th=[  293], 95.00th=[  293],
     | 99.00th=[  293], 99.50th=[  293], 99.90th=[  293], 99.95th=[  293],
     | 99.99th=[  293]
  lat (usec)   : 500=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=4, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=242: Thu Apr 10 18:01:20 2025
  write: IOPS=0, BW=670B/s (670B/s)(4096B/6112msec)
    slat (nsec): min=6109.3M, max=6109.3M, avg=6109259944.00, stdev= 0.00
    clat (nsec): min=378287, max=378287, avg=378287.00, stdev= 0.00
     lat (nsec): min=6109.6M, max=6109.6M, avg=6109641999.00, stdev= 0.00
    clat percentiles (usec):
     |  1.00th=[  379],  5.00th=[  379], 10.00th=[  379], 20.00th=[  379],
     | 30.00th=[  379], 40.00th=[  379], 50.00th=[  379], 60.00th=[  379],
     | 70.00th=[  379], 80.00th=[  379], 90.00th=[  379], 95.00th=[  379],
     | 99.00th=[  379], 99.50th=[  379], 99.90th=[  379], 99.95th=[  379],
     | 99.99th=[  379]
  lat (usec)   : 500=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=6, majf=0, minf=8
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=243: Thu Apr 10 18:01:20 2025
  write: IOPS=0, BW=670B/s (670B/s)(4096B/6113msec)
    slat (nsec): min=6109.4M, max=6109.4M, avg=6109418575.00, stdev= 0.00
    clat (nsec): min=944867, max=944867, avg=944867.00, stdev= 0.00
     lat (nsec): min=6110.4M, max=6110.4M, avg=6110365942.00, stdev= 0.00
    clat percentiles (usec):
     |  1.00th=[  947],  5.00th=[  947], 10.00th=[  947], 20.00th=[  947],
     | 30.00th=[  947], 40.00th=[  947], 50.00th=[  947], 60.00th=[  947],
     | 70.00th=[  947], 80.00th=[  947], 90.00th=[  947], 95.00th=[  947],
     | 99.00th=[  947], 99.50th=[  947], 99.90th=[  947], 99.95th=[  947],
     | 99.99th=[  947]
  lat (usec)   : 1000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=4, majf=0, minf=8
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=244: Thu Apr 10 18:01:20 2025
  write: IOPS=0, BW=670B/s (670B/s)(4096B/6113msec)
    slat (nsec): min=6109.4M, max=6109.4M, avg=6109408620.00, stdev= 0.00
    clat (nsec): min=663936, max=663936, avg=663936.00, stdev= 0.00
     lat (nsec): min=6110.1M, max=6110.1M, avg=6110075158.00, stdev= 0.00
    clat percentiles (usec):
     |  1.00th=[  668],  5.00th=[  668], 10.00th=[  668], 20.00th=[  668],
     | 30.00th=[  668], 40.00th=[  668], 50.00th=[  668], 60.00th=[  668],
     | 70.00th=[  668], 80.00th=[  668], 90.00th=[  668], 95.00th=[  668],
     | 99.00th=[  668], 99.50th=[  668], 99.90th=[  668], 99.95th=[  668],
     | 99.99th=[  668]
  lat (usec)   : 750=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=4, majf=0, minf=10
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=245: Thu Apr 10 18:01:20 2025
  write: IOPS=0, BW=670B/s (670B/s)(4096B/6111msec)
    slat (nsec): min=6109.2M, max=6109.2M, avg=6109221473.00, stdev= 0.00
    clat (nsec): min=441950, max=441950, avg=441950.00, stdev= 0.00
     lat (nsec): min=6109.7M, max=6109.7M, avg=6109665855.00, stdev= 0.00
    clat percentiles (usec):
     |  1.00th=[  441],  5.00th=[  441], 10.00th=[  441], 20.00th=[  441],
     | 30.00th=[  441], 40.00th=[  441], 50.00th=[  441], 60.00th=[  441],
     | 70.00th=[  441], 80.00th=[  441], 90.00th=[  441], 95.00th=[  441],
     | 99.00th=[  441], 99.50th=[  441], 99.90th=[  441], 99.95th=[  441],
     | 99.99th=[  441]
  lat (usec)   : 500=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=4, majf=0, minf=8
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=246: Thu Apr 10 18:01:20 2025
  write: IOPS=0, BW=670B/s (670B/s)(4096B/6113msec)
    slat (nsec): min=6109.2M, max=6109.2M, avg=6109189568.00, stdev= 0.00
    clat (nsec): min=889453, max=889453, avg=889453.00, stdev= 0.00
     lat (nsec): min=6110.1M, max=6110.1M, avg=6110082280.00, stdev= 0.00
    clat percentiles (usec):
     |  1.00th=[  889],  5.00th=[  889], 10.00th=[  889], 20.00th=[  889],
     | 30.00th=[  889], 40.00th=[  889], 50.00th=[  889], 60.00th=[  889],
     | 70.00th=[  889], 80.00th=[  889], 90.00th=[  889], 95.00th=[  889],
     | 99.00th=[  889], 99.50th=[  889], 99.90th=[  889], 99.95th=[  889],
     | 99.99th=[  889]
  lat (usec)   : 1000=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=6, majf=0, minf=7
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=247: Thu Apr 10 18:01:20 2025
  write: IOPS=0, BW=670B/s (670B/s)(4096B/6113msec)
    slat (nsec): min=6109.5M, max=6109.5M, avg=6109476475.00, stdev= 0.00
    clat (nsec): min=1183.5k, max=1183.5k, avg=1183495.00, stdev= 0.00
     lat (nsec): min=6110.7M, max=6110.7M, avg=6110663505.00, stdev= 0.00
    clat percentiles (usec):
     |  1.00th=[ 1188],  5.00th=[ 1188], 10.00th=[ 1188], 20.00th=[ 1188],
     | 30.00th=[ 1188], 40.00th=[ 1188], 50.00th=[ 1188], 60.00th=[ 1188],
     | 70.00th=[ 1188], 80.00th=[ 1188], 90.00th=[ 1188], 95.00th=[ 1188],
     | 99.00th=[ 1188], 99.50th=[ 1188], 99.90th=[ 1188], 99.95th=[ 1188],
     | 99.99th=[ 1188]
  lat (msec)   : 2=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=6, majf=0, minf=8
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=248: Thu Apr 10 18:01:20 2025
  write: IOPS=0, BW=670B/s (670B/s)(4096B/6113msec)
    slat (nsec): min=6109.3M, max=6109.3M, avg=6109326276.00, stdev= 0.00
    clat (nsec): min=766762, max=766762, avg=766762.00, stdev= 0.00
     lat (nsec): min=6110.1M, max=6110.1M, avg=6110096046.00, stdev= 0.00
    clat percentiles (usec):
     |  1.00th=[  766],  5.00th=[  766], 10.00th=[  766], 20.00th=[  766],
     | 30.00th=[  766], 40.00th=[  766], 50.00th=[  766], 60.00th=[  766],
     | 70.00th=[  766], 80.00th=[  766], 90.00th=[  766], 95.00th=[  766],
     | 99.00th=[  766], 99.50th=[  766], 99.90th=[  766], 99.95th=[  766],
     | 99.99th=[  766]
  lat (usec)   : 1000=100.00%
  cpu          : usr=0.03%, sys=0.00%, ctx=5, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=249: Thu Apr 10 18:01:20 2025
  write: IOPS=0, BW=670B/s (670B/s)(4096B/6112msec)
    slat (nsec): min=6111.1M, max=6111.1M, avg=6111058716.00, stdev= 0.00
    clat (nsec): min=210531, max=210531, avg=210531.00, stdev= 0.00
     lat (nsec): min=6111.3M, max=6111.3M, avg=6111272148.00, stdev= 0.00
    clat percentiles (usec):
     |  1.00th=[  210],  5.00th=[  210], 10.00th=[  210], 20.00th=[  210],
     | 30.00th=[  210], 40.00th=[  210], 50.00th=[  210], 60.00th=[  210],
     | 70.00th=[  210], 80.00th=[  210], 90.00th=[  210], 95.00th=[  210],
     | 99.00th=[  210], 99.50th=[  210], 99.90th=[  210], 99.95th=[  210],
     | 99.99th=[  210]
  lat (usec)   : 250=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=7, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=250: Thu Apr 10 18:01:20 2025
  write: IOPS=0, BW=670B/s (670B/s)(4096B/6113msec)
    slat (nsec): min=6111.2M, max=6111.2M, avg=6111237291.00, stdev= 0.00
    clat (nsec): min=1096.7k, max=1096.7k, avg=1096715.00, stdev= 0.00
     lat (nsec): min=6112.3M, max=6112.3M, avg=6112337061.00, stdev= 0.00
    clat percentiles (usec):
     |  1.00th=[ 1090],  5.00th=[ 1090], 10.00th=[ 1090], 20.00th=[ 1090],
     | 30.00th=[ 1090], 40.00th=[ 1090], 50.00th=[ 1090], 60.00th=[ 1090],
     | 70.00th=[ 1090], 80.00th=[ 1090], 90.00th=[ 1090], 95.00th=[ 1090],
     | 99.00th=[ 1090], 99.50th=[ 1090], 99.90th=[ 1090], 99.95th=[ 1090],
     | 99.99th=[ 1090]
  lat (msec)   : 2=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=5, majf=0, minf=7
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=251: Thu Apr 10 18:01:20 2025
  write: IOPS=0, BW=670B/s (670B/s)(4096B/6112msec)
    slat (nsec): min=6109.4M, max=6109.4M, avg=6109428635.00, stdev= 0.00
    clat (nsec): min=1302.4k, max=1302.4k, avg=1302353.00, stdev= 0.00
     lat (nsec): min=6110.7M, max=6110.7M, avg=6110739006.00, stdev= 0.00
    clat percentiles (usec):
     |  1.00th=[ 1303],  5.00th=[ 1303], 10.00th=[ 1303], 20.00th=[ 1303],
     | 30.00th=[ 1303], 40.00th=[ 1303], 50.00th=[ 1303], 60.00th=[ 1303],
     | 70.00th=[ 1303], 80.00th=[ 1303], 90.00th=[ 1303], 95.00th=[ 1303],
     | 99.00th=[ 1303], 99.50th=[ 1303], 99.90th=[ 1303], 99.95th=[ 1303],
     | 99.99th=[ 1303]
  lat (msec)   : 2=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=3, majf=0, minf=9
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=252: Thu Apr 10 18:01:20 2025
  write: IOPS=0, BW=670B/s (670B/s)(4096B/6111msec)
    slat (nsec): min=6109.3M, max=6109.3M, avg=6109292813.00, stdev= 0.00
    clat (nsec): min=1475.0k, max=1475.0k, avg=1475037.00, stdev= 0.00
     lat (nsec): min=6110.8M, max=6110.8M, avg=6110771089.00, stdev= 0.00
    clat percentiles (usec):
     |  1.00th=[ 1483],  5.00th=[ 1483], 10.00th=[ 1483], 20.00th=[ 1483],
     | 30.00th=[ 1483], 40.00th=[ 1483], 50.00th=[ 1483], 60.00th=[ 1483],
     | 70.00th=[ 1483], 80.00th=[ 1483], 90.00th=[ 1483], 95.00th=[ 1483],
     | 99.00th=[ 1483], 99.50th=[ 1483], 99.90th=[ 1483], 99.95th=[ 1483],
     | 99.99th=[ 1483]
  lat (msec)   : 2=100.00%
  cpu          : usr=0.00%, sys=0.00%, ctx=4, majf=0, minf=8
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256
test: (groupid=0, jobs=1): err= 0: pid=253: Thu Apr 10 18:01:20 2025
  write: IOPS=0, BW=670B/s (670B/s)(4096B/6113msec)
    slat (nsec): min=6111.3M, max=6111.3M, avg=6111260908.00, stdev= 0.00
    clat (nsec): min=547185, max=547185, avg=547185.00, stdev= 0.00
     lat (nsec): min=6111.8M, max=6111.8M, avg=6111810531.00, stdev= 0.00
    clat percentiles (usec):
     |  1.00th=[  545],  5.00th=[  545], 10.00th=[  545], 20.00th=[  545],
     | 30.00th=[  545], 40.00th=[  545], 50.00th=[  545], 60.00th=[  545],
     | 70.00th=[  545], 80.00th=[  545], 90.00th=[  545], 95.00th=[  545],
     | 99.00th=[  545], 99.50th=[  545], 99.90th=[  545], 99.95th=[  545],
     | 99.99th=[  545]
  lat (usec)   : 750=100.00%
  cpu          : usr=0.02%, sys=0.00%, ctx=6, majf=0, minf=7
  IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwt: total=0,1,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=256

Run status group 0 (all jobs):
  WRITE: bw=10.5KiB/s (10.7kB/s), 670B/s-670B/s (670B/s-670B/s), io=64.0KiB (65.5kB), run=6111-6113msec

Disk stats (read/write):
  pxd!pxd1234: ios=48/16, merge=0/0, ticks=13064/196716, in_queue=209728, util=86.28%
time="2025-04-10 18:01:20Z" level=INFO msg="[fio] completed."
time="2025-04-10 18:01:20Z" level=INFO msg="sleeping for 10 seconds"
time="2025-04-10 18:01:30Z" level=INFO msg="epoll_wait returned 1"
time="2025-04-10 18:01:30Z" level=INFO msg="done with the control thread"
time="2025-04-10 18:01:30Z" level=INFO msg="nr_failover_to_userspace : 0, nr_fallback_to_kernel : 0, nr_unknown : 0"
[       OK ] FailoverTest.FastpathRace (25257 ms)
[----------] 1 test from FailoverTest (25257 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (25257 ms total)
[  PASSED  ] 1 test.
time="2025-04-10 18:01:30Z" level=INFO msg="Shutting down System Monitor"
```



**What this PR does / why we need it**:
the race is describe in detail here : https://purestorage.atlassian.net/browse/PWX-43070


**Which issue(s) this PR fixes** (optional)
Closes # PWX-43070

**Special notes for your reviewer**:

