### PR TITLE
PWX-44986: cherry-pick 1mb discard fix to v3.3.1

### DIFF
--- a/pxd.h
+++ b/pxd.h
@@ -48,7 +48,7 @@
 #define PXD_MAX_DEVICES	512			/**< maximum number of devices supported */
 #define PXD_MAX_IO		(1024*1024)	/**< maximum io size in bytes */
 #define PXD_MAX_QDEPTH  256			/**< maximum device queue depth */
-#define PXD_MAX_DISCARD_GRANULARITY		(2 << 20) /**< 2MiB discard granularity on pxd device to cover all pool behavior */
+#define PXD_MAX_DISCARD_GRANULARITY		(1 << 20) /**< 1MiB discard granularity on pxd device to cover all pool behavior */
 
 // use by fastpath for congestion control
 #define DEFAULT_CONGESTION_THRESHOLD (PXD_MAX_QDEPTH)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # PWX-44986

**Special notes for your reviewer**:
root@ip-10-38-34-35:~/px-fuse# runc exec -t portworx pxd -v 
Version: v3.3.0:1mb-discard-fix
root@ip-10-38-34-35:~/px-fuse# 
root@ip-10-38-34-35:~/px-fuse# pxctl v c vol1 --nodes LocalNode 
Volume successfully created: 971456823351722830
root@ip-10-38-34-35:~/px-fuse# pxctl host attach vol1 
Volume successfully attached at: /dev/pxd/pxd971456823351722830
root@ip-10-38-34-35:~/px-fuse# 
root@ip-10-38-34-35:~/px-fuse# blkdiscard /dev/pxd/pxd971456823351722830 
root@ip-10-38-34-35:~/px-fuse# 
root@ip-10-38-34-35:~/px-fuse# pxctl status 
Status: PX is operational
Telemetry: Disabled or Unhealthy
Metering: Disabled or Unhealthy
License: Trial (expires in 29 days)
Node ID: a7a5b1fc-2790-4534-99fb-278513cb7aa3
	IP: 10.38.34.35 
 	Local Storage Pool: 1 pool
	POOL	IO_PRIORITY	RAID_LEVEL	USABLE	USED	STATUS	ZONE	REGION
	0	HIGH		raid0		365 GiB	37 MiB	Online	default	default
	Local Storage Devices: 3 devices
	Device	Path		Media Type		Size		Last-Scan
	0:0	/dev/sdd	STORAGE_MEDIUM_SSD	128 GiB		25 Jun 25 05:57 UTC
	0:1	/dev/sde	STORAGE_MEDIUM_SSD	128 GiB		25 Jun 25 05:57 UTC
	0:2	/dev/sdf	STORAGE_MEDIUM_SSD	128 GiB		25 Jun 25 05:57 UTC
	total			-			384 GiB
	Cache Devices:
	 * No cache devices
	Kvdb Device:
	Device Path	Size
	/dev/sdb	64 GiB
	 * Internal kvdb on this node is using this dedicated kvdb device to store its data.
	Journal Device: 
	1	/dev/sdc1	STORAGE_MEDIUM_SSD	3.0 GiB
	Metadata Device: 
	1	/dev/sdc2	STORAGE_MEDIUM_SSD	61 GiB
Cluster Summary
	Cluster ID: instant-tb-236922
	Cluster UUID: a960fbdf-9811-4109-843c-30a26fc202c7
	Scheduler: kubernetes
	Total Nodes: 3 node(s) with storage (3 online)
	IP		ID					SchedulerNodeName			Auth		StorageNode	Used	Capacity	Status	StorageStatus	Version		Kernel			OS
	10.38.34.35	a7a5b1fc-2790-4534-99fb-278513cb7aa3	ip-10-38-34-35.pwx.purestorage.com	Disabled	Yes(PX-StoreV2)	37 MiB	365 GiB		Online	Up (This node)	3.2.1.0-b298102	5.4.0-107-generic	Ubuntu 20.04.2 LTS
	10.38.35.229	6a1e0abc-c74a-413d-bc8d-2320be691fd4	ip-10-38-35-229.pwx.purestorage.com	Disabled	Yes(PX-StoreV2)	37 MiB	365 GiB		Online	Up		3.2.1.0-b298102	5.4.0-107-generic	Ubuntu 20.04.2 LTS
	10.38.38.82	1e1f5721-b76e-4746-8d5d-a7da151c3415	ip-10-38-38-82.pwx.purestorage.com	Disabled	Yes(PX-StoreV2)	37 MiB	365 GiB		Online	Up		3.2.1.0-b298102	5.4.0-107-generic	Ubuntu 20.04.2 LTS
Global Storage Pool
	Total Used    	:  112 MiB
	Total Capacity	:  1.1 TiB
