### PR TITLE
Added fixes to handle ubuntu 24.04 keernel 6.14.x errors

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1659,7 +1659,7 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 	spin_unlock(&pxd_dev->lock);
 #if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0)
-	blk_mq_unfreeze_queue(pxd_dev->disk->queue);
+	blk_mq_unfreeze_queue(pxd_dev->disk->queue, blk_mq_queue_flag);
 #else
 	blk_mq_unfreeze_queue(pxd_dev->disk->queue);
 #endif

--- a/test/pxd_test.cc
+++ b/test/pxd_test.cc
@@ -1,23 +1,74 @@
-#include <stdlib.h>
-#include <gtest/gtest.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <sys/poll.h>
+#include <algorithm>
 #include <boost/iostreams/device/file_descriptor.hpp>
-#include <sys/uio.h>
-#include <string>
 #include <boost/lexical_cast.hpp>
+#include <fcntl.h>
+#include <fstream>
 #include <functional>
+#include <gtest/gtest.h>
 #include <linux/fs.h>
+#include <stdlib.h>
+#include <string>
 #include <sys/ioctl.h>
+#include <sys/poll.h>
+#include <sys/stat.h>
+#include <sys/uio.h>
 #include <thread>
 #include <vector>
-#include <fstream>
-#include <algorithm>
-#include "pxd.h"
+
+#include <cstdlib>
+#include <memory>
+#include <stdexcept>
+
 #include "fuse.h"
+#include "pxd.h"
 
 using namespace std::placeholders;
+
+struct fuse_notify_header : public ::fuse_out_header {
+	fuse_notify_header(int32_t opcode, uint32_t op_len);
+};
+
+fuse_notify_header::fuse_notify_header(int32_t opcode, uint32_t op_len)
+{
+	unique = 0;
+	error = opcode;
+	len = sizeof(fuse_out_header) + op_len;
+}
+
+static ::testing::AssertionResult verify_pattern(void *buf, size_t len)
+{
+	uint8_t *d = (uint8_t *)buf;
+	for (size_t i = 0; i < len; ++i) {
+		if (d[i] != (i % UINT8_MAX)) {
+			return ::testing::AssertionFailure() << "at " << i << " val " << d[i];
+		}
+	}
+	return ::testing::AssertionSuccess();
+}
+
+static std::vector<uint8_t> make_pattern(size_t size)
+{
+	std::vector<uint8_t> v(size);
+	for (size_t i = 0; i < v.size(); ++i)
+		v[i] = i % UINT8_MAX;
+	return v;
+}
+
+static void init_pattern(void *vv, size_t size)
+{
+	uint8_t *v = (uint8_t *)vv;
+	for (size_t i = 0; i < size; ++i)
+		v[i] = i % UINT8_MAX;
+}
+
+std::unique_ptr<void, decltype(&std::free)> aligned_buffer(size_t buffer_size)
+{
+	void *ptr = nullptr;
+	if (posix_memalign(&ptr, 4096, buffer_size) != 0) {
+		throw std::runtime_error("Failed to allocate aligned buffer");
+	}
+	return std::unique_ptr<void, decltype(&std::free)>(ptr, &std::free);
+}
 
 std::string control_device(unsigned int driver_context_id)
 {
@@ -28,18 +79,24 @@ std::string control_device(unsigned int driver_context_id)
 	return ret;
 }
 
-class PxdTest : public ::testing::Test {
-protected:
+class PxdTest : public ::testing::Test
+{
+  protected:
 	bool killed{false};
-	int ctl_fd;		// control file descriptor
+	int ctl_fd; // control file descriptor
 	std::set<uint64_t> added_ids;
 	const size_t write_len = PXD_LBS * 4;
 	const size_t test_off = 4 * 4096;
 
-	PxdTest() : ctl_fd(-1) {}
-	virtual ~PxdTest() {
-		if (ctl_fd >= 0)
+	PxdTest() : ctl_fd(-1)
+	{
+	}
+	virtual ~PxdTest()
+	{
+		if (ctl_fd >= 0) {
 			close(ctl_fd);
+			fprintf(stderr, "closed control fd");
+		}
 	}
 
 	virtual void SetUp();
@@ -51,87 +108,310 @@ protected:
 	void dev_remove(uint64_t dev_id);
 	int wait_msg(int timeout); // timeout in seconds
 	void read_block(fuse_in_header *in, pxd_rdwr_in *rd);
-	void validate_device_properties(const std::string &device_name, uint64_t expected_discard_granularity = 1048576, uint64_t expected_max_discard_bytes = 1048576);
+	void validate_device_properties(const std::string &device_name,
+	                                uint64_t expected_discard_granularity = 1048576,
+	                                uint64_t expected_max_discard_bytes = 1048576);
 
-public:
-	void fail_io(rdwr_in*);
+	int write_pxd_timeout(int minor, int timeout_value);
+
+  public:
+	void fail_io(struct rdwr_in *);
+	int finish_io(struct rdwr_in *, bool read_data = false);
 	void write_thread(const char *name);
 	void read_thread(const char *name);
 	void cleaner();
 };
 
-TEST_F(PxdTest, simple)
+int PxdTest::write_pxd_timeout(int minor, int timeout_value)
 {
-	std::cout << "simple test" << std::endl;
+	char sysfs_path[256];
+	snprintf(sysfs_path, sizeof(sysfs_path), "/sys/devices/pxd!pxd/%d/timeout", minor);
+
+	FILE *fp = fopen(sysfs_path, "w");
+	if (!fp) {
+		perror("fopen");
+		return -1;
+	}
+
+	int ret = fprintf(fp, "%d\n", timeout_value);
+	if (ret < 0) {
+		perror("fprintf");
+		fclose(fp);
+		return -1;
+	}
+
+	fclose(fp);
+	return 0;
+}
+
+void PxdTest::dev_add(pxd_add_out &add, int &minor, std::string &name)
+{
+	fuse_out_header oh;
+	struct iovec iov[2];
+
+	ASSERT_TRUE(added_ids.find(add.dev_id) == added_ids.end());
+
+	oh.unique = 0;
+	oh.error = PXD_ADD, oh.len = sizeof(oh) + sizeof(add);
+
+	iov[0].iov_base = &oh;
+	iov[0].iov_len = sizeof(oh);
+	iov[1].iov_base = &add;
+	iov[1].iov_len = sizeof(add);
+
+	ssize_t write_bytes = writev(ctl_fd, iov, 2);
+	ASSERT_GT(write_bytes, 0);
+
+	added_ids.insert(add.dev_id);
+
+	minor = write_bytes;
+	name = std::string(PXD_DEV_PATH) + std::to_string(add.dev_id);
+
+	dev_export(minor, name);
+	validate_device_properties(name, 1024 * 1024, 1024 * 1024);
 }
 
 void PxdTest::dev_add_ext(pxd_add_ext_out &add_ext, int &minor, std::string &name)
 {
-    fuse_out_header oh;
-    struct iovec iov[2];
+	fuse_out_header oh;
+	struct iovec iov[2];
 
-    ASSERT_TRUE(added_ids.find(add_ext.dev_id) == added_ids.end());
+	ASSERT_TRUE(added_ids.find(add_ext.dev_id) == added_ids.end());
 
-    oh.unique = 0;
-    oh.error = PXD_ADD_EXT;
-    oh.len = sizeof(oh) + sizeof(add_ext);
+	oh.unique = 0;
+	oh.error = PXD_ADD_EXT;
+	oh.len = sizeof(oh) + sizeof(add_ext);
 
-    iov[0].iov_base = &oh;
-    iov[0].iov_len = sizeof(oh);
-    iov[1].iov_base = &add_ext;
-    iov[1].iov_len = sizeof(add_ext);
+	iov[0].iov_base = &oh;
+	iov[0].iov_len = sizeof(oh);
+	iov[1].iov_base = &add_ext;
+	iov[1].iov_len = sizeof(add_ext);
 
-    ssize_t write_bytes = writev(ctl_fd, iov, 2);
-    ASSERT_GT(write_bytes, 0);
+	ssize_t write_bytes = writev(ctl_fd, iov, 2);
+	ASSERT_GT(write_bytes, 0);
 
-    std::cout << "dev_add_ext: PXD_ADD_EXT completed, wrote " << write_bytes << " bytes" << std::endl;
-    std::cout << "dev_add_ext: device ID = " << add_ext.dev_id << std::endl;
+	std::cout << "dev_add_ext: PXD_ADD_EXT completed, wrote " << write_bytes << " bytes"
+	          << std::endl;
+	std::cout << "dev_add_ext: device ID = " << add_ext.dev_id << std::endl;
 
-    added_ids.insert(add_ext.dev_id);
-    minor = write_bytes;
-    name = std::string(PXD_DEV_PATH) + std::to_string(add_ext.dev_id);
+	added_ids.insert(add_ext.dev_id);
+	minor = write_bytes;
+	name = std::string(PXD_DEV_PATH) + std::to_string(add_ext.dev_id);
 
-    dev_export(minor, name);
-    std::cout << "dev_add_ext: expected device path = " << name << std::endl;
+	dev_export(minor, name);
+	std::cout << "dev_add_ext: expected device path = " << name << std::endl;
 }
 
 void PxdTest::dev_export(uint64_t dev_id, const std::string &expected_name)
 {
-    fuse_out_header oh;
-    struct iovec iov[2];
+	fuse_out_header oh;
+	struct iovec iov[2];
 
-    oh.unique = 0;
-    oh.error = PXD_EXPORT_DEV;
-    oh.len = sizeof(oh) + sizeof(dev_id);
+	oh.unique = 0;
+	oh.error = PXD_EXPORT_DEV;
+	oh.len = sizeof(oh) + sizeof(dev_id);
 
-    iov[0].iov_base = &oh;
-    iov[0].iov_len = sizeof(oh);
-    iov[1].iov_base = &dev_id;
-    iov[1].iov_len = sizeof(dev_id);
+	iov[0].iov_base = &oh;
+	iov[0].iov_len = sizeof(oh);
+	iov[1].iov_base = &dev_id;
+	iov[1].iov_len = sizeof(dev_id);
 
-    ssize_t write_bytes = writev(ctl_fd, iov, 2);
-    ASSERT_GT(write_bytes, 0);
+	ssize_t write_bytes = writev(ctl_fd, iov, 2);
+	ASSERT_GT(write_bytes, 0);
 
-    std::cout << "dev_export: PXD_EXPORT completed, wrote " << write_bytes << " bytes" << std::endl;
-    std::cout << "dev_export: device ID = " << dev_id << std::endl;
-    std::cout << "dev_export: expected device path = " << expected_name << std::endl;
+	std::cout << "dev_export: PXD_EXPORT completed, wrote " << write_bytes << " bytes" << std::endl;
+	std::cout << "dev_export: device ID = " << dev_id << std::endl;
+	std::cout << "dev_export: expected device path = " << expected_name << std::endl;
 
-    // Wait for device file to appear
-    for (int i = 0; i < 10; i++) {
-        sleep(1);
-	if (access(expected_name.c_str(), F_OK) == 0) {
-            std::cout << "dev_export: device file appeared after " << (i+1) << " seconds" << std::endl;
-            return;
-        }
-        std::cout << "dev_export: waiting for device file... (" << (i+1) << "/10)" << std::endl;
-    }
+	// Wait for device file to appear
+	for (int i = 0; i < 10; i++) {
+		sleep(1);
+		if (access(expected_name.c_str(), F_OK) == 0) {
+			std::cout << "dev_export: device file appeared after " << (i + 1) << " seconds"
+			          << std::endl;
+			return;
+		}
+		std::cout << "dev_export: waiting for device file... (" << (i + 1) << "/10)" << std::endl;
+	}
 
-    std::cout << "dev_export: WARNING - device file never appeared!" << std::endl;
+	std::cout << "dev_export: WARNING - device file never appeared!" << std::endl;
+}
+
+int PxdTest::wait_msg(int timeout_secs)
+{
+	struct pollfd fds = {};
+	int ret;
+
+	fds.fd = ctl_fd;
+	fds.events = POLLIN;
+
+	ret = poll(&fds, 1, timeout_secs * 1000);
+
+	if (ret > 0)
+		return 0;
+	if (ret == 0)
+		return -ETIMEDOUT;
+
+	// should never arise?!
+	ret = -errno;
+	EXPECT_GE(ret, 0);
+	return ret;
+}
+
+void PxdTest::fail_io(struct rdwr_in *rdwr)
+{
+	struct pxd_rdwr_in *req;
+	fuse_out_header oh;
+	struct iovec iov[1];
+
+	req = reinterpret_cast<pxd_rdwr_in *>(&rdwr->rdwr);
+
+	// Reply to the kernel
+	oh.len = sizeof(oh);
+	oh.error = -EIO;
+	oh.unique = rdwr->in.unique;
+	iov[0].iov_base = &oh;
+	iov[0].iov_len = sizeof(oh);
+
+	fprintf(stderr, "%s: opc (%d) reply to kernel: status: %d iovcnt: %d\n", __func__,
+	        rdwr->in.opcode, oh.error, 1);
+	size_t ret = writev(ctl_fd, iov, 1);
+	ASSERT_GE(ret, 0);
+}
+
+int PxdTest::finish_io(struct rdwr_in *rdwr, bool read_data)
+{
+	struct pxd_rdwr_in *rd;
+	fuse_out_header oh;
+	struct iovec iov[16];
+	int iovcnt = 0;
+	char buf[PXD_LBS];
+	int rc = 0;
+	size_t ret;
+
+	rd = reinterpret_cast<pxd_rdwr_in *>(&rdwr->rdwr);
+
+	switch (rdwr->in.opcode) {
+	case PXD_READ:
+		if (rdwr->in.opcode == PXD_READ && rd->offset == test_off) {
+			if (rd->size == write_len) {
+				rc = 1;
+			}
+		}
+		// Reply to the kernel
+		iovcnt = rd->size / PXD_LBS;
+		oh.len = sizeof(oh) + rd->size;
+		oh.error = 0;
+		oh.unique = rdwr->in.unique;
+		iov[0].iov_base = &oh;
+		iov[0].iov_len = sizeof(oh);
+
+		if (iovcnt >= 16) {
+			fail_io(rdwr);
+			return 0;
+		}
+
+		for (int i = 1; i <= iovcnt; i++) {
+			iov[i].iov_base = buf;
+			iov[i].iov_len = PXD_LBS;
+		}
+
+		fprintf(stderr, "%s: reply to kernel: status: %d iovcnt: %d\n", __func__, oh.error, iovcnt);
+		ret = writev(ctl_fd, iov, iovcnt + 1);
+		EXPECT_GE(ret, 0);
+		break;
+	case PXD_WRITE:
+		if (read_data && rd->size != 0)
+			read_block(&rdwr->in, reinterpret_cast<pxd_rdwr_in *>(&rdwr->rdwr));
+		// Reply to the kernel
+		oh.len = sizeof(oh);
+		oh.error = 0;
+		oh.unique = rdwr->in.unique;
+		fprintf(stderr, "%s: reply to kernel: status: %d\n", __func__, oh.error);
+		ret = ::write(ctl_fd, &oh, sizeof(oh));
+		EXPECT_EQ(sizeof(oh), ret);
+
+		break;
+	default:
+		fail_io(rdwr);
+	}
+	return rc;
+}
+
+void PxdTest::cleaner()
+{
+	struct rdwr_in rdwr;
+
+	fprintf(stderr, "cleaner thread active\n");
+	// Now read in the request from kernel
+	while (!killed) {
+		size_t ret = wait_msg(1);
+		if (ret == -ETIMEDOUT) {
+			sleep(1);
+			continue;
+		}
+		size_t read_bytes = read(ctl_fd, &rdwr, sizeof(rdwr));
+		if (read_bytes < 0) {
+			EXPECT_EQ(read_bytes, -EAGAIN);
+		} else if (read_bytes > 0) {
+			// finish_io(&rdwr);
+			fail_io(&rdwr);
+		}
+	}
+	fprintf(stderr, "cleaner thread done\n");
+}
+
+void PxdTest::dev_remove(uint64_t dev_id)
+{
+	pxd_remove_out remove;
+	fuse_out_header oh;
+	struct iovec iov[2];
+	int iter = 0;
+
+	fprintf(stderr, "%s: device removing %ld\n", __func__, dev_id);
+	killed = false;
+	std::thread cleaner(&PxdTest::cleaner, this);
+	sleep(1);
+	while (1) {
+		fprintf(stderr, "initiating dev cleanup\n");
+		oh.unique = 0;
+		oh.error = PXD_REMOVE;
+		oh.len = sizeof(oh) + sizeof(remove);
+
+		remove.dev_id = dev_id;
+		remove.force = false; //// cannot force
+
+		iov[0].iov_base = &oh;
+		iov[0].iov_len = sizeof(oh);
+		iov[1].iov_base = &remove;
+		iov[1].iov_len = sizeof(remove);
+
+		ssize_t write_bytes = writev(ctl_fd, iov, 2);
+		if (write_bytes > 0) {
+			fprintf(stderr, "device removal success\n");
+			ASSERT_EQ(write_bytes, oh.len);
+			break;
+		}
+
+		ASSERT_EQ(EBUSY, errno);
+		fprintf(stderr, "device busy.. will retry after sleep\n");
+		iter++;
+		sleep(1);
+	}
+
+	fprintf(stderr, "%s: device %ld removed after %d secs\n", __func__, dev_id, iter);
+	fprintf(stderr, "prepping to stop background cleaner\n");
+	killed = true;
+	sleep(1);
+	cleaner.join();
+	killed = false;
+
+	added_ids.erase(dev_id);
 }
 
 void PxdTest::validate_device_properties(const std::string &device_name,
-                                        uint64_t expected_discard_granularity,
-                                        uint64_t expected_max_discard_bytes)
+                                         uint64_t expected_discard_granularity,
+                                         uint64_t expected_max_discard_bytes)
 {
 	std::cout << "validating pxd device: " << device_name << std::endl;
 
@@ -180,10 +460,12 @@ void PxdTest::validate_device_properties(const std::string &device_name,
 
 void PxdTest::SetUp()
 {
+	fprintf(stderr, "%s\n", __func__);
 	seteuid(0);
 	ASSERT_EQ(0, system("/usr/bin/sudo /sbin/insmod px.ko"));
 
 	std::cout << "Opening control dev: " << control_device(0) << "\n";
+	// ctl_fd = open(control_device(0).c_str(), O_RDWR | O_NONBLOCK);
 	ctl_fd = open(control_device(0).c_str(), O_RDWR);
 	ASSERT_GT(ctl_fd, 0);
 
@@ -201,94 +483,25 @@ void PxdTest::SetUp()
 
 void PxdTest::TearDown()
 {
-	sleep(1);
-	std::for_each(added_ids.begin(), added_ids.end(),
-			std::bind(&PxdTest::dev_remove, this, _1));
+	fprintf(stderr, "%s\n", __func__);
+	std::for_each(added_ids.begin(), added_ids.end(), std::bind(&PxdTest::dev_remove, this, _1));
 
 	if (ctl_fd >= 0) {
 		close(ctl_fd);
 		ctl_fd = -1;
 	}
 
-	ASSERT_EQ(0, system("/usr/bin/sudo /sbin/rmmod px.ko"));
-}
-
-void PxdTest::dev_add(pxd_add_out &add, int &minor, std::string &name)
-{
-	fuse_out_header oh;
-	struct iovec iov[2];
-
-	ASSERT_TRUE(added_ids.find(add.dev_id) == added_ids.end());
-
-	oh.unique = 0;
-	oh.error = PXD_ADD,
-	oh.len = sizeof(oh) + sizeof(add);
-
-	iov[0].iov_base = &oh;
-	iov[0].iov_len = sizeof(oh);
-	iov[1].iov_base = &add;
-	iov[1].iov_len = sizeof(add);
-
-	ssize_t write_bytes = writev(ctl_fd, iov, 2);
-	ASSERT_GT(write_bytes, 0);
-
-	added_ids.insert(add.dev_id);
-
-	minor = write_bytes;
-	name = std::string(PXD_DEV_PATH) + std::to_string(add.dev_id);
-
-	dev_export(minor, name);
-	validate_device_properties(name, 1024*1024, 1024*1024);
-}
-
-int PxdTest::wait_msg(int timeout_secs)
-{
-	struct pollfd fds = {};
-	int ret;
-
-	fds.fd = ctl_fd;
-	fds.events = POLLIN;
-
-	ret = poll(&fds, 1, timeout_secs * 1000);
-
-	if (ret > 0) return 0;
-	if (ret == 0) return -ETIMEDOUT;
-
-	// should never arise?!
-	ret = -errno;
-	EXPECT_GE(ret, 0);
-	return ret;
-}
-
-static ::testing::AssertionResult verify_pattern(void *buf, size_t len)
-{
-	uint8_t *d = (uint8_t *)buf;
-	for (size_t i = 0; i < len; ++i) {
-		if (d[i] != (i % UINT8_MAX)) {
-			return ::testing::AssertionFailure() << "at " <<
-					i << " val " << d[i];
-		}
+	int ret = 0;
+	int iter = 0;
+	while (1) {
+		iter++;
+		ret = system("/usr/bin/sudo /sbin/rmmod px.ko");
+		if (ret == 0)
+			break;
+		fprintf(stderr, "waiting for rmmod to pass\n");
+		sleep(1);
 	}
-	return ::testing::AssertionSuccess();
-}
-
-static std::vector<uint8_t> make_pattern(size_t size)
-{
-	std::vector<uint8_t> v(size);
-	for (size_t i = 0; i < v.size(); ++i)
-		v[i] = i % UINT8_MAX;
-	return v;
-}
-
-struct fuse_notify_header : public ::fuse_out_header {
-	fuse_notify_header(int32_t opcode, uint32_t op_len);
-};
-
-fuse_notify_header::fuse_notify_header(int32_t opcode, uint32_t op_len)
-{
-	unique = 0;
-	error = opcode;
-	len = sizeof(fuse_out_header) + op_len;
+	fprintf(stderr, "took %d seconds to perform rmmod\n", iter);
 }
 
 // Read block from kernel
@@ -297,100 +510,57 @@ void PxdTest::read_block(fuse_in_header *hdr, pxd_rdwr_in *req)
 	int iovcnt = 1;
 	struct iovec iov[iovcnt];
 	size_t iovlen = iovcnt * sizeof(iov);
-	char buf[req->size];
+	std::vector<uint8_t> buf(req->size, 0);
 	size_t ret = 0;
 
-
-	fprintf(stderr, "request opc(%d) offset (%ld) len (%d)", hdr->opcode, req->offset, req->size);
+	fprintf(stderr, "request opc(%d) offset (%ld) len (%d)\n", hdr->opcode, req->offset, req->size);
 
 	// Setup request header and payload
 	fuse_notify_header oh(PXD_READ_DATA, sizeof(pxd_read_data_out) + iovlen);
 	pxd_read_data_out rd_out = {hdr->unique, iovcnt, 0};
 
-	memset(buf, 0, req->size);
-	iov[0].iov_base = buf;
+	// memset(buf, 0, req->size);
+	iov[0].iov_base = buf.data();
 	iov[0].iov_len = req->size;
-	struct iovec wr_iov[3] = { { &oh, sizeof(oh) }, { &rd_out, sizeof(rd_out) },
-		{ iov, iovlen} };
+	struct iovec wr_iov[3] = {{&oh, sizeof(oh)}, {&rd_out, sizeof(rd_out)}, {iov, iovlen}};
 
 	// Send a read request to kernel
 	ret = writev(ctl_fd, wr_iov, 3);
 	fprintf(stderr, "%s: read/verify data from kernel\n", __func__);
 	ASSERT_EQ(ret, oh.len);
-	ASSERT_TRUE(verify_pattern(buf, req->size));
+	ASSERT_TRUE(verify_pattern(buf.data(), req->size));
 }
 
 void PxdTest::write_thread(const char *name)
 {
-	std::vector<uint8_t> v(make_pattern(write_len));
+	auto buf = aligned_buffer(write_len);
+	init_pattern(buf.get(), write_len);
+
 	boost::iostreams::file_descriptor dev_fd(name);
 
-	ssize_t write_bytes = pwrite(dev_fd.handle(), v.data(), write_len, test_off);
+	ssize_t write_bytes = pwrite(dev_fd.handle(), buf.get(), write_len, test_off);
 	ASSERT_EQ(write_bytes, write_len);
 	fprintf(stderr, "%s: bytes written: %lu\n", __func__, write_bytes);
 }
 
 void PxdTest::read_thread(const char *name)
 {
-	std::vector<uint8_t> v(make_pattern(write_len));
-	boost::iostreams::file_descriptor dev_fd(name);
+	auto buf = aligned_buffer(write_len);
+	init_pattern(buf.get(), write_len);
+
+	int fd = open(name, O_RDWR | O_DIRECT);
+	boost::iostreams::file_descriptor dev_fd(fd, boost::iostreams::close_handle);
 
 	// explicitly read non-zero offset
 	fprintf(stderr, "%s: submit read req: size: %lu\n", __func__, write_len);
-	ssize_t read_bytes = pread(dev_fd.handle(), v.data(), write_len, test_off);
-	fprintf(stderr, "%s: bytes read req: %lu\n", __func__, read_bytes);
+	ssize_t read_bytes = pread(dev_fd.handle(), buf.get(), write_len, test_off);
+	fprintf(stderr, "%s: response read bytes: %lu\n", __func__, read_bytes);
 	ASSERT_EQ(read_bytes, write_len);
 }
 
-
-void PxdTest::cleaner()
+TEST_F(PxdTest, simple)
 {
-	struct rdwr_in rdwr;
-        // Now read in the request from kernel
-        while (!killed) {
-                size_t ret = wait_msg(1);
-		if (ret == -ETIMEDOUT) { sleep(1); continue; }
-                size_t read_bytes = read(ctl_fd, &rdwr, sizeof(rdwr));
-		fail_io(&rdwr);
-        }
-}
-
-void PxdTest::dev_remove(uint64_t dev_id)
-{
-	pxd_remove_out remove;
-	fuse_out_header oh;
-	struct iovec iov[2];
-
-	std::thread cleaner(&PxdTest::cleaner, this);
-	sleep(2);
-	killed = true;
-	cleaner.join();
-	killed = false;
-	
-	while (1) {
-		oh.unique = 0;
-		oh.error = PXD_REMOVE;
-		oh.len = sizeof(oh) + sizeof(remove);
-
-		remove.dev_id = dev_id;
-		remove.force = true;
-
-		iov[0].iov_base = &oh;
-		iov[0].iov_len = sizeof(oh);
-		iov[1].iov_base = &remove;
-		iov[1].iov_len = sizeof(remove);
-
-		ssize_t write_bytes = writev(ctl_fd, iov, 2);
-		if (write_bytes > 0) {
-			ASSERT_EQ(write_bytes, oh.len);
-			break;
-		}
-
-		ASSERT_EQ(EBUSY, errno);
-	}
-
-	added_ids.erase(dev_id);
-	sleep(10);
+	std::cout << "simple test" << std::endl;
 }
 
 TEST_F(PxdTest, device_size)
@@ -419,37 +589,13 @@ TEST_F(PxdTest, device_size)
 	dev_remove(add.dev_id);
 }
 
-void PxdTest::fail_io(struct rdwr_in *rdwr)
-{
-	struct pxd_rdwr_in *req;
-	fuse_out_header oh;
-	struct iovec iov[1];
-
-        req = reinterpret_cast<pxd_rdwr_in *>(&rdwr->rdwr);
-
-        // Reply to the kernel
-        oh.len = sizeof(oh);
-        oh.error = -EIO;
-        oh.unique = rdwr->in.unique;
-        iov[0].iov_base = &oh;
-        iov[0].iov_len = sizeof(oh);
-
-        fprintf(stderr, "%s: opc (%d) reply to kernel: status: %d iovcnt: %d\n",
-                __func__, rdwr->in.opcode, oh.error, 1);
-        size_t ret = writev(ctl_fd, iov, 1);
-	ASSERT_GE(ret, 0);
-}
-
 TEST_F(PxdTest, write)
 {
 	struct pxd_add_out add;
-	struct rdwr_in *rdwr = NULL;
-	struct fuse_in_header *in = NULL;
+	struct rdwr_in rdwr;
 	struct pxd_rdwr_in *wr = NULL;
-	struct fuse_out_header oh;
 	std::string name;
 	int minor = 0;
-	char msg_buf[write_len * 2];
 	ssize_t read_bytes = 0;
 
 	// Attach a kernel block device (/dev/pxd/pxd1)
@@ -465,35 +611,31 @@ TEST_F(PxdTest, write)
 	// Now read in the request from kernel
 	while (1) {
 		int ret = wait_msg(1);
-		if (ret == -ETIMEDOUT) { sleep(1); continue; }
+		if (ret == -ETIMEDOUT) {
+			sleep(1);
+			continue;
+		}
 		ASSERT_EQ(ret, 0);
 
-		read_bytes = read(ctl_fd, msg_buf, sizeof(msg_buf));
-		rdwr = reinterpret_cast<rdwr_in *>(msg_buf);
-		wr = reinterpret_cast<pxd_rdwr_in *>(&rdwr->rdwr);
+		read_bytes = read(ctl_fd, &rdwr, sizeof(rdwr_in));
+		wr = reinterpret_cast<pxd_rdwr_in *>(&rdwr.rdwr);
 
-		if (rdwr->in.opcode == PXD_WRITE && rdwr->rdwr.offset == test_off) {
-			read_block(&rdwr->in, reinterpret_cast<pxd_rdwr_in *>(&rdwr->rdwr));
+		if (rdwr.in.opcode == PXD_WRITE && rdwr.rdwr.offset == test_off) {
+			read_block(&rdwr.in, reinterpret_cast<pxd_rdwr_in *>(&rdwr.rdwr));
 			break;
 		} else {
-			fail_io(rdwr);
+			finish_io(&rdwr);
 		}
 	}
 
 	// Process the write request
-	ASSERT_EQ(rdwr->in.opcode, PXD_WRITE);
+	ASSERT_EQ(rdwr.in.opcode, PXD_WRITE);
 	ASSERT_EQ(wr->dev_minor, minor);
 	ASSERT_EQ(wr->offset, test_off);
 	ASSERT_EQ(wr->size, write_len);
-	
-	// Reply to the kernel
-	oh.len = sizeof(oh);
-	oh.error = 0;
-	oh.unique = rdwr->in.unique;
-	fprintf(stderr, "%s: reply to kernel: status: %d\n", __func__, oh.error);
-	size_t ret = ::write(ctl_fd, &oh, sizeof(oh));
-	ASSERT_EQ(sizeof(oh), ret);
 
+	// Reply to the kernel
+	finish_io(&rdwr);
 	wt.join();
 
 	// Detach block device
@@ -503,16 +645,10 @@ TEST_F(PxdTest, write)
 TEST_F(PxdTest, read)
 {
 	struct pxd_add_out add;
-	struct rdwr_in *rdwr = NULL;
-	struct pxd_rdwr_in *rd = NULL;
-	struct fuse_out_header oh;
 	std::string name;
 	int minor = 0;
-	char msg_buf[write_len * 2];
+	struct rdwr_in rdwr;
 	ssize_t read_bytes = 0;
-	struct iovec iov[16];
-	int iovcnt = 0;
-	char buf[PXD_LBS];
 
 	// Attach a kernel block device (/dev/pxd/pxd1)
 	add.dev_id = 1;
@@ -527,48 +663,21 @@ TEST_F(PxdTest, read)
 	// Now read in the request from kernel
 	while (1) {
 		int ret = wait_msg(1);
-		if (ret == -ETIMEDOUT) { sleep(1); continue; }
-		ASSERT_EQ(ret, 0);
+		if (ret == -ETIMEDOUT) {
+			sleep(1);
+			continue;
+		}
+		EXPECT_EQ(ret, 0);
 
-		read_bytes = read(ctl_fd, msg_buf, sizeof(msg_buf));
-		rdwr = reinterpret_cast<rdwr_in *>(msg_buf);
-		rd = reinterpret_cast<pxd_rdwr_in *>(&rdwr->rdwr);
+		read_bytes = read(ctl_fd, &rdwr, sizeof(rdwr));
 
-		if (rdwr->in.opcode == PXD_READ && rd->offset == test_off) {
+		if (finish_io(&rdwr) == 1) {
+			fprintf(stderr, "found the test read\n");
 			break;
-		} else {
-			fail_io(rdwr);
 		}
 	}
 
-	// Process the read request
-	ASSERT_EQ(rdwr->in.opcode, PXD_READ);
-	ASSERT_EQ(rd->dev_minor, minor);
-	ASSERT_EQ(rd->offset, test_off);
-	//XXX: for some reason read req size we recieve here
-	// is greater than what read_thread issued. Ignore it
-	// for now and respond with the new size.
-	ASSERT_EQ(rd->size, write_len);
-
-	// Reply to the kernel
-	iovcnt = rd->size / PXD_LBS;
-	oh.len = sizeof(oh) + rd->size;
-	oh.error = 0;
-	oh.unique = rdwr->in.unique;
-	iov[0].iov_base = &oh;
-	iov[0].iov_len = sizeof(oh);
-
-	for (int i = 1; i <= iovcnt; i++) {
-		iov[i].iov_base = buf;
-		iov[i].iov_len = PXD_LBS;
-	}
-
-	fprintf(stderr, "%s: reply to kernel: status: %d iovcnt: %d\n",
-		__func__, oh.error, iovcnt);
-	size_t ret = writev(ctl_fd, iov, iovcnt + 1);
-
 	rt.join();
-
 	// Detach block device
 	dev_remove(add.dev_id);
 }


### PR DESCRIPTION
Initial Error:

```
pxd.c: In function 'pxd_export':
pxd.c:1662:9: error: too few arguments to function 'blk_mq_unfreeze_queue'
 1662 |         blk_mq_unfreeze_queue(pxd_dev->disk->queue);
      |         ^~~~~~~~~~~~~~~~~~~~~
In file included from pxd_core.h:7,
                 from pxd.c:41:
/usr/src/linux-headers-6.14.0-061400-generic/include/linux/blk-mq.h:932:1: note: declared here
  932 | blk_mq_unfreeze_queue(struct request_queue *q, unsigned int memflags)
      | ^~~~~~~~~~~~~~~~~~~~~
make[4]: *** [/usr/src/linux-headers-6.14.0-061400-generic/scripts/Makefile.build:207: pxd.o] Error 1
make[3]: *** [/usr/src/linux-headers-6.14.0-061400-generic/Makefile:2001: .] Error 2
make[2]: *** [/usr/src/linux-headers-6.14.0-061400-generic/Makefile:251: __sub-make] Error 2
make[2]: Leaving directory '/root/px-fuse'
make[1]: *** [Makefile:251: __sub-make] Error 2
make[1]: Leaving directory '/usr/src/linux-headers-6.14.0-061400-generic'
make: *** [Makefile:169: all] Error 2
```

**What this PR does / why we need it**:
Fix issues with ubuntu 24.04 compatibility.


**Which issue(s) this PR fixes** (optional)
Closes #
PWX-45488

**Special notes for your reviewer**:

