### PR TITLE
Fix photon OS blkcg_root_css not found issue

### DIFF
--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -419,12 +419,10 @@ static struct bio *clone_root(struct fp_root_context *fproot, int i) {
         clone_bio->bi_end_io = end_clone_bio;
 
 #ifdef CONFIG_BLK_CGROUP
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0) && defined(__EL8__))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0) ||                          \
+    (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 18, 0) && defined(__EL8__))
         if (clone_bio->bi_blkg == NULL)
-        	bio_associate_blkg_from_css(clone_bio, blkcg_root_css);
-#else
-        if (clone_bio->bi_css == NULL)
-        	bio_associate_blkcg(clone_bio, blkcg_root_css);
+                bio_associate_blkg_from_css(clone_bio, blkcg_root_css);
 #endif
 #endif
 

--- a/test/pxd_test.cc
+++ b/test/pxd_test.cc
@@ -455,7 +455,11 @@ void PxdTest::validate_device_properties(const std::string &device_name,
 
 	// Validate other properties
 	EXPECT_EQ(128, read_sysfs_value(sysfs_path + "nr_requests"));
-	EXPECT_EQ(128, read_sysfs_value(sysfs_path + "read_ahead_kb"));
+
+	// read_ahead_kb value is set by kernel based on physical storage performance
+	// For HDDs it is 256 or higher, for SSDs it could be 128 or lower
+	// Some older kernel version also set it to 512 kbs by default.
+	EXPECT_GE(read_sysfs_value(sysfs_path + "read_ahead_kb"), 128);
 
 	// Check if FUA file exists before trying to read it
     std::string fua_path = sysfs_path + "fua";


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR fixes issue with photon OS compatibility with px-fuse by removing calls involving blkcg_root_css since this symbol is present but not exported in kernel module below 5.0.0 version. 
Hence, the compiled sources on any OS below 5.0.0 kernel version do not support this operation.

## Photon OS 3.0 Error before the change
```
root@ip-10-13-241-210 [ ~/px-fuse ]# uname -r
4.19.325-1.ph3
root@ip-10-13-241-210 [ ~/px-fuse ]# sudo insmod px.ko
insmod: ERROR: could not insert module px.ko: Unknown symbol in module
root@ip-10-13-241-210 [ ~/px-fuse ]# lsmod | grep px
root@ip-10-13-241-210 [ ~/px-fuse ]# dmesg -e | grep px
...
...
[  +0.001011] pxd_control_open: pxd-control-0(1) open OK
[  +0.000003] pxd_read_init: pxd-control-0 init OK 0 devs version 12
[  +2.001573] pxd_finish_remove: dev 1
[  +1.032487] pxd_control_release: pxd-control-0(1) close OK
[  +0.000765] pxd: driver unloaded
[Aug 7 12:08] px: Unknown symbol blkcg_root_css (err -2)
```

## We have the same error on Ubuntu 18.04 as well:
```
root@ip-10-13-188-189:~# uname -r
4.15.0-175-generic
root@ip-10-13-181-206:~/px-fuse# sudo insmod px.ko
insmod: ERROR: could not insert module px.ko: Unknown symbol in module
root@ip-10-13-181-206:~/px-fuse# dmesg -e | grep px
[Aug 7 15:23] px: loading out-of-tree module taints kernel.
[  +0.012785] px: module verification failed: signature and/or required key missing - tainting kernel
[  +0.000342] px: Unknown symbol blkcg_root_css (err 0)
[Aug 7 17:07] px: Unknown symbol blkcg_root_css (err 0)
```

## Even though the above compilation failure not present on SUSE / SLE - following test failure was present:
```
reading sysfs path: /sys/block/pxd!pxd1/queue/read_ahead_kb
test/pxd_test.cc:458: Failure
Expected equality of these values:
  128
  read_sysfs_value(sysfs_path + "read_ahead_kb")
    Which is: 512
```

**Which issue(s) this PR fixes** (optional)
Closes #
[PWX-44437](https://purestorage.atlassian.net/browse/PWX-44437)

**Special notes for your reviewer**:



[PWX-44437]: https://purestorage.atlassian.net/browse/PWX-44437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ