### PR TITLE
Apply 3.7.0 changes to main

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1213,7 +1213,6 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, unsigned int *blk_mq_queue_
 	if (pxd_dev->discard_size > 0) {
 		DISCARD_ENABLE(q);
 	}
-	
 
     q->limits.discard_granularity = PXD_MAX_DISCARD_GRANULARITY;
     q->limits.discard_alignment = PXD_MAX_DISCARD_GRANULARITY;
@@ -1234,7 +1233,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, unsigned int *blk_mq_queue_
 	pxd_dev->disk = disk;
 
 #if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || defined(__BLK_Q_FREEZE_WITH_MEMFLAG__) || (LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) && defined(__SUSE_GTE_16_0__))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || defined(__BLK_Q_FREEZE_WITH_MEMFLAG__) || (LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) && defined(CONFIG_SUSE_VERSION) && (CONFIG_SUSE_VERSION >= 16))
 	*blk_mq_queue_flag = blk_mq_freeze_queue(q);
 #else
 	blk_mq_freeze_queue(q);
@@ -1404,7 +1403,7 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 out_fp:
 	pxd_fastpath_cleanup(pxd_dev);
 out_id:
-	ida_remove(&pxd_minor_ida, new_minor);
+	pxd_ida_remove(&pxd_minor_ida, new_minor);
 out_module:
 	if (pxd_dev)
 		kfree(pxd_dev);
@@ -1468,7 +1467,7 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 	pxd_dev->exported = true;
 	spin_unlock(&pxd_dev->lock);
 #if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || defined(__BLK_Q_FREEZE_WITH_MEMFLAG__) || (LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) && defined(__SUSE_GTE_16_0__))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || defined(__BLK_Q_FREEZE_WITH_MEMFLAG__) || (LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) && defined(CONFIG_SUSE_VERSION) && (CONFIG_SUSE_VERSION >= 16))
 	blk_mq_unfreeze_queue(pxd_dev->disk->queue, blk_mq_queue_flag);
 #else
 	blk_mq_unfreeze_queue(pxd_dev->disk->queue);
@@ -1481,7 +1480,7 @@ cleanup:
     list_del(&pxd_dev->node);
     --ctx->num_devices;
 	pxd_dev->exported = false;
-	ida_remove(&pxd_minor_ida, pxd_dev->minor);
+	pxd_ida_remove(&pxd_minor_ida, pxd_dev->minor);
     spin_unlock(&pxd_dev->lock);
     spin_unlock(&ctx->lock);
 	kfree(pxd_dev);
@@ -1504,19 +1503,8 @@ static void pxd_finish_remove(struct work_struct *work)
 
 		mutex_unlock(&pxd_dev->disk->queue->sysfs_lock);
 #else
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,25) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && ((defined(__EL8__) && !defined(QUEUE_FLAG_DEAD)) || defined(__SUSE_HAS_NO_PART_SCAN__)))
-	// del_gendisk will try to fsync device
-	// so freeze queue and then *mark queue dead* to ensure no new reqs
-	// gets accepted.
-    blk_freeze_queue_start(pxd_dev->disk->queue);
-    blk_mark_disk_dead(pxd_dev->disk);
-#elif LINUX_VERSION_CODE < KERNEL_VERSION(5,13,0)
-	// del_gendisk will not submit any new IO.
-	// so freeze queue and then queue dying, to ensure no new reqs
-	// gets accepted.
-    blk_freeze_queue_start(pxd_dev->disk->queue);
-    blk_set_queue_dying(pxd_dev->disk->queue);
-#endif
+	blk_freeze_queue_start(pxd_dev->disk->queue);
+	pxd_mark_device_dead(pxd_dev);
 	// kernel bug here, disk deletion code, fsync IO, checking for disk dead while queue is marked dying,
 	// which will never happen, and the disk deletion code is stuck in deadlock.
 	// in this case, allow IOs to go to the queue and let px-storage handle IO
@@ -2340,7 +2328,7 @@ static void pxd_dev_device_release(struct device *dev)
 	struct pxd_device *pxd_dev = dev_to_pxd_dev(dev);
 
 	pxd_free_disk(pxd_dev);
-	ida_remove(&pxd_minor_ida, pxd_dev->minor);
+	pxd_ida_remove(&pxd_minor_ida, pxd_dev->minor);
 	pxd_mem_printk("freeing dev %llu pxd device %px\n", pxd_dev->dev_id, pxd_dev);
 	pxd_dev->magic = PXD_POISON;
 	kfree(pxd_dev);

--- a/pxd.c
+++ b/pxd.c
@@ -1099,47 +1099,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, unsigned int *blk_mq_queue_
 	  }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
-#ifdef __ELREPO9__
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,9,0)
-	  disk = blk_mq_alloc_disk(&pxd_dev->tag_set, pxd_dev);
-#endif
-#elif defined(RHEL_RELEASE_CODE)
-#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 6)
-	  struct queue_limits lim = {
-		  .logical_block_size = PXD_LBS,
-		  .physical_block_size = PXD_LBS,
-		  .max_segment_size = SEGMENT_SIZE,
-		  .max_segments = PXD_MAX_IO / PXD_LBS,
-		  .max_hw_sectors = PXD_MAX_IO / SECTOR_SIZE,
-		  .discard_alignment = PXD_MAX_DISCARD_GRANULARITY,
-		  .discard_granularity = PXD_MAX_DISCARD_GRANULARITY,
-		  .io_min = PXD_LBS,
-		  .io_opt = PXD_LBS,
-		  .max_hw_discard_sectors = pxd_dev->discard_size / SECTOR_SIZE,
-		  .max_discard_sectors = pxd_dev->discard_size / SECTOR_SIZE
-	  };
-	  disk = blk_mq_alloc_disk(&pxd_dev->tag_set, &lim, pxd_dev);
-#else
-	  disk = blk_mq_alloc_disk(&pxd_dev->tag_set, pxd_dev);
-#endif
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0) || ((LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__)) && !defined(__ORACLE_UEK__))
-	  struct queue_limits lim = {
-		  .logical_block_size = PXD_LBS,
-		  .physical_block_size = PXD_LBS,
-		  .max_segment_size = SEGMENT_SIZE,
-		  .max_segments = PXD_MAX_IO / PXD_LBS,
-		  .max_hw_sectors = PXD_MAX_IO / SECTOR_SIZE,
-		  .discard_alignment = PXD_MAX_DISCARD_GRANULARITY,
-		  .discard_granularity = PXD_MAX_DISCARD_GRANULARITY,
-		  .io_min = PXD_LBS,
-		  .io_opt = PXD_LBS,
-		  .max_hw_discard_sectors = pxd_dev->discard_size / SECTOR_SIZE,
-		  .max_discard_sectors = pxd_dev->discard_size / SECTOR_SIZE
-	  };
-	  disk = blk_mq_alloc_disk(&pxd_dev->tag_set, &lim, pxd_dev);
-#else
-	  disk = blk_mq_alloc_disk(&pxd_dev->tag_set, pxd_dev);
-#endif
+	  disk = pxd_alloc_disk(pxd_dev);
 
 	  if (IS_ERR(disk)) {
 		blk_mq_free_tag_set(&pxd_dev->tag_set);
@@ -1232,13 +1192,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, unsigned int *blk_mq_queue_
 	q->queuedata = pxd_dev;
 	pxd_dev->disk = disk;
 
-#if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || defined(__BLK_Q_FREEZE_WITH_MEMFLAG__) || (LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) && defined(CONFIG_SUSE_VERSION) && (CONFIG_SUSE_VERSION >= 16))
-	*blk_mq_queue_flag = blk_mq_freeze_queue(q);
-#else
-	blk_mq_freeze_queue(q);
-#endif
-#endif
+	pxd_freeze_queue(q, blk_mq_queue_flag);
 
 	return 0;
 }
@@ -1466,13 +1420,9 @@ ssize_t pxd_export(struct fuse_conn *fc, uint64_t dev_id)
 	spin_lock(&pxd_dev->lock);
 	pxd_dev->exported = true;
 	spin_unlock(&pxd_dev->lock);
-#if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || defined(__BLK_Q_FREEZE_WITH_MEMFLAG__) || (LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) && defined(CONFIG_SUSE_VERSION) && (CONFIG_SUSE_VERSION >= 16))
-	blk_mq_unfreeze_queue(pxd_dev->disk->queue, blk_mq_queue_flag);
-#else
-	blk_mq_unfreeze_queue(pxd_dev->disk->queue);
-#endif
-#endif
+
+	pxd_unfreeze_queue(pxd_dev, &blk_mq_queue_flag);
+
 	return 0;
 cleanup:
     spin_lock(&ctx->lock);
@@ -1635,21 +1585,19 @@ ssize_t pxd_ioc_update_size(struct fuse_conn *fc, struct pxd_update_size *update
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
 	set_capacity(pxd_dev->disk, update_size->size / SECTOR_SIZE);
-#else
-	// set_capacity is sufficient for modifying disk size from 5.11 onwards
-	set_capacity_and_notify(pxd_dev->disk, update_size->size / SECTOR_SIZE);
-#endif
 	pxd_dev->size = update_size->size;
 	spin_unlock(&pxd_dev->lock);
-
 	// set_capacity is sufficient for modifying disk size from 5.11 onwards
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0) || (defined(__EL8__) && defined(GD_READ_ONLY))
+	#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0) || (defined(__EL8__) && defined(GD_READ_ONLY))
 	revalidate_disk_size(pxd_dev->disk, true);
-#else
+	#else
 	err = revalidate_disk(pxd_dev->disk);
 	BUG_ON(err);
-#endif
+	#endif
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0)
+	pxd_dev->size = update_size->size;
+	spin_unlock(&pxd_dev->lock);
+	set_capacity_and_notify(pxd_dev->disk, update_size->size / SECTOR_SIZE);
 #endif
 	put_device(&pxd_dev->dev);
 
@@ -2075,12 +2023,12 @@ static char* __strtok_r(char *src, const char delim, char **saveptr) {
 
 static void __strip_nl(const char *src, char *dst, int maxlen) {
 	char *tmp;
-	int len=strlen(src);
-
-
+	int len;
 	if (!src || !dst) {
 		return;
 	}
+
+	len = strlen(src);
 
 	dst[0] = '\0';
 	if (!len) {

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -267,7 +267,7 @@ static inline int ida_get(struct ida *ida, unsigned int min, unsigned int max, g
 	#endif
 }
 
-static inline void ida_remove(struct ida *ida, unsigned int id)
+static inline void pxd_ida_remove(struct ida *ida, unsigned int id)
 {
 	#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,18,0)
 	ida_free(ida, id);

--- a/pxd_compat.h
+++ b/pxd_compat.h
@@ -276,4 +276,104 @@ static inline void pxd_ida_remove(struct ida *ida, unsigned int id)
 	#endif
 }
 
+#ifdef __PX_BLKMQ__
+#include <linux/blk-mq.h>
+#include "pxd_core.h"
+
+static inline struct gendisk *pxd_alloc_disk(struct pxd_device *pxd_dev)
+{
+	struct gendisk *disk;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
+#ifdef __ELREPO9__
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,9,0)
+	disk = blk_mq_alloc_disk(&pxd_dev->tag_set, pxd_dev);
+#else
+	unsigned int wz_sectors = (pxd_has_cap(pxd_dev, PXD_DEV_CAP_WRITE_ZEROES) && !fastpath_enabled(pxd_dev)) ?
+	                          (pxd_dev->discard_size / SECTOR_SIZE) : 0;
+	struct queue_limits lim = {
+		.logical_block_size = PXD_LBS,
+		.physical_block_size = PXD_LBS,
+		.max_segment_size = SEGMENT_SIZE,
+		.max_segments = PXD_MAX_IO / PXD_LBS,
+		.max_hw_sectors = PXD_MAX_IO / SECTOR_SIZE,
+		.discard_alignment = pxd_dev->discard_granularity,
+		.discard_granularity = pxd_dev->discard_granularity,
+		.io_min = PXD_LBS,
+		.io_opt = PXD_LBS,
+		.max_hw_discard_sectors = pxd_dev->discard_size / SECTOR_SIZE,
+		.max_discard_sectors = pxd_dev->discard_size / SECTOR_SIZE,
+		.max_write_zeroes_sectors = wz_sectors
+	};
+	disk = blk_mq_alloc_disk(&pxd_dev->tag_set, &lim, pxd_dev);
+#endif
+#elif defined(RHEL_RELEASE_CODE)
+#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 6)
+	unsigned int wz_sectors = (pxd_has_cap(pxd_dev, PXD_DEV_CAP_WRITE_ZEROES) && !fastpath_enabled(pxd_dev)) ?
+	                          (pxd_dev->discard_size / SECTOR_SIZE) : 0;
+	struct queue_limits lim = {
+		.logical_block_size = PXD_LBS,
+		.physical_block_size = PXD_LBS,
+		.max_segment_size = SEGMENT_SIZE,
+		.max_segments = PXD_MAX_IO / PXD_LBS,
+		.max_hw_sectors = PXD_MAX_IO / SECTOR_SIZE,
+		.discard_alignment = pxd_dev->discard_granularity,
+		.discard_granularity = pxd_dev->discard_granularity,
+		.io_min = PXD_LBS,
+		.io_opt = PXD_LBS,
+		.max_hw_discard_sectors = pxd_dev->discard_size / SECTOR_SIZE,
+		.max_discard_sectors = pxd_dev->discard_size / SECTOR_SIZE,
+		.max_write_zeroes_sectors = wz_sectors
+	};
+	disk = blk_mq_alloc_disk(&pxd_dev->tag_set, &lim, pxd_dev);
+#else
+	disk = blk_mq_alloc_disk(&pxd_dev->tag_set, pxd_dev);
+#endif
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0) || ((LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__)) && !defined(__ORACLE_UEK__))
+	unsigned int wz_sectors = (pxd_has_cap(pxd_dev, PXD_DEV_CAP_WRITE_ZEROES) && !fastpath_enabled(pxd_dev)) ?
+	                          (pxd_dev->discard_size / SECTOR_SIZE) : 0;
+	struct queue_limits lim = {
+		.logical_block_size = PXD_LBS,
+		.physical_block_size = PXD_LBS,
+		.max_segment_size = SEGMENT_SIZE,
+		.max_segments = PXD_MAX_IO / PXD_LBS,
+		.max_hw_sectors = PXD_MAX_IO / SECTOR_SIZE,
+		.discard_alignment = pxd_dev->discard_granularity,
+		.discard_granularity = pxd_dev->discard_granularity,
+		.io_min = PXD_LBS,
+		.io_opt = PXD_LBS,
+		.max_hw_discard_sectors = pxd_dev->discard_size / SECTOR_SIZE,
+		.max_discard_sectors = pxd_dev->discard_size / SECTOR_SIZE,
+		.max_write_zeroes_sectors = wz_sectors
+	};
+	disk = blk_mq_alloc_disk(&pxd_dev->tag_set, &lim, pxd_dev);
+#else
+	disk = blk_mq_alloc_disk(&pxd_dev->tag_set, pxd_dev);
+#endif
+#endif
+	return disk;
+}
+
+static inline void pxd_freeze_queue(struct request_queue *q, unsigned int *blk_mq_queue_flag) {
+#if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || defined(__BLK_Q_FREEZE_WITH_MEMFLAG__) || (LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) && defined(CONFIG_SUSE_VERSION))
+	*blk_mq_queue_flag = blk_mq_freeze_queue(q);
+#else
+	blk_mq_freeze_queue(q);
+#endif
+#endif
+}
+
+static inline void pxd_unfreeze_queue(struct pxd_device *pxd_dev, unsigned int *blk_mq_queue_flag) {
+#if defined __PX_BLKMQ__ && !defined __PXD_BIO_MAKEREQ__
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || defined(__BLK_Q_FREEZE_WITH_MEMFLAG__) || (LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) && defined(CONFIG_SUSE_VERSION))
+	blk_mq_unfreeze_queue(pxd_dev->disk->queue, *blk_mq_queue_flag);
+#else
+	blk_mq_unfreeze_queue(pxd_dev->disk->queue);
+#endif
+#endif
+}
+
+#endif /* __PX_BLKMQ__ */
+
 #endif //GDFS_PXD_COMPAT_H

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -73,6 +73,22 @@ struct pxd_device {
 #endif
 };
 
+static inline void pxd_mark_device_dead(struct pxd_device *pxd_dev)
+{
+	#if (((LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,25) && LINUX_VERSION_CODE <  KERNEL_VERSION(5,16,0))) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,16,11))) || \
+			(LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && ((defined(__EL8__) && !defined(QUEUE_FLAG_DEAD)) || defined(__SUSE_HAS_NO_PART_SCAN__)))
+		// del_gendisk will try to fsync device
+		// so freeze queue and then *mark queue dead* to ensure no new reqs
+		// gets accepted.
+		blk_mark_disk_dead(pxd_dev->disk);
+	#elif LINUX_VERSION_CODE < KERNEL_VERSION(5,13,0)
+		// del_gendisk will not submit any new IO.
+		// so freeze queue and then queue dying, to ensure no new reqs
+		// gets accepted.
+		blk_set_queue_dying(pxd_dev->disk->queue);
+	#endif
+}
+
 // how pxd_device got registered with the kernel during device add.
 static inline
 bool fastpath_enabled(struct pxd_device *pxd_dev) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Apply latest spinlock and compatibility changes in fuse 3.7.0 to main.

**Which issue(s) this PR fixes** (optional)
Closes #
PWX-43353


**Build Output**
```
Kernel version 5.15 supports fastpath.
Kernel version 5.15 supports blkmq driver model.
make  -C /usr/src/linux-headers-5.15.0-67-generic  M=/root/px-fuse modules
make[1]: Entering directory '/usr/src/linux-headers-5.15.0-67-generic'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
  You are using:           gcc (GCC) 12.2.0
Kernel version 5.15 supports fastpath.
Kernel version 5.15 supports blkmq driver model.
  CC [M]  /root/px-fuse/pxd.o
  CC [M]  /root/px-fuse/dev.o
  CC [M]  /root/px-fuse/iov_iter.o
  CC [M]  /root/px-fuse/px_version.o
  CC [M]  /root/px-fuse/kiolib.o
  CC [M]  /root/px-fuse/pxd_bio_blkmq.o
  CC [M]  /root/px-fuse/pxd_fastpath.o
  LD [M]  /root/px-fuse/px.o
Kernel version 5.15 supports fastpath.
Kernel version 5.15 supports blkmq driver model.
  MODPOST /root/px-fuse/Module.symvers
  CC [M]  /root/px-fuse/px.mod.o
  LD [M]  /root/px-fuse/px.ko
  BTF [M] /root/px-fuse/px.ko
Skipping BTF generation for /root/px-fuse/px.ko due to unavailability of vmlinux
make[1]: Leaving directory '/usr/src/linux-headers-5.15.0-67-generic'
Kernel version 5.15 supports fastpath.
Kernel version 5.15 supports blkmq driver model.
```

**Test Output**

```
TearDown
dev_remove_fastpath: device removing 100
cleaner thread active
initiating dev cleanup
device removal success
dev_remove_fastpath: device 100 removed after 0 secs
prepping to stop background cleaner
cleaner thread done
took 1 seconds to perform rmmod
backing devices cleared
[       OK ] BackingDeviceTypes/PxdFastpathTest.error_handling_fastpath/LoopDevice (7378 ms)
[----------] 14 tests from BackingDeviceTypes/PxdFastpathTest (46283 ms total)

[----------] Global test environment tear-down
[==========] 20 tests from 2 test suites ran. (133241 ms total)
[  PASSED  ] 20 tests.
```
