### PR TITLE
Revert "move blk_mq_freeze_queue before queue property modification"

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1000,7 +1000,7 @@ static const struct blk_mq_ops pxd_mq_ops = {
 #endif /* __PX_BLKMQ__ */
 #endif /* __PXD_BIO_BLKMQ__ */
 
-static int pxd_init_disk(struct pxd_device *pxd_dev)
+static int pxd_init_disk(struct pxd_device *pxd_dev, unsigned int *blk_mq_queue_flag)
 {
 	struct gendisk *disk;
 	struct request_queue *q;
@@ -1206,6 +1206,14 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 	q->queuedata = pxd_dev;
 	pxd_dev->disk = disk;
 
+#if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0)
+	*blk_mq_queue_flag = blk_mq_freeze_queue(q);
+#else
+	blk_mq_freeze_queue(q);
+#endif
+#endif
+
 	return 0;
 }
 
@@ -1393,6 +1401,7 @@ out_module:
 
 ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 {
+	unsigned int blk_mq_queue_flag = 0;
 	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
 	struct pxd_device *pxd_dev = find_pxd_device(ctx, dev_id);
 	int err = 0;
@@ -1414,7 +1423,7 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 		goto cleanup;
 	}
 
-	err = pxd_init_disk(pxd_dev);
+	err = pxd_init_disk(pxd_dev, &blk_mq_queue_flag);
 	if (err) {
 		module_put(THIS_MODULE);
 		goto cleanup;
@@ -1445,6 +1454,13 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 	spin_lock(&pxd_dev->lock);
 	pxd_dev->exported = true;
 	spin_unlock(&pxd_dev->lock);
+#if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0)
+	blk_mq_unfreeze_queue(pxd_dev->disk->queue, blk_mq_queue_flag);
+#else
+	blk_mq_unfreeze_queue(pxd_dev->disk->queue);
+#endif
+#endif
 	return 0;
 cleanup:
     spin_lock(&ctx->lock);


### PR DESCRIPTION
This reverts commit c8c0b312c652c7f2ebf258191a072146f3000de5.


**What this PR does / why we need it**: Reverts changes made as part of PR - https://github.com/portworx/px-fuse/pull/386/files



**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

