### PR TITLE
PWX-43578: trigger failover on -ENOLINK if fastpath is flakey

### DIFF
--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -730,7 +730,7 @@ static void _end_clone_bio(struct kthread_work *work)
                 blkrc = -EIO;
 
         atomic_dec(&pxd_dev->ncount);
-        if (pxd_dev->fp.can_failover && (blkrc == -EIO || blkrc == -ENOLINK)) {
+        if (pxd_dev->fp.can_failover && blkrc < 0) {
                 atomic_inc(&pxd_dev->fp.nerror);
                 pxd_failover_initiate(fproot);
                 return;

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -730,7 +730,7 @@ static void _end_clone_bio(struct kthread_work *work)
                 blkrc = -EIO;
 
         atomic_dec(&pxd_dev->ncount);
-        if (pxd_dev->fp.can_failover && (blkrc == -EIO)) {
+        if (pxd_dev->fp.can_failover && (blkrc == -EIO || blkrc == -ENOLINK)) {
                 atomic_inc(&pxd_dev->fp.nerror);
                 pxd_failover_initiate(fproot);
                 return;

--- a/pxd_bio_makereq.c
+++ b/pxd_bio_makereq.c
@@ -546,7 +546,7 @@ static void pxd_complete_io(struct bio *bio, int error)
         atomic_inc(&pxd_dev->fp.ncomplete);
         atomic_dec(&pxd_dev->ncount);
 
-        if (pxd_dev->fp.can_failover && (blkrc == -EIO || blkrc == -ENOLINK)) {
+        if (pxd_dev->fp.can_failover && blkrc < 0) {
                 atomic_inc(&pxd_dev->fp.nerror);
                 pxd_failover_initiate(pxd_dev, head);
                 pxd_check_q_decongested(pxd_dev);

--- a/pxd_bio_makereq.c
+++ b/pxd_bio_makereq.c
@@ -546,7 +546,7 @@ static void pxd_complete_io(struct bio *bio, int error)
         atomic_inc(&pxd_dev->fp.ncomplete);
         atomic_dec(&pxd_dev->ncount);
 
-        if (pxd_dev->fp.can_failover && (blkrc == -EIO)) {
+        if (pxd_dev->fp.can_failover && (blkrc == -EIO || blkrc == -ENOLINK)) {
                 atomic_inc(&pxd_dev->fp.nerror);
                 pxd_failover_initiate(pxd_dev, head);
                 pxd_check_q_decongested(pxd_dev);


### PR DESCRIPTION

**What this PR does / why we need it**:
* On some kernel versions (ubuntu 22.04, 5.15.0-67-generic), if the fastpath has issues because of network, the error returned in the BIO's completion callback is -ENOLINK (-67). Trigger a failover if we can.

```
[Thu Apr 24 21:34:21 2025] blkmq fastpath: FAILED IO nvme0n1 (err=-67): dev m 1 g 1031823872070688543 wr at 52682752 len 0 bytes 0 pages flags 0x8800
[Thu Apr 24 21:34:21 2025] blkmq fastpath: FAILED IO nvme0n1 (err=-67): dev m 1 g 1031823872070688543 wr at 56987648 len 0 bytes 0 pages flags 0x8800
[Thu Apr 24 21:34:21 2025] blkmq fastpath: FAILED IO nvme0n1 (err=-67): dev m 1 g 1031823872070688543 wr at 540672 len 0 bytes 0 pages flags 0x8800
[Thu Apr 24 21:34:21 2025] blkmq fastpath: FAILED IO nvme0n1 (err=-67): dev m 1 g 1031823872070688543 wr at 83152896 len 0 bytes 0 pages flags 0x8800
[Thu Apr 24 21:34:21 2025] blkmq fastpath: FAILED IO nvme0n1 (err=-67): dev m 1 g 1031823872070688543 wr at 48549888 len 0 bytes 0 pages flags 0x8800
[Thu Apr 24 21:34:21 2025] blkmq fastpath: FAILED IO nvme0n1 (err=-67): dev m 1 g 1031823872070688543 wr at 107982848 len 0 bytes 0 pages flags 0x8800
[Thu Apr 24 21:34:21 2025] blkmq fastpath: FAILED IO nvme0n1 (err=-67): dev m 1 g 1031823872070688543 wr at 59125760 len 0 bytes 0 pages flags 0x8800
[Thu Apr 24 21:34:21 2025] blkmq fastpath: FAILED IO nvme0n1 (err=-67): dev m 1 g 1031823872070688543 wr at 75026432 len 0 bytes 0 pages flags 0x8800
[Thu Apr 24 21:34:21 2025] blkmq fastpath: FAILED IO nvme0n1 (err=-67): dev m 1 g 1031823872070688543 wr at 124628992 len 0 bytes 0 pages flags 0x8800
[Thu Apr 24 21:34:21 2025] blkmq fastpath: FAILED IO nvme0n1 (err=-67): dev m 1 g 1031823872070688543 wr at 87396352 len 0 bytes 0 pages flags 0x8800
```

**Which issue(s) this PR fixes** (optional)
Closes # PWX-43578

**Special notes for your reviewer**:

