### PR TITLE
declare blk_mq_queue_flag correctly

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1064,7 +1064,7 @@ static const struct blk_mq_ops pxd_mq_ops = {
 #endif /* __PX_BLKMQ__ */
 #endif /* __PXD_BIO_BLKMQ__ */
 
-static int pxd_init_disk(struct pxd_device *pxd_dev)
+static int pxd_init_disk(struct pxd_device *pxd_dev, unsigned int *blk_mq_queue_flag)
 {
 	struct gendisk *disk;
 	struct request_queue *q;
@@ -1414,6 +1414,7 @@ out_module:
 
 ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 {
+	unsigned int blk_mq_queue_flag = 0;
 	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
 	struct pxd_device *pxd_dev = find_pxd_device(ctx, dev_id);
 	int err = 0;
@@ -1435,7 +1436,7 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 		goto cleanup;
 	}
 
-	err = pxd_init_disk(pxd_dev);
+	err = pxd_init_disk(pxd_dev, &blk_mq_queue_flag);
 	if (err) {
 		module_put(THIS_MODULE);
 		goto cleanup;

--- a/test/pxd_fastpath_test.cc
+++ b/test/pxd_fastpath_test.cc
@@ -393,7 +393,7 @@ void PxdFastpathTest::dev_add_fastpath(pxd_add_out &add, int &minor, std::string
 	ssize_t write_bytes = writev(ctl_fd, iov, 2);
     if (write_bytes <= 0) {
         fprintf(stderr, "writev failed: errno=%d (%s)\n", errno, strerror(errno));
-        fprintf(stderr, "dev_id=%llu, size=%zu, ctl_fd=%d\n", 
+        fprintf(stderr, "dev_id=%lu, size=%zu, ctl_fd=%d\n", 
                 add.dev_id, add.size, ctl_fd);
     }
 	ASSERT_GT(write_bytes, 0);


### PR DESCRIPTION
**What this PR does / why we need it**:

Build and test fuse build against ubuntu 6.14, 6.18, 7.0.

**Build Outputs**

### Ubuntu 25 - 6.14.0-37-generic

```
make[1]: Entering directory '/usr/src/linux-headers-6.14.0-37-generic'
make[2]: Entering directory '/root/px-fuse'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: x86_64-linux-gnu-gcc-14 (Ubuntu 14.2.0-19ubuntu2) 14.2.0
  You are using:           gcc-14 (Ubuntu 14.2.0-19ubuntu2) 14.2.0
Kernel version 6.14 supports fastpath.
Kernel version 6.14 supports blkmq driver model.
  CC [M]  pxd.o
  CC [M]  dev.o
  CC [M]  iov_iter.o
  CC [M]  px_version.o
  CC [M]  kiolib.o
  CC [M]  pxd_bio_blkmq.o
  CC [M]  pxd_fastpath.o
  LD [M]  px.o
Kernel version 6.14 supports fastpath.
Kernel version 6.14 supports blkmq driver model.
  MODPOST Module.symvers
  CC [M]  px.mod.o
  CC [M]  .module-common.o
  LD [M]  px.ko
  BTF [M] px.ko
Skipping BTF generation for px.ko due to unavailability of vmlinux
make[2]: Leaving directory '/root/px-fuse'
make[1]: Leaving directory '/usr/src/linux-headers-6.14.0-37-generic'
```

### Ubuntu 26 - 7.0.0-15-generic

```
make[1]: Entering directory '/usr/src/linux-headers-7.0.0-15-generic'
make[2]: Entering directory '/root/px-fuse'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: x86_64-linux-gnu-gcc (Ubuntu 15.2.0-16ubuntu1) 15.2.0
  You are using:           gcc (Ubuntu 15.2.0-16ubuntu1) 15.2.0
warning: pahole version differs from the one used to build the kernel
  The kernel was built with: 131
  You are using:             0
Kernel version 7.0 supports fastpath.
Kernel version 7.0 supports blkmq driver model.
  CC [M]  pxd.o
  CC [M]  dev.o
  CC [M]  iov_iter.o
  CC [M]  px_version.o
  CC [M]  kiolib.o
  CC [M]  pxd_bio_blkmq.o
  CC [M]  pxd_fastpath.o
  LD [M]  px.o
Kernel version 7.0 supports fastpath.
Kernel version 7.0 supports blkmq driver model.
  MODPOST Module.symvers
WARNING: modpost: missing MODULE_DESCRIPTION() in px.o
  CC [M]  px.mod.o
  CC [M]  .module-common.o
  LD [M]  px.ko
  BTF [M] px.ko
Skipping BTF generation for px.ko due to unavailability of vmlinux
make[2]: Leaving directory '/root/px-fuse'
make[1]: Leaving directory '/usr/src/linux-headers-7.0.0-15-generic'
```

### CentOS 10 - 6.12.0-224.el10
```
make[1]: Entering directory '/usr/src/kernels/6.12.0-224.el10.x86_64'
Kernel version 6.12 supports fastpath.
Kernel version 6.12 supports blkmq driver model.
  CC [M]  /root/px-fuse/pxd.o
  CC [M]  /root/px-fuse/dev.o
  CC [M]  /root/px-fuse/iov_iter.o
  CC [M]  /root/px-fuse/px_version.o
  CC [M]  /root/px-fuse/kiolib.o
  CC [M]  /root/px-fuse/pxd_bio_blkmq.o
  CC [M]  /root/px-fuse/pxd_fastpath.o
  LD [M]  /root/px-fuse/px.o
Kernel version 6.12 supports fastpath.
Kernel version 6.12 supports blkmq driver model.
  MODPOST /root/px-fuse/Module.symvers
  CC [M]  /root/px-fuse/px.mod.o
  CC [M]  /root/px-fuse/.module-common.o
  LD [M]  /root/px-fuse/px.ko
  BTF [M] /root/px-fuse/px.ko
Skipping BTF generation for /root/px-fuse/px.ko due to unavailability of vmlinux
make[1]: Leaving directory '/usr/src/kernels/6.12.0-224.el10.x86_64'
```

### CentOS 10 - 7.0.3-1.el10.elrepo.x86_64

```
make[1]: Entering directory '/usr/src/kernels/7.0.3-1.el10.elrepo.x86_64'
make[2]: Entering directory '/root/px-fuse'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: gcc (GCC) 14.3.1 20250617 (Red Hat 14.3.1-2)
  You are using:           gcc (GCC) 14.3.1 20251022 (Red Hat 14.3.1-4)
warning: pahole version differs from the one used to build the kernel
  The kernel was built with: 130
  You are using:             0
Kernel version 7.0 supports fastpath.
Kernel version 7.0 supports blkmq driver model.
  CC [M]  pxd.o
  CC [M]  dev.o
  CC [M]  iov_iter.o
  CC [M]  px_version.o
  CC [M]  kiolib.o
  CC [M]  pxd_bio_blkmq.o
  CC [M]  pxd_fastpath.o
  LD [M]  px.o
Kernel version 7.0 supports fastpath.
Kernel version 7.0 supports blkmq driver model.
  MODPOST Module.symvers
WARNING: modpost: missing MODULE_DESCRIPTION() in px.o
  CC [M]  px.mod.o
  CC [M]  .module-common.o
  LD [M]  px.ko
  BTF [M] px.ko
Skipping BTF generation for px.ko due to unavailability of vmlinux
make[2]: Leaving directory '/root/px-fuse'
make[1]: Leaving directory '/usr/src/kernels/7.0.3-1.el10.elrepo.x86_64'
```


**Test Outputs**

### Ubuntu 26 - 7.0.0-15-generic
```
=== Fastpath Error Handling Test completed with loop device ===
TearDown
dev_remove_fastpath: device removing 100
cleaner thread active
initiating dev cleanup
device removal success
dev_remove_fastpath: device 100 removed after 0 secs
prepping to stop background cleaner
cleaner thread done
took 1 seconds to perform rmmod
backing devices cleared
[       OK ] BackingDeviceTypes/PxdFastpathTest.error_handling_fastpath/LoopDevice (7256 ms)
[----------] 14 tests from BackingDeviceTypes/PxdFastpathTest (45284 ms total)

[----------] Global test environment tear-down
[==========] 20 tests from 2 test suites ran. (131780 ms total)
[  PASSED  ] 20 tests.
```

The tests passed in other ubuntu kernels as well. 

### CentOS 10 - 6.12.0-224.el10

```
I/O operations work after recovery
=== Fastpath Error Handling Test completed with loop device ===
TearDown
dev_remove_fastpath: device removing 100
cleaner thread active
initiating dev cleanup
device removal success
dev_remove_fastpath: device 100 removed after 0 secs
prepping to stop background cleaner
cleaner thread done
took 1 seconds to perform rmmod
backing devices cleared
[       OK ] BackingDeviceTypes/PxdFastpathTest.error_handling_fastpath/LoopDevice (7315 ms)
[----------] 14 tests from BackingDeviceTypes/PxdFastpathTest (45980 ms total)

[----------] Global test environment tear-down
[==========] 20 tests from 2 test suites ran. (132928 ms total)
[  PASSED  ] 20 tests.
```


