### PR TITLE
compatibility fix for blk_mq_freeze_queue, blk_mq_unfreeze_queue

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -101,7 +101,39 @@ endif
 # CentOS Stream 9-10 Specific kernel checks
 ifeq ($(shell echo "$(CHK_KVER)" | grep -Eq '.*\.el(9|10)\.x86_64'; echo $$?),0)
 PXDEFINES += -D__EL9_STREAM__
+
+# Extract kernel build number for EL9 (e.g., 5.14.0-691.el9 -> 691)
+EL9_BUILD=$(shell echo $(CHK_KVER) | sed -n 's/.*-\([0-9]\+\)\.el9.*/\1/p')
+ifneq ($(EL9_BUILD),)
+# blk_mq_freeze_queue() kernel API changed in rhel since version 5.14.0-611 kernel version
+ifeq ($(shell test $(EL9_BUILD) -gt 687; echo $$?),0)
+PXDEFINES += -D__BLK_Q_FREEZE_WITH_MEMFLAG__
 endif
+endif
+
+endif
+
+
+# EL10 Specific kernel checks, uapi version.h file has RHEL specific defines maybe can use.
+ifeq ($(shell echo "$(CHK_KVER)" | grep -Eq '.*\.el10.*\.x86_64'; echo $$?),0)
+
+ifeq ($(shell test -f /proc/version && grep -q ".stream" /proc/version; echo $$?),0)
+PXDEFINES += -D__BLK_Q_FREEZE_WITH_MEMFLAG__
+endif
+
+PXDEFINES += -D__PX_BLKMQ__ -D__EL10__
+# Extract kernel build number for EL10 (e.g., 6.12.0-124.el10 -> 124)
+EL10_BUILD=$(shell echo $(CHK_KVER) | sed -n 's/.*-\([0-9]\+\)\.el10.*/\1/p')
+ifneq ($(EL10_BUILD),)
+# blk_mq_freeze_queue() kernel API changed in rhel 10 since version 6.12.0-55 kernel version
+ifeq ($(shell test $(EL10_BUILD) -gt 55; echo $$?),0)
+PXDEFINES += -D__BLK_Q_FREEZE_WITH_MEMFLAG__
+endif
+endif
+
+endif
+
+
 
 # ELRepo 9-10 Specific kernel checks
 ifeq ($(shell echo "$(CHK_KVER)" | grep -Eq '.*\.el(9|10)\.elrepo\.x86_64'; echo $$?),0)
@@ -179,6 +211,7 @@ ifdef CONFIG_SUSE_PATCHLEVEL
         else ifeq ($(shell test $(SUSE_BUILD) -gt 150600; echo $$?),0)
             # Newer SUSE versions (e.g., 160000+) use blk_mode_t
             SUSE_HAS_BLK_MODE_T := 1
+			PXDEFINES += -D__SUSE_GTE_16_0__
         endif
 
         ifeq ($(SUSE_HAS_BLK_MODE_T),1)

--- a/pxd.c
+++ b/pxd.c
@@ -1207,7 +1207,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, unsigned int *blk_mq_queue_
 	pxd_dev->disk = disk;
 
 #if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || defined(__BLK_Q_FREEZE_WITH_MEMFLAG__) || (LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) && defined(__SUSE_GTE_16_0__))
 	*blk_mq_queue_flag = blk_mq_freeze_queue(q);
 #else
 	blk_mq_freeze_queue(q);
@@ -1455,7 +1455,7 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 	pxd_dev->exported = true;
 	spin_unlock(&pxd_dev->lock);
 #if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0)) || defined(__BLK_Q_FREEZE_WITH_MEMFLAG__) || (LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) && defined(__SUSE_GTE_16_0__))
 	blk_mq_unfreeze_queue(pxd_dev->disk->queue, blk_mq_queue_flag);
 #else
 	blk_mq_unfreeze_queue(pxd_dev->disk->queue);


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Testing Results**:

Ubuntu - 5.15.0-67-generic
```
 make
Kernel version 5.15 supports fastpath.
Kernel version 5.15 supports blkmq driver model.
make  -C /usr/src/linux-headers-5.15.0-67-generic  M=/root/px-fuse modules
make[1]: Entering directory '/usr/src/linux-headers-5.15.0-67-generic'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
  You are using:           gcc (GCC) 12.2.0
Kernel version 5.15 supports fastpath.
Kernel version 5.15 supports blkmq driver model.
  CC [M]  /root/px-fuse/pxd.o
  CC [M]  /root/px-fuse/dev.o
  CC [M]  /root/px-fuse/iov_iter.o
  CC [M]  /root/px-fuse/px_version.o
  CC [M]  /root/px-fuse/kiolib.o
  CC [M]  /root/px-fuse/pxd_bio_blkmq.o
  CC [M]  /root/px-fuse/pxd_fastpath.o
  LD [M]  /root/px-fuse/px.o
Kernel version 5.15 supports fastpath.
Kernel version 5.15 supports blkmq driver model.
  MODPOST /root/px-fuse/Module.symvers
  CC [M]  /root/px-fuse/px.mod.o
  LD [M]  /root/px-fuse/px.ko
  BTF [M] /root/px-fuse/px.ko
Skipping BTF generation for /root/px-fuse/px.ko due to unavailability of vmlinux
make[1]: Leaving directory '/usr/src/linux-headers-5.15.0-67-generic'
```

RHEL 10 -  6.12.0-124.21.1.el10_1.x86_64
```
make[1]: Entering directory '/usr/src/kernels/6.12.0-124.21.1.el10_1.x86_64'
Kernel version 6.12 supports fastpath.
Kernel version 6.12 supports blkmq driver model.
  CC [M]  /root/px-fuse/pxd.o
  CC [M]  /root/px-fuse/dev.o
  CC [M]  /root/px-fuse/iov_iter.o
  CC [M]  /root/px-fuse/px_version.o
  CC [M]  /root/px-fuse/kiolib.o
  CC [M]  /root/px-fuse/pxd_bio_blkmq.o
  CC [M]  /root/px-fuse/pxd_fastpath.o
  LD [M]  /root/px-fuse/px.o
Kernel version 6.12 supports fastpath.
Kernel version 6.12 supports blkmq driver model.
  MODPOST /root/px-fuse/Module.symvers
  CC [M]  /root/px-fuse/px.mod.o
  CC [M]  /root/px-fuse/.module-common.o
  LD [M]  /root/px-fuse/px.ko
  BTF [M] /root/px-fuse/px.ko
Skipping BTF generation for /root/px-fuse/px.ko due to unavailability of vmlinux
make[1]: Leaving directory '/usr/src/kernels/6.12.0-124.21.1.el10_1.x86_64'
```


SLES - 6.12.0-160000.27-default
```
make[1]: Entering directory '/usr/src/kernels/6.12.0-160000.27-default'
Kernel version 6.12 supports fastpath.
Kernel version 6.12 supports blkmq driver model.
Kernel version 6.12 supports fastpath.
Kernel version 6.12 supports blkmq driver model.
  MODPOST /root/px-fuse/Module.symvers
WARNING: Module.symvers is missing.
         Modules may not have dependencies or modversions.
         You may get many unresolved symbol errors.
         You can set KBUILD_MODPOST_WARN=1 to turn errors into warning
         if you want to proceed at your own risk.
WARNING: modpost: "module_put" [/root/px-fuse/px.ko] undefined!
WARNING: modpost: "page_offset_base" [/root/px-fuse/px.ko] undefined!
WARNING: modpost: "work_busy" [/root/px-fuse/px.ko] undefined!
WARNING: modpost: "bioset_exit" [/root/px-fuse/px.ko] undefined!
WARNING: modpost: "unregister_blkdev" [/root/px-fuse/px.ko] undefined!
WARNING: modpost: "__task_pid_nr_ns" [/root/px-fuse/px.ko] undefined!
WARNING: modpost: "bio_put" [/root/px-fuse/px.ko] undefined!
WARNING: modpost: "bio_endio" [/root/px-fuse/px.ko] undefined!
WARNING: modpost: "init_wait_entry" [/root/px-fuse/px.ko] undefined!
WARNING: modpost: "perf_trace_buf_alloc" [/root/px-fuse/px.ko] undefined!
WARNING: modpost: suppressed 184 unresolved symbol warnings because there were too many)
  CC [M]  /root/px-fuse/px.mod.o
  CC [M]  /root/px-fuse/.module-common.o
  LD [M]  /root/px-fuse/px.ko
  BTF [M] /root/px-fuse/px.ko
Skipping BTF generation for /root/px-fuse/px.ko due to unavailability of vmlinux
make[1]: Leaving directory '/usr/src/kernels/6.12.0-160000.27-default'
```

**Special notes for your reviewer**:

