### PR TITLE
apply revert changes from blk_mq_freeze_queue_PR-433, PR-439

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -103,6 +103,40 @@ ifeq ($(shell echo "$(CHK_KVER)" | grep -Eq '.*\.el(9|10)\.x86_64'; echo $$?),0)
 PXDEFINES += -D__EL9_STREAM__
 endif
 
+ifeq ($(shell echo "$(CHK_KVER)" | grep -Eq '.*\.el9.*'; echo $$?),0)
+
+# Extract kernel build number for EL9 (e.g., 5.14.0-691.el9 -> 691)
+EL9_BUILD=$(shell echo $(CHK_KVER) | sed -n -E 's/.*-([0-9]+)\..*el9.*/\1/p')
+ifneq ($(EL9_BUILD),)
+# blk_mq_freeze_queue() kernel API changed in rhel since version 5.14.0-611 kernel version
+ifeq ($(shell test $(EL9_BUILD) -ge 603; echo $$?),0)
+PXDEFINES += -D__BLK_Q_FREEZE_WITH_MEMFLAG__
+endif
+endif
+
+endif
+
+
+# EL10 Specific kernel checks, uapi version.h file has RHEL specific defines maybe can use.
+ifeq ($(shell echo "$(CHK_KVER)" | grep -Eq '.*\.el10.*'; echo $$?),0)
+
+ifeq ($(shell test -f /proc/version && grep -q ".stream" /proc/version; echo $$?),0)
+PXDEFINES += -D__BLK_Q_FREEZE_WITH_MEMFLAG__
+endif
+
+PXDEFINES += -D__PX_BLKMQ__ -D__EL10__
+# Extract kernel build number for EL10 (e.g., 6.12.0-124.el10 -> 124)
+EL10_BUILD=$(shell echo $(CHK_KVER) | sed -n -E 's/.*-([0-9]+)\..*el10.*/\1/p')
+ifneq ($(EL10_BUILD),)
+# blk_mq_freeze_queue() kernel API changed in rhel 10 since version 6.12.0-55 kernel version
+ifeq ($(shell test $(EL10_BUILD) -gt 55; echo $$?),0)
+PXDEFINES += -D__BLK_Q_FREEZE_WITH_MEMFLAG__
+endif
+endif
+
+endif
+
+
 # ELRepo 9-10 Specific kernel checks
 ifeq ($(shell echo "$(CHK_KVER)" | grep -Eq '.*\.el(9|10)\.elrepo\.x86_64'; echo $$?),0)
 PXDEFINES += -D__ELREPO9__

--- a/pxd.c
+++ b/pxd.c
@@ -1233,6 +1233,14 @@ static int pxd_init_disk(struct pxd_device *pxd_dev)
 	q->queuedata = pxd_dev;
 	pxd_dev->disk = disk;
 
+#if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || defined(__BLK_Q_FREEZE_WITH_MEMFLAG__) || (LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) && defined(__SUSE_GTE_16_0__))
+	*blk_mq_queue_flag = blk_mq_freeze_queue(q);
+#else
+	blk_mq_freeze_queue(q);
+#endif
+#endif
+
 	return 0;
 }
 
@@ -1458,6 +1466,13 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 	spin_lock(&pxd_dev->lock);
 	pxd_dev->exported = true;
 	spin_unlock(&pxd_dev->lock);
+#if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || defined(__BLK_Q_FREEZE_WITH_MEMFLAG__) || (LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) && defined(__SUSE_GTE_16_0__))
+	blk_mq_unfreeze_queue(pxd_dev->disk->queue, blk_mq_queue_flag);
+#else
+	blk_mq_unfreeze_queue(pxd_dev->disk->queue);
+#endif
+#endif
 	return 0;
 cleanup:
     spin_lock(&ctx->lock);


### PR DESCRIPTION
**What this PR does / why we need it**:
apply compatibility changes from blk_mq_freeze_queue_PR-433, PR-439

**Which issue(s) this PR fixes** (optional)
Closes #

**Testing Done**

Ubuntu - 5.15.0-67-generic
```
make  -C /usr/src/linux-headers-5.15.0-67-generic  M=/root/px-fuse modules
make[1]: Entering directory '/usr/src/linux-headers-5.15.0-67-generic'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
  You are using:           gcc (GCC) 12.2.0
Kernel version 5.15 supports fastpath.
Kernel version 5.15 supports blkmq driver model.
  CC [M]  /root/px-fuse/pxd.o
  CC [M]  /root/px-fuse/dev.o
  CC [M]  /root/px-fuse/iov_iter.o
  CC [M]  /root/px-fuse/px_version.o
  CC [M]  /root/px-fuse/kiolib.o
  CC [M]  /root/px-fuse/pxd_bio_blkmq.o
  CC [M]  /root/px-fuse/pxd_fastpath.o
  LD [M]  /root/px-fuse/px.o
Kernel version 5.15 supports fastpath.
Kernel version 5.15 supports blkmq driver model.
  MODPOST /root/px-fuse/Module.symvers
  CC [M]  /root/px-fuse/px.mod.o
  LD [M]  /root/px-fuse/px.ko
  BTF [M] /root/px-fuse/px.ko
Skipping BTF generation for /root/px-fuse/px.ko due to unavailability of vmlinux
make[1]: Leaving directory '/usr/src/linux-headers-5.15.0-67-generic'
```
