### PR TITLE
PWX-45751: 5.14.x and 6.x kernel driver support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -180,7 +180,7 @@ install:
 test_clean:
 	@/bin/rm -f test/pxd_test
 
-pxd_test: pxd_test.cc
+pxd_test: test/pxd_test.cc
 	@echo "Building Test ..."
 	g++ -I. -std=c++11 test/pxd_test.cc -lgtest -lboost_iostreams -lpthread -o test/pxd_test
 

--- a/dev.c
+++ b/dev.c
@@ -1305,7 +1305,11 @@ const struct file_operations fuse_dev_operations = {
 #else
 const struct file_operations fuse_dev_operations = {
 	.owner		= THIS_MODULE,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,0,0)
 	.llseek		= no_llseek,
+#else
+	.llseek         = NULL,
+#endif
 	.read_iter	= fuse_dev_read_iter,
 	.splice_read	= fuse_dev_splice_read,
 	.write_iter	= fuse_dev_write_iter,

--- a/pxd.c
+++ b/pxd.c
@@ -1212,7 +1212,7 @@ static const struct blk_mq_ops pxd_mq_ops = {
 #endif /* __PX_BLKMQ__ */
 #endif /* __PXD_BIO_BLKMQ__ */
 
-static int pxd_init_disk(struct pxd_device *pxd_dev)
+static int pxd_init_disk(struct pxd_device *pxd_dev, unsigned int *blk_mq_queue_flag)
 {
 	struct gendisk *disk;
 	struct request_queue *q;
@@ -1264,7 +1264,9 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 	  pxd_dev->tag_set.ops = &pxd_mq_ops;
 	  pxd_dev->tag_set.queue_depth = pxd_dev->queue_depth;
 	  pxd_dev->tag_set.numa_node = NUMA_NO_NODE;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,14,0)
 	  pxd_dev->tag_set.flags = BLK_MQ_F_SHOULD_MERGE;
+#endif
 	  pxd_dev->tag_set.nr_hw_queues = num_online_nodes() * pxd_num_fpthreads;
 	  pxd_dev->tag_set.cmd_size = sizeof(struct fuse_req);
 
@@ -1363,7 +1365,17 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 	disk->private_data = pxd_dev;
 	set_capacity(disk, pxd_dev->size / SECTOR_SIZE);
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,14,0) || (LINUX_VERSION_CODE < KERNEL_VERSION(6,9,0) && !defined(__EL8__))
+#if defined(RHEL_RELEASE_CODE) && defined(RHEL_RELEASE_VERSION)
+#if RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(9,6) && LINUX_VERSION_CODE < KERNEL_VERSION(6,10,0)
+	blk_queue_max_hw_sectors(q, PXD_MAX_IO / SECTOR_SIZE);
+	blk_queue_max_segment_size(q, SEGMENT_SIZE);
+	blk_queue_max_segments(q, (PXD_MAX_IO / PXD_LBS));
+	blk_queue_io_min(q, PXD_LBS);
+	blk_queue_io_opt(q, PXD_LBS);
+	blk_queue_logical_block_size(q, PXD_LBS);
+	blk_queue_physical_block_size(q, PXD_LBS);
+#endif
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(5,14,0) || (LINUX_VERSION_CODE < KERNEL_VERSION(6,9,0) && !defined(__EL8__))
 	blk_queue_max_hw_sectors(q, PXD_MAX_IO / SECTOR_SIZE);
 	blk_queue_max_segment_size(q, SEGMENT_SIZE);
 	blk_queue_max_segments(q, (PXD_MAX_IO / PXD_LBS));
@@ -1411,7 +1423,11 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 	pxd_dev->disk = disk;
 
 #if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0)
+	*blk_mq_queue_flag = blk_mq_freeze_queue(q);
+#else
 	blk_mq_freeze_queue(q);
+#endif
 #endif
 
 	return 0;
@@ -1589,6 +1605,7 @@ out_module:
 
 ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 {
+	unsigned int blk_mq_queue_flag = 0;
 	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
 	struct pxd_device *pxd_dev = find_pxd_device(ctx, dev_id);
 	int err = 0;
@@ -1609,7 +1626,7 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 		goto cleanup;
 	}
 
-	err = pxd_init_disk(pxd_dev);
+	err = pxd_init_disk(pxd_dev, &blk_mq_queue_flag);
 	if (err) {
 		module_put(THIS_MODULE);
 		goto cleanup;
@@ -1641,7 +1658,11 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 	pxd_dev->exported = true;
 	spin_unlock(&pxd_dev->lock);
 #if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0)
 	blk_mq_unfreeze_queue(pxd_dev->disk->queue);
+#else
+	blk_mq_unfreeze_queue(pxd_dev->disk->queue);
+#endif
 #endif
 	return 0;
 cleanup:
@@ -2412,7 +2433,8 @@ static int pxd_control_open(struct inode *inode, struct file *file)
 	if (strcmp(current->comm, PROC_PX_STORAGE) != 0 &&
 		strcmp(current->comm, PROC_PX_CONTROL) != 0 &&
 		strcmp(current->comm, PROC_PX_UT) != 0 &&
-		strcmp(current->comm, PROC_PX_TOOL) != 0) {
+		strcmp(current->comm, PROC_PX_TOOL) != 0 &&
+		strcmp(current->comm, PROC_PX_TEST) != 0) {
 		printk_ratelimited(KERN_INFO "%s: invalid access comm=%s",
 			__func__, current->comm);
 		return -EACCES;

--- a/pxd.h
+++ b/pxd.h
@@ -62,6 +62,7 @@
 #define PROC_PX_CONTROL		"px"
 #define PROC_PX_TOOL		"pxd"
 #define PROC_PX_UT			"t"
+#define PROC_PX_TEST            "pxd_test"
 
 /** fuse opcodes */
 enum pxd_opcode {

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -75,6 +75,7 @@ int fastpath_init(void)
 {
 	int rc = 0;
 	int node, cpu;
+	char namefmt[64];
 
 	// sanity check the pxfp worker thread values from mod param
 	if (MAX_PXFP_WORKERS_PER_NODE > MAX_ALLOC_PXFP_WORKER_THREADS_PER_NODE) {
@@ -124,7 +125,8 @@ int fastpath_init(void)
 			if (!cpu_online(cpu)) {
 				continue;
 			}
-			worker = kthread_create_worker_on_cpu(cpu, 0, "pxfpn%dc%d", node, cpu);
+			snprintf(namefmt, sizeof(namefmt), "pxfpn%dc%d", node, cpu);
+			worker = kthread_create_worker_on_cpu(cpu, 0, namefmt);
 			if (IS_ERR_OR_NULL(worker)) {
 				rc = PTR_ERR(worker);
 				goto out;


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

https://purestorage.atlassian.net/browse/PWX-45751

**What this PR does / why we need it**:
# problem reproduced with a UT # 
```
[root@ip-10-13-190-34 ~]# uname -a
Linux ip-10-13-190-34.pwx.purestorage.com 5.14.0-503.11.1.el9_5.x86_64 #1 SMP PREEMPT_DYNAMIC Mon Sep 30 11:54:45 EDT 2024 x86_64 x86_64 x86_64 GNU/Linux
[root@ip-10-13-190-34 ~]# cd px-fuse/px-fuse/
[root@ip-10-13-190-34 px-fuse]# test/pxd_test
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from PxdTest
[ RUN      ] PxdTest.simple
Opening control dev: /dev/pxd/pxd-control
simple test
[       OK ] PxdTest.simple (1238 ms)
[ RUN      ] PxdTest.device_size
Opening control dev: /dev/pxd/pxd-control
dev_export: PXD_EXPORT completed, wrote 24 bytes
dev_export: device ID = 1
dev_export: expected device path = /dev/pxd/pxd1
dev_export: device file appeared after 1 seconds
validating pxd device: /dev/pxd/pxd1
reading sysfs path: /sys/block/pxd!pxd1/queue/minimum_io_size
test/pxd_test.cc:160: Failure
Expected equality of these values:
  4096
  read_sysfs_value(sysfs_path + "minimum_io_size")
    Which is: 512
reading sysfs path: /sys/block/pxd!pxd1/queue/optimal_io_size
test/pxd_test.cc:161: Failure
Expected equality of these values:
  4096
  read_sysfs_value(sysfs_path + "optimal_io_size")
    Which is: 0
reading sysfs path: /sys/block/pxd!pxd1/queue/logical_block_size
test/pxd_test.cc:162: Failure
Expected equality of these values:
  4096
  read_sysfs_value(sysfs_path + "logical_block_size")
    Which is: 512
reading sysfs path: /sys/block/pxd!pxd1/queue/physical_block_size
test/pxd_test.cc:163: Failure
Expected equality of these values:
  4096
  read_sysfs_value(sysfs_path + "physical_block_size")
    Which is: 512
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segments
test/pxd_test.cc:166: Failure
Expected equality of these values:
  256
  read_sysfs_value(sysfs_path + "max_segments")
    Which is: 128
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segment_size
test/pxd_test.cc:167: Failure
Expected equality of these values:
  524288
  read_sysfs_value(sysfs_path + "max_segment_size")
    Which is: 65536
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_granularity
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_max_bytes
reading sysfs path: /sys/block/pxd!pxd1/queue/max_discard_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/fua
reading sysfs path: /sys/block/pxd!pxd1/queue/nr_requests
reading sysfs path: /sys/block/pxd!pxd1/queue/read_ahead_kb
[  FAILED  ] PxdTest.device_size (14224 ms)
[ RUN      ] PxdTest.write
Opening control dev: /dev/pxd/pxd-control
dev_export: PXD_EXPORT completed, wrote 24 bytes
dev_export: device ID = 1
dev_export: expected device path = /dev/pxd/pxd1
dev_export: device file appeared after 1 seconds
validating pxd device: /dev/pxd/pxd1
reading sysfs path: /sys/block/pxd!pxd1/queue/minimum_io_size
test/pxd_test.cc:160: Failure
Expected equality of these values:
  4096
  read_sysfs_value(sysfs_path + "minimum_io_size")
    Which is: 512
reading sysfs path: /sys/block/pxd!pxd1/queue/optimal_io_size
test/pxd_test.cc:161: Failure
Expected equality of these values:
  4096
  read_sysfs_value(sysfs_path + "optimal_io_size")
    Which is: 0
reading sysfs path: /sys/block/pxd!pxd1/queue/logical_block_size
test/pxd_test.cc:162: Failure
Expected equality of these values:
  4096
  read_sysfs_value(sysfs_path + "logical_block_size")
    Which is: 512
reading sysfs path: /sys/block/pxd!pxd1/queue/physical_block_size
test/pxd_test.cc:163: Failure
Expected equality of these values:
  4096
  read_sysfs_value(sysfs_path + "physical_block_size")
    Which is: 512
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segments
test/pxd_test.cc:166: Failure
Expected equality of these values:
  256
  read_sysfs_value(sysfs_path + "max_segments")
    Which is: 128
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segment_size
test/pxd_test.cc:167: Failure
Expected equality of these values:
  524288
  read_sysfs_value(sysfs_path + "max_segment_size")
    Which is: 65536
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_granularity
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_max_bytes
reading sysfs path: /sys/block/pxd!pxd1/queue/max_discard_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/fua
reading sysfs path: /sys/block/pxd!pxd1/queue/nr_requests
reading sysfs path: /sys/block/pxd!pxd1/queue/read_ahead_kb
write_thread: bytes written: 16384
request opc(8193) offset (16384) len (16384)read_block: read/verify data from kernel
TestBody: reply to kernel: status: 0
[  FAILED  ] PxdTest.write (14226 ms)
[ RUN      ] PxdTest.read
Opening control dev: /dev/pxd/pxd-control
dev_export: PXD_EXPORT completed, wrote 24 bytes
dev_export: device ID = 1
dev_export: expected device path = /dev/pxd/pxd1
dev_export: device file appeared after 1 seconds
validating pxd device: /dev/pxd/pxd1
reading sysfs path: /sys/block/pxd!pxd1/queue/minimum_io_size
test/pxd_test.cc:160: Failure
Expected equality of these values:
  4096
  read_sysfs_value(sysfs_path + "minimum_io_size")
    Which is: 512
reading sysfs path: /sys/block/pxd!pxd1/queue/optimal_io_size
test/pxd_test.cc:161: Failure
Expected equality of these values:
  4096
  read_sysfs_value(sysfs_path + "optimal_io_size")
    Which is: 0
reading sysfs path: /sys/block/pxd!pxd1/queue/logical_block_size
test/pxd_test.cc:162: Failure
Expected equality of these values:
  4096
  read_sysfs_value(sysfs_path + "logical_block_size")
    Which is: 512
reading sysfs path: /sys/block/pxd!pxd1/queue/physical_block_size
test/pxd_test.cc:163: Failure
Expected equality of these values:
  4096
  read_sysfs_value(sysfs_path + "physical_block_size")
    Which is: 512
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segments
test/pxd_test.cc:166: Failure
Expected equality of these values:
  256
  read_sysfs_value(sysfs_path + "max_segments")
    Which is: 128
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segment_size
test/pxd_test.cc:167: Failure
Expected equality of these values:
  524288
  read_sysfs_value(sysfs_path + "max_segment_size")
    Which is: 65536
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_granularity
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_max_bytes
reading sysfs path: /sys/block/pxd!pxd1/queue/max_discard_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/fua
reading sysfs path: /sys/block/pxd!pxd1/queue/nr_requests
reading sysfs path: /sys/block/pxd!pxd1/queue/read_ahead_kb
read_thread: submit read req: size: 16384
TestBody: reply to kernel: status: 0 iovcnt: 4
read_thread: bytes read req: 16384
[  FAILED  ] PxdTest.read (14263 ms)
[----------] 4 tests from PxdTest (43952 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (43952 ms total)
[  PASSED  ] 1 test.
[  FAILED  ] 3 tests, listed below:
[  FAILED  ] PxdTest.device_size
[  FAILED  ] PxdTest.write
[  FAILED  ] PxdTest.read

 3 FAILED TESTS
[root@ip-10-13-190-34 px-fuse]#
```



**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:


# On 9.6 RHEL #
```
ROTA property is set as 0 

[root@ip-10-13-190-34 px-fuse]# uname -a
Linux ip-10-13-190-34.pwx.purestorage.com 5.14.0-570.28.1.el9_6.x86_64 #1 SMP PREEMPT_DYNAMIC Wed Jul 16 02:51:06 EDT 2025 x86_64 x86_64 x86_64 GNU/Linux
[root@ip-10-13-190-34 px-fuse]#

[root@ip-10-13-190-34 px-fuse]# make pxd_test
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
Building Test ...
g++ -I. -std=c++11 test/pxd_test.cc -lgtest -lboost_iostreams -lpthread -o test/pxd_test
[root@ip-10-13-190-34 px-fuse]# ./test/pxd_test
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from PxdTest
[ RUN      ] PxdTest.simple
Opening control dev: /dev/pxd/pxd-control
simple test
[       OK ] PxdTest.simple (1202 ms)
[ RUN      ] PxdTest.device_size
Opening control dev: /dev/pxd/pxd-control
dev_export: PXD_EXPORT completed, wrote 24 bytes
dev_export: device ID = 1
dev_export: expected device path = /dev/pxd/pxd1
dev_export: device file appeared after 1 seconds
validating pxd device: /dev/pxd/pxd1
reading sysfs path: /sys/block/pxd!pxd1/queue/minimum_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/optimal_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/logical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/physical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segment_size
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_granularity
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_max_bytes
reading sysfs path: /sys/block/pxd!pxd1/queue/max_discard_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/fua
reading sysfs path: /sys/block/pxd!pxd1/queue/nr_requests
reading sysfs path: /sys/block/pxd!pxd1/queue/read_ahead_kb
[       OK ] PxdTest.device_size (14231 ms)
[ RUN      ] PxdTest.write
Opening control dev: /dev/pxd/pxd-control
dev_export: PXD_EXPORT completed, wrote 24 bytes
dev_export: device ID = 1
dev_export: expected device path = /dev/pxd/pxd1
dev_export: device file appeared after 1 seconds
validating pxd device: /dev/pxd/pxd1
reading sysfs path: /sys/block/pxd!pxd1/queue/minimum_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/optimal_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/logical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/physical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segment_size
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_granularity
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_max_bytes
reading sysfs path: /sys/block/pxd!pxd1/queue/max_discard_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/fua
reading sysfs path: /sys/block/pxd!pxd1/queue/nr_requests
reading sysfs path: /sys/block/pxd!pxd1/queue/read_ahead_kb
write_thread: bytes written: 16384
request opc(8193) offset (16384) len (16384)read_block: read/verify data from kernel
TestBody: reply to kernel: status: 0
[       OK ] PxdTest.write (14240 ms)
[ RUN      ] PxdTest.read
Opening control dev: /dev/pxd/pxd-control
dev_export: PXD_EXPORT completed, wrote 24 bytes
dev_export: device ID = 1
dev_export: expected device path = /dev/pxd/pxd1
dev_export: device file appeared after 1 seconds
validating pxd device: /dev/pxd/pxd1
reading sysfs path: /sys/block/pxd!pxd1/queue/minimum_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/optimal_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/logical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/physical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segment_size
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_granularity
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_max_bytes
reading sysfs path: /sys/block/pxd!pxd1/queue/max_discard_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/fua
reading sysfs path: /sys/block/pxd!pxd1/queue/nr_requests
reading sysfs path: /sys/block/pxd!pxd1/queue/read_ahead_kb
read_thread: submit read req: size: 16384
TestBody: reply to kernel: status: 0 iovcnt: 4
read_thread: bytes read req: 16384
[       OK ] PxdTest.read (14228 ms)
[----------] 4 tests from PxdTest (43903 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (43903 ms total)
[  PASSED  ] 4 tests.
[root@ip-10-13-190-34 px-fuse]# vi test/pxd_test.cc
[root@ip-10-13-190-34 px-fuse]#
```


# On RHEL 9.5 # 
```
[root@ip-10-13-190-34 px-fuse]# make
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
make  -C /usr/src/kernels/5.14.0-503.11.1.el9_5.x86_64  M=/root/px-fuse/px-fuse modules
make[1]: Entering directory '/usr/src/kernels/5.14.0-503.11.1.el9_5.x86_64'
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
  CC [M]  /root/px-fuse/px-fuse/pxd.o
  LD [M]  /root/px-fuse/px-fuse/px.o
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
  MODPOST /root/px-fuse/px-fuse/Module.symvers
  CC [M]  /root/px-fuse/px-fuse/px.mod.o
  LD [M]  /root/px-fuse/px-fuse/px.ko
  BTF [M] /root/px-fuse/px-fuse/px.ko
Skipping BTF generation for /root/px-fuse/px-fuse/px.ko due to unavailability of vmlinux
make[1]: Leaving directory '/usr/src/kernels/5.14.0-503.11.1.el9_5.x86_64'
[root@ip-10-13-190-34 px-fuse]# lsmod | grep px
[root@ip-10-13-190-34 px-fuse]# test/pxd_test
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from PxdTest
[ RUN      ] PxdTest.simple
Opening control dev: /dev/pxd/pxd-control
simple test
[       OK ] PxdTest.simple (1216 ms)
[ RUN      ] PxdTest.device_size
Opening control dev: /dev/pxd/pxd-control
dev_export: PXD_EXPORT completed, wrote 24 bytes
dev_export: device ID = 1
dev_export: expected device path = /dev/pxd/pxd1
dev_export: device file appeared after 1 seconds
validating pxd device: /dev/pxd/pxd1
reading sysfs path: /sys/block/pxd!pxd1/queue/minimum_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/optimal_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/logical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/physical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segment_size
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_granularity
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_max_bytes
reading sysfs path: /sys/block/pxd!pxd1/queue/max_discard_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/fua
reading sysfs path: /sys/block/pxd!pxd1/queue/nr_requests
reading sysfs path: /sys/block/pxd!pxd1/queue/read_ahead_kb
[       OK ] PxdTest.device_size (14223 ms)
[ RUN      ] PxdTest.write
Opening control dev: /dev/pxd/pxd-control
dev_export: PXD_EXPORT completed, wrote 24 bytes
dev_export: device ID = 1
dev_export: expected device path = /dev/pxd/pxd1
dev_export: device file appeared after 1 seconds
validating pxd device: /dev/pxd/pxd1
reading sysfs path: /sys/block/pxd!pxd1/queue/minimum_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/optimal_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/logical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/physical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segment_size
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_granularity
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_max_bytes
reading sysfs path: /sys/block/pxd!pxd1/queue/max_discard_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/fua
reading sysfs path: /sys/block/pxd!pxd1/queue/nr_requests
reading sysfs path: /sys/block/pxd!pxd1/queue/read_ahead_kb
write_thread: bytes written: 16384
request opc(8193) offset (16384) len (16384)read_block: read/verify data from kernel
TestBody: reply to kernel: status: 0
[       OK ] PxdTest.write (14221 ms)
[ RUN      ] PxdTest.read
Opening control dev: /dev/pxd/pxd-control
dev_export: PXD_EXPORT completed, wrote 24 bytes
dev_export: device ID = 1
dev_export: expected device path = /dev/pxd/pxd1
dev_export: device file appeared after 1 seconds
validating pxd device: /dev/pxd/pxd1
reading sysfs path: /sys/block/pxd!pxd1/queue/minimum_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/optimal_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/logical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/physical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segment_size
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_granularity
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_max_bytes
reading sysfs path: /sys/block/pxd!pxd1/queue/max_discard_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/fua
reading sysfs path: /sys/block/pxd!pxd1/queue/nr_requests
reading sysfs path: /sys/block/pxd!pxd1/queue/read_ahead_kb
read_thread: submit read req: size: 16384
TestBody: reply to kernel: status: 0 iovcnt: 4
read_thread: bytes read req: 16384
[       OK ] PxdTest.read (14229 ms)
[----------] 4 tests from PxdTest (43891 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (43892 ms total)
[  PASSED  ] 4 tests.
[root@ip-10-13-190-34 px-fuse]#
```


# On RHEL 9.4 # 
```
[root@ip-10-13-190-34 ~]# uname -a
Linux ip-10-13-190-34.pwx.purestorage.com 5.14.0-427.13.1.el9_4.x86_64 #1 SMP PREEMPT_DYNAMIC Wed Apr 10 10:29:16 EDT 2024 x86_64 x86_64 x86_64 GNU/Linux
[root@ip-10-13-190-34 ~]# cd px-fuse/px-fuse/
[root@ip-10-13-190-34 px-fuse]# make clean ; make ; make pxd_test
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
make -C /usr/src/kernels/5.14.0-427.13.1.el9_4.x86_64  M=/root/px-fuse/px-fuse clean
make[1]: Entering directory '/usr/src/kernels/5.14.0-427.13.1.el9_4.x86_64'
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
  CLEAN   /root/px-fuse/px-fuse/Module.symvers
make[1]: Leaving directory '/usr/src/kernels/5.14.0-427.13.1.el9_4.x86_64'
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
make  -C /usr/src/kernels/5.14.0-427.13.1.el9_4.x86_64  M=/root/px-fuse/px-fuse modules
make[1]: Entering directory '/usr/src/kernels/5.14.0-427.13.1.el9_4.x86_64'
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
  CC [M]  /root/px-fuse/px-fuse/pxd.o
  CC [M]  /root/px-fuse/px-fuse/dev.o
  CC [M]  /root/px-fuse/px-fuse/iov_iter.o
  CC [M]  /root/px-fuse/px-fuse/px_version.o
  CC [M]  /root/px-fuse/px-fuse/kiolib.o
  CC [M]  /root/px-fuse/px-fuse/pxd_bio_makereq.o
  CC [M]  /root/px-fuse/px-fuse/pxd_bio_blkmq.o
  CC [M]  /root/px-fuse/px-fuse/pxd_fastpath.o
  LD [M]  /root/px-fuse/px-fuse/px.o
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
  MODPOST /root/px-fuse/px-fuse/Module.symvers
  CC [M]  /root/px-fuse/px-fuse/px.mod.o
  LD [M]  /root/px-fuse/px-fuse/px.ko
  BTF [M] /root/px-fuse/px-fuse/px.ko
Skipping BTF generation for /root/px-fuse/px-fuse/px.ko due to unavailability of vmlinux
make[1]: Leaving directory '/usr/src/kernels/5.14.0-427.13.1.el9_4.x86_64'
Kernel version 5.14 supports fastpath.
Kernel version 5.14 supports blkmq driver model.
Building Test ...
g++ -I. -std=c++11 test/pxd_test.cc -lgtest -lboost_iostreams -lpthread -o test/pxd_test
[root@ip-10-13-190-34 px-fuse]#
[root@ip-10-13-190-34 px-fuse]#
[root@ip-10-13-190-34 px-fuse]#
[root@ip-10-13-190-34 px-fuse]# test/pxd_test
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from PxdTest
[ RUN      ] PxdTest.simple
Opening control dev: /dev/pxd/pxd-control
simple test
[       OK ] PxdTest.simple (1223 ms)
[ RUN      ] PxdTest.device_size
Opening control dev: /dev/pxd/pxd-control
dev_export: PXD_EXPORT completed, wrote 24 bytes
dev_export: device ID = 1
dev_export: expected device path = /dev/pxd/pxd1
dev_export: device file appeared after 1 seconds
validating pxd device: /dev/pxd/pxd1
reading sysfs path: /sys/block/pxd!pxd1/queue/minimum_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/optimal_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/logical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/physical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segment_size
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_granularity
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_max_bytes
reading sysfs path: /sys/block/pxd!pxd1/queue/max_discard_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/fua
reading sysfs path: /sys/block/pxd!pxd1/queue/nr_requests
reading sysfs path: /sys/block/pxd!pxd1/queue/read_ahead_kb
[       OK ] PxdTest.device_size (14230 ms)
[ RUN      ] PxdTest.write
Opening control dev: /dev/pxd/pxd-control
dev_export: PXD_EXPORT completed, wrote 24 bytes
dev_export: device ID = 1
dev_export: expected device path = /dev/pxd/pxd1
dev_export: device file appeared after 1 seconds
validating pxd device: /dev/pxd/pxd1
reading sysfs path: /sys/block/pxd!pxd1/queue/minimum_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/optimal_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/logical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/physical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segment_size
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_granularity
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_max_bytes
reading sysfs path: /sys/block/pxd!pxd1/queue/max_discard_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/fua
reading sysfs path: /sys/block/pxd!pxd1/queue/nr_requests
reading sysfs path: /sys/block/pxd!pxd1/queue/read_ahead_kb
write_thread: bytes written: 16384
request opc(8193) offset (16384) len (16384)read_block: read/verify data from kernel
TestBody: reply to kernel: status: 0
[       OK ] PxdTest.write (14230 ms)
[ RUN      ] PxdTest.read
Opening control dev: /dev/pxd/pxd-control
dev_export: PXD_EXPORT completed, wrote 24 bytes
dev_export: device ID = 1
dev_export: expected device path = /dev/pxd/pxd1
dev_export: device file appeared after 1 seconds
validating pxd device: /dev/pxd/pxd1
reading sysfs path: /sys/block/pxd!pxd1/queue/minimum_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/optimal_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/logical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/physical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segment_size
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_granularity
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_max_bytes
reading sysfs path: /sys/block/pxd!pxd1/queue/max_discard_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/fua
reading sysfs path: /sys/block/pxd!pxd1/queue/nr_requests
reading sysfs path: /sys/block/pxd!pxd1/queue/read_ahead_kb
read_thread: submit read req: size: 16384
TestBody: reply to kernel: status: 0 iovcnt: 4
read_thread: bytes read req: 16384
[       OK ] PxdTest.read (14221 ms)
[----------] 4 tests from PxdTest (43907 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (43907 ms total)
[  PASSED  ] 4 tests.
[root@ip-10-13-190-34 px-fuse]#
```

# On ubuntu 18 # 
```
lns@lsundararajan:~/srcs/src/github.com/portworx/px-fuse$ make clean; make ; make pxd_test
Kernel version 5.4 supports fastpath.
Kernel version 5.4 supports blkmq driver model.
make -C /usr/src/linux-headers-5.4.188-0504188-generic  M=/home/lns/srcs/src/github.com/portworx/px-fuse clean
make[1]: Entering directory '/usr/src/linux-headers-5.4.188-0504188-generic'
Kernel version 5.4 supports fastpath.
Kernel version 5.4 supports blkmq driver model.
  CLEAN   /home/lns/srcs/src/github.com/portworx/px-fuse/Module.symvers
make[1]: Leaving directory '/usr/src/linux-headers-5.4.188-0504188-generic'
Kernel version 5.4 supports fastpath.
Kernel version 5.4 supports blkmq driver model.
make  -C /usr/src/linux-headers-5.4.188-0504188-generic  M=/home/lns/srcs/src/github.com/portworx/px-fuse modules
make[1]: Entering directory '/usr/src/linux-headers-5.4.188-0504188-generic'
Kernel version 5.4 supports fastpath.
Kernel version 5.4 supports blkmq driver model.
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/pxd.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/dev.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/iov_iter.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/px_version.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/kiolib.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/pxd_bio_makereq.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/pxd_bio_blkmq.o
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/pxd_fastpath.o
  LD [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/px.o
Kernel version 5.4 supports fastpath.
Kernel version 5.4 supports blkmq driver model.
  Building modules, stage 2.
  MODPOST 1 modules
  CC [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/px.mod.o
  LD [M]  /home/lns/srcs/src/github.com/portworx/px-fuse/px.ko
make[1]: Leaving directory '/usr/src/linux-headers-5.4.188-0504188-generic'
Kernel version 5.4 supports fastpath.
Kernel version 5.4 supports blkmq driver model.
Building Test ...
g++ -I. -std=c++11 test/pxd_test.cc -lgtest -lboost_iostreams -lpthread -o test/pxd_test
lns@lsundararajan:~/srcs/src/github.com/portworx/px-fuse$ uname -a
Linux lsundararajan.pwx.purestorage.com 5.4.188-0504188-generic #202203280745 SMP Mon Mar 28 08:24:30 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
lns@lsundararajan:~/srcs/src/github.com/portworx/px-fuse$ sudo su
root@lsundararajan:/home/lns/srcs/src/github.com/portworx/px-fuse# lsmod | grep px
root@lsundararajan:/home/lns/srcs/src/github.com/portworx/px-fuse# test/pxd_test
[==========] Running 4 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 4 tests from PxdTest
[ RUN      ] PxdTest.simple
Opening control dev: /dev/pxd/pxd-control
simple test
[       OK ] PxdTest.simple (1076 ms)
[ RUN      ] PxdTest.device_size
Opening control dev: /dev/pxd/pxd-control
dev_export: PXD_EXPORT completed, wrote 24 bytes
dev_export: device ID = 1
dev_export: expected device path = /dev/pxd/pxd1
dev_export: device file appeared after 1 seconds
validating pxd device: /dev/pxd/pxd1
reading sysfs path: /sys/block/pxd!pxd1/queue/minimum_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/optimal_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/logical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/physical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segment_size
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_granularity
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_max_bytes
reading sysfs path: /sys/block/pxd!pxd1/queue/max_discard_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/fua
reading sysfs path: /sys/block/pxd!pxd1/queue/nr_requests
reading sysfs path: /sys/block/pxd!pxd1/queue/read_ahead_kb
fail_io: opc (8194) reply to kernel: status: -5 iovcnt: 1
fail_io: opc (8194) reply to kernel: status: -5 iovcnt: 1
fail_io: opc (8194) reply to kernel: status: -5 iovcnt: 1
[       OK ] PxdTest.device_size (14096 ms)
[ RUN      ] PxdTest.write
Opening control dev: /dev/pxd/pxd-control
dev_export: PXD_EXPORT completed, wrote 24 bytes
dev_export: device ID = 1
dev_export: expected device path = /dev/pxd/pxd1
dev_export: device file appeared after 1 seconds
validating pxd device: /dev/pxd/pxd1
reading sysfs path: /sys/block/pxd!pxd1/queue/minimum_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/optimal_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/logical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/physical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segment_size
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_granularity
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_max_bytes
reading sysfs path: /sys/block/pxd!pxd1/queue/max_discard_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/fua
reading sysfs path: /sys/block/pxd!pxd1/queue/nr_requests
reading sysfs path: /sys/block/pxd!pxd1/queue/read_ahead_kb
fail_io: opc (8194) reply to kernel: status: -5 iovcnt: 1
write_thread: bytes written: 16384
fail_io: opc (8194) reply to kernel: status: -5 iovcnt: 1
fail_io: opc (8194) reply to kernel: status: -5 iovcnt: 1
request opc(8193) offset (16384) len (16384)read_block: read/verify data from kernel
TestBody: reply to kernel: status: 0
[       OK ] PxdTest.write (14133 ms)
[ RUN      ] PxdTest.read
Opening control dev: /dev/pxd/pxd-control
dev_export: PXD_EXPORT completed, wrote 24 bytes
dev_export: device ID = 1
dev_export: expected device path = /dev/pxd/pxd1
dev_export: device file appeared after 1 seconds
validating pxd device: /dev/pxd/pxd1
reading sysfs path: /sys/block/pxd!pxd1/queue/minimum_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/optimal_io_size
reading sysfs path: /sys/block/pxd!pxd1/queue/logical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/physical_block_size
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/max_segment_size
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_granularity
reading sysfs path: /sys/block/pxd!pxd1/queue/discard_max_bytes
reading sysfs path: /sys/block/pxd!pxd1/queue/max_discard_segments
reading sysfs path: /sys/block/pxd!pxd1/queue/fua
reading sysfs path: /sys/block/pxd!pxd1/queue/nr_requests
reading sysfs path: /sys/block/pxd!pxd1/queue/read_ahead_kb
fail_io: opc (8194) reply to kernel: status: -5 iovcnt: 1
read_thread: submit read req: size: 16384
TestBody: reply to kernel: status: 0 iovcnt: 4
read_thread: bytes read req: 16384
fail_io: opc (8194) reply to kernel: status: -5 iovcnt: 1
fail_io: opc (8194) reply to kernel: status: -5 iovcnt: 1
[       OK ] PxdTest.read (14095 ms)
[----------] 4 tests from PxdTest (43400 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test case ran. (43401 ms total)
[  PASSED  ] 4 tests.
root@lsundararajan:/home/lns/srcs/src/github.com/portworx/px-fuse#
```