### PR TITLE
9.2 rhel fix

### DIFF
--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -180,13 +180,20 @@ static inline char *bdevname(struct block_device *bdev, char *buf) {
 #endif
 
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0) || (LINUX_VERSION_CODE == KERNEL_VERSION(5,14,0) && defined(__EL8__))
+#ifdef RHEL_RELEASE_CODE
+#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 3)
 static inline void bio_set_op_attrs(struct bio *bio, enum req_op op,
                                     blk_opf_t op_flags)
 {
   bio->bi_opf = op | op_flags;
 }
-
+#endif
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)
+static inline void bio_set_op_attrs(struct bio *bio, enum req_op op,
+                                    blk_opf_t op_flags)
+{
+  bio->bi_opf = op | op_flags;
+}
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: 
This PR fixes re-declaration of exisiting methods issue of method call `bio_set_op_attrs` for rhel 9.2.

**Which issue(s) this PR fixes** (optional)
Closes #


- [5.14.0-284.30.1.el9_2](https://purestorage.atlassian.net/browse/PWX-45490)
- [5.14.0-362.24.1.el9_3](https://purestorage.atlassian.net/browse/PWX-45521)

**Special notes for your reviewer**:

