### PR TITLE
PWX-43070

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1185,6 +1185,11 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 {
 	struct fp_root_context *fproot = &req->fproot;
 	fp_root_context_init(fproot);
+
+	// rcu read side critical section can't sleep
+	// fastpath_queue_work -> kthread_queue_work
+	// and kthread_queue_work won't sleep since it
+	// acquires a spinlock (see : https://elixir.bootlin.com/linux/v6.13.7/source/kernel/kthread.c#L1030)
 	rcu_read_lock();
 	if (READ_ONCE(pxd_dev->fp.fastpath)) {
 		// route through fastpath

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -510,6 +510,8 @@ void disableFastPath(struct pxd_device *pxd_dev, bool skipsync)
 	}
 
 	pxd_suspend_io(pxd_dev);
+	WRITE_ONCE(pxd_dev->fp.fastpath, false);
+	synchronize_rcu();
 	fastpath_flush_work();
 
 	if (PXD_ACTIVE(pxd_dev)) {
@@ -533,7 +535,6 @@ void disableFastPath(struct pxd_device *pxd_dev, bool skipsync)
 		}
 	}
 	fp->nfd = 0;
-	pxd_dev->fp.fastpath = false;
 
 	pxd_resume_io(pxd_dev);
 }

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -511,7 +511,10 @@ void disableFastPath(struct pxd_device *pxd_dev, bool skipsync)
 
 	pxd_suspend_io(pxd_dev);
 	WRITE_ONCE(pxd_dev->fp.fastpath, false);
+	// in pxd_queue_rq, if there are existing readers in the RCU read side critical section
+	// synchronize_rcu will wait for them to end (queue to fastpath kthread)
 	synchronize_rcu();
+	// at this point, all readers would see pxd_dev->fp.fastpath = false
 	fastpath_flush_work();
 
 	if (PXD_ACTIVE(pxd_dev)) {


### PR DESCRIPTION
For reference, use https://docs.kernel.org/RCU/Design/Requirements/Requirements.html, and it has a specific example which is similar to our use-case

```
1 #define STATE_NORMAL        0
 2 #define STATE_WANT_RECOVERY 1
 3 #define STATE_RECOVERING    2
 4 #define STATE_WANT_NORMAL   3
 5
 6 int state = STATE_NORMAL;
 7
 8 void do_something_dlm(void)
 9 {
10   int state_snap;
11
12   rcu_read_lock();
13   state_snap = READ_ONCE(state);
14   if (state_snap == STATE_NORMAL)
15     do_something();
16   else
17     do_something_carefully();
18   rcu_read_unlock();
19 }
20
21 void start_recovery(void)
22 {
23   WRITE_ONCE(state, STATE_WANT_RECOVERY);
24   synchronize_rcu();
25   WRITE_ONCE(state, STATE_RECOVERING);
26   recovery();
27   WRITE_ONCE(state, STATE_WANT_NORMAL);
28   synchronize_rcu();
29   WRITE_ONCE(state, STATE_NORMAL);
30 }
```

```
The RCU read-side critical section in do_something_dlm() works with the synchronize_rcu() in start_recovery() to guarantee that do_something() never runs concurrently with recovery(), but with little or no synchronization overhead in do_something_dlm().
```


What this PR does / why we need it:
the race is describe in detail here : https://purestorage.atlassian.net/browse/PWX-43070

Which issue(s) this PR fixes (optional)
Closes # PWX-43070


**Special notes for your reviewer**:

