### PR TITLE
Fix rhel 9.x compile bugs 3.4.0

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1275,7 +1275,27 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
+// #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
+#ifdef RHEL_RELEASE_CODE
+#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 6)
+	  struct queue_limits lim = {
+		  .logical_block_size = PXD_LBS,
+		  .physical_block_size = PXD_LBS,
+		  .max_segment_size = SEGMENT_SIZE,
+		  .max_segments = PXD_MAX_IO / PXD_LBS,
+		  .max_hw_sectors = PXD_MAX_IO / SECTOR_SIZE,
+		  .discard_alignment = PXD_MAX_DISCARD_GRANULARITY,
+		  .discard_granularity = PXD_MAX_DISCARD_GRANULARITY,
+		  .io_min = PXD_LBS,
+		  .io_opt = PXD_LBS,
+		  .max_hw_discard_sectors = pxd_dev->discard_size / SECTOR_SIZE,
+		  .max_discard_sectors = pxd_dev->discard_size / SECTOR_SIZE
+	  };
+	  disk = blk_mq_alloc_disk(&pxd_dev->tag_set, &lim, pxd_dev);
+#else
+	  disk = blk_mq_alloc_disk(&pxd_dev->tag_set, pxd_dev);
+#endif
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
 	  struct queue_limits lim = {
 		  .logical_block_size = PXD_LBS,
 		  .physical_block_size = PXD_LBS,

--- a/pxd.h
+++ b/pxd.h
@@ -45,7 +45,7 @@
 #define PXD_IOC_IO_FLUSHER		_IO(PXD_IOCTL_MAGIC, 10)	/* 0x50580a */
 #define PXD_IOC_DETACH_DEVICE		_IO(PXD_IOCTL_MAGIC, 11)	/* 0x50580b */
 
-#define PXD_MAX_DEVICES	512			/**< maximum number of devices supported */
+#define PXD_MAX_DEVICES	1024		/**< maximum number of devices supported */
 #define PXD_MAX_IO		(1024*1024)	/**< maximum io size in bytes */
 #define PXD_MAX_QDEPTH  256			/**< maximum device queue depth */
 #define PXD_MAX_DISCARD_GRANULARITY		(2 << 20) /**< 2MiB discard granularity on pxd device to cover all pool behavior */

--- a/pxd.h
+++ b/pxd.h
@@ -45,7 +45,7 @@
 #define PXD_IOC_IO_FLUSHER		_IO(PXD_IOCTL_MAGIC, 10)	/* 0x50580a */
 #define PXD_IOC_DETACH_DEVICE		_IO(PXD_IOCTL_MAGIC, 11)	/* 0x50580b */
 
-#define PXD_MAX_DEVICES	1024		/**< maximum number of devices supported */
+#define PXD_MAX_DEVICES	512			/**< maximum number of devices supported */
 #define PXD_MAX_IO		(1024*1024)	/**< maximum io size in bytes */
 #define PXD_MAX_QDEPTH  256			/**< maximum device queue depth */
 #define PXD_MAX_DISCARD_GRANULARITY		(2 << 20) /**< 2MiB discard granularity on pxd device to cover all pool behavior */

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -22,7 +22,18 @@
 #define HAVE_BVEC_ITER
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,11,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
+// #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,11,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
+#ifdef RHEL_RELEASE_CODE
+#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 6)
+#define BLK_QUEUE_FLUSH(q)  q->limits.features |= BLK_FEAT_WRITE_CACHE | BLK_FEAT_FUA
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0) || defined(REQ_PREFLUSH)
+#define BLK_QUEUE_FLUSH(q) \
+       blk_queue_write_cache(q, true, true)
+#else
+#define BLK_QUEUE_FLUSH(q) \
+       blk_queue_flush(q, REQ_FLUSH | REQ_FUA)
+#endif
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,11,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__))
 #define BLK_QUEUE_FLUSH(q) \
 	q->limits.features |= BLK_FEAT_WRITE_CACHE | BLK_FEAT_FUA
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,7,0) || defined(REQ_PREFLUSH)
@@ -180,7 +191,17 @@ static inline char *bdevname(struct block_device *bdev, char *buf) {
 #endif
 
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__))
+
+// #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__))
+// static inline void bio_set_op_attrs(struct bio *bio, enum req_op op,
+//                                     blk_opf_t op_flags)
+// {
+//   bio->bi_opf = op | op_flags;
+// }
+
+// #endif
+#ifdef RHEL_RELEASE_CODE
+#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 3)
 static inline void bio_set_op_attrs(struct bio *bio, enum req_op op,
                                     blk_opf_t op_flags)
 {
@@ -188,6 +209,16 @@ static inline void bio_set_op_attrs(struct bio *bio, enum req_op op,
 }
 
 #endif
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)
+static inline void bio_set_op_attrs(struct bio *bio, enum req_op op,
+                                    blk_opf_t op_flags)
+{
+  bio->bi_opf = op | op_flags;
+}
+#endif
+
+
+
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)
 #define BIO_SET_OP_ATTRS(b, op, flags) bio_set_op_attrs(b, op, flags)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

This PR is a follow-up of https://github.com/portworx/px-fuse/pull/374. 

Where it addes additional checks for rhel version being greater than or equal to 9.3 before declaring function bio_set_op_attrs() in pxd_compat.h file.


**Which issue(s) this PR fixes** (optional)
Closes #

[5.14.0-284.30.1.el9_2](https://purestorage.atlassian.net/browse/PWX-45490)

[5.14.0-284.123.1.el9_2
](https://purestorage.atlassian.net/browse/PWX-45489)

[5.14.0-362.24.1.el9_3](https://purestorage.atlassian.net/browse/PWX-45521)

**Special notes for your reviewer**:

The changes in https://github.com/portworx/px-fuse/pull/374 PR already help compile all rhel code successfully except 9.2. 
Because the 374 PR is not merged yet, adding changes for 9.2 as well with in it.

