### PR TITLE
fix tests for px-fuse runtime testing

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -180,7 +180,7 @@ install:
 test_clean:
 	@/bin/rm -f test/pxd_test
 
-pxd_test: pxd_test.cc
+pxd_test: test/pxd_test.cc
 	@echo "Building Test ..."
 	g++ -I. -std=c++11 test/pxd_test.cc -lgtest -lboost_iostreams -lpthread -o test/pxd_test
 

--- a/pxd.c
+++ b/pxd.c
@@ -2412,7 +2412,8 @@ static int pxd_control_open(struct inode *inode, struct file *file)
 	if (strcmp(current->comm, PROC_PX_STORAGE) != 0 &&
 		strcmp(current->comm, PROC_PX_CONTROL) != 0 &&
 		strcmp(current->comm, PROC_PX_UT) != 0 &&
-		strcmp(current->comm, PROC_PX_TOOL) != 0) {
+		strcmp(current->comm, PROC_PX_TOOL) != 0 &&
+		strcmp(current->comm, PROC_PX_TEST) != 0) {
 		printk_ratelimited(KERN_INFO "%s: invalid access comm=%s",
 			__func__, current->comm);
 		return -EACCES;

--- a/pxd.h
+++ b/pxd.h
@@ -62,6 +62,7 @@
 #define PROC_PX_CONTROL		"px"
 #define PROC_PX_TOOL		"pxd"
 #define PROC_PX_UT			"t"
+#define PROC_PX_TEST 		"pxd_test"
 
 /** fuse opcodes */
 enum pxd_opcode {
@@ -302,7 +303,7 @@ struct rdwr_in {
 };
 
 struct rdwr_in_v1 {
-	struct fuse_in_header_v1 in;	/**< fuse header */
+	struct fuse_in_header in;	/**< fuse header */
 	struct pxd_rdwr_in rdwr;	/**< read/write request */
 };
 

--- a/test/create_devices.sh
+++ b/test/create_devices.sh
@@ -1,0 +1,20 @@
+#!/ bin / bash
+
+#Create / dev / pxd directory
+mkdir - p / dev /
+            pxd
+
+#Read misc devices and create device nodes
+                grep pxd /
+            proc / misc |
+    while read minor name;
+do
+echo "Creating device /dev/$name with minor $minor" mknod / dev /
+            $name c 10 $minor 2 >
+        / dev / null ||
+    true chmod 666 / dev /
+            $name done
+
+#List created devices
+                ls -
+        la / dev / pxd /


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR Fixes the Unit Tests for px-fuse.
Which tests:
1. Adding and exporting a block device
2. Perform Read operation
3. Perform Write operation


Test results:

```
root@ip-10-13-172-207:~/go/src/github.com/portworx/px-fuse# ./test/pxd_test
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from PxdTest
[ RUN      ] PxdTest.device_size
⚠️ Directory '/dev/pxd' already exists. Skipping creation.
px                    258048  0
Opening control dev: /dev/pxd/pxd-control
Device /dev/pxd/pxd1 created
px                    258048  0
[       OK ] PxdTest.device_size (4195 ms)
[ RUN      ] PxdTest.write
⚠️ Directory '/dev/pxd' already exists. Skipping creation.
px                    258048  0
Opening control dev: /dev/pxd/pxd-control
Attempting to open device: /dev/pxd/pxd1
write_thread: bytes written: 16384
read_block: read/verify data from kernel
TestBody: reply to kernel: status: 0
px                    258048  0
[       OK ] PxdTest.write (4125 ms)
[ RUN      ] PxdTest.read
⚠️ Directory '/dev/pxd' already exists. Skipping creation.
px                    258048  0
Opening control dev: /dev/pxd/pxd-control
read_thread: submit read req: size: 16384
TestBody: reply to kernel: status: 0 iovcnt: 8
read_thread: bytes read req: 16384
px                    258048  0
[       OK ] PxdTest.read (4163 ms)
[----------] 3 tests from PxdTest (12484 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (12484 ms total)
[  PASSED  ] 3 tests.
```


**Which issue(s) this PR fixes** (optional)
Closes #

This PR makes it easy to test runtime behaviour of px-fuse.

**Special notes for your reviewer**:

