### PR TITLE
PWX-44121: Fix fuse build for RHEL 9.6 + 5.14.0-570.17.1.el9_6

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1275,7 +1275,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
 	  struct queue_limits lim = {
 		  .logical_block_size = PXD_LBS,
 		  .physical_block_size = PXD_LBS,
@@ -1344,7 +1344,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 	disk->private_data = pxd_dev;
 	set_capacity(disk, pxd_dev->size / SECTOR_SIZE);
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,9,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,14,0) || (LINUX_VERSION_CODE < KERNEL_VERSION(6,9,0) && !defined(__EL8__))
 	blk_queue_max_hw_sectors(q, PXD_MAX_IO / SECTOR_SIZE);
 	blk_queue_max_segment_size(q, SEGMENT_SIZE);
 	blk_queue_max_segments(q, (PXD_MAX_IO / PXD_LBS));

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -22,7 +22,7 @@
 #define HAVE_BVEC_ITER
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,11,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,11,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
 #define BLK_QUEUE_FLUSH(q) \
 	q->limits.features |= BLK_FEAT_WRITE_CACHE | BLK_FEAT_FUA
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0) || defined(REQ_PREFLUSH)
@@ -180,7 +180,7 @@ static inline char *bdevname(struct block_device *bdev, char *buf) {
 #endif
 
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__) && defined(QUEUE_FLAG_SKIP_TAGSET_QUIESCE))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__))
 static inline void bio_set_op_attrs(struct bio *bio, enum req_op op,
                                     blk_opf_t op_flags)
 {

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -664,14 +664,14 @@ void pxd_fastpath_adjust_limits(struct pxd_device *pxd_dev, struct request_queue
 	}
 
 	// ensure few block properties are still as expected.
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
 	topque->limits.max_write_zeroes_sectors = 0;
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
 	blk_queue_max_write_zeroes_sectors(topque, 0);
 #endif
 
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
 	topque->limits.logical_block_size = PXD_LBS;
 	topque->limits.physical_block_size = PXD_LBS;
 #else


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # PWX-44121

build on
  Operating System: Red Hat Enterprise Linux CoreOS 9.6.20250402-0 (Plow)
  CPE OS Name: cpe:/o:redhat:enterprise_linux:9::baseos
  Kernel: Linux 5.14.0-570.10.1.el9_6.x86_64

```
[root@localhost px-fuse]# KERNELPATH=/usr/src/kernels/5.14.0-570.17.1.el9_6.x86_64/ make
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
make  -C /usr/src/kernels/5.14.0-570.17.1.el9_6.x86_64/  M=/var/roothome/px-fuse modules
make[1]: Entering directory '/usr/src/kernels/5.14.0-570.17.1.el9_6.x86_64'
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
make[1]: Leaving directory '/usr/src/kernels/5.14.0-570.17.1.el9_6.x86_64'
```

**Special notes for your reviewer**:
