### PR TITLE
PWX-45369: WriteZero FUSE Changes (Cherry-Pick PR) (#444)

### DIFF
--- a/fuse_i.h
+++ b/fuse_i.h
@@ -351,7 +351,7 @@ struct fuse_conn *fuse_conn_get(struct fuse_conn *fc);
 void fuse_restart_requests(struct fuse_conn *fc);
 void fuse_convert_zero_writes(struct fuse_req *req);
 
-ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add);
+ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_v2_out *add);
 ssize_t pxd_remove(struct fuse_conn *fc, struct pxd_remove_out *remove);
 ssize_t pxd_update_size(struct fuse_conn *fc, struct pxd_update_size *update_size);
 ssize_t pxd_ioc_update_size(struct fuse_conn *fc, struct pxd_update_size *update_size);

--- a/pxd.c
+++ b/pxd.c
@@ -565,31 +565,9 @@ static void pxd_req_misc(struct fuse_req *req, uint32_t size, uint64_t off,
 #endif
 }
 
-/*
- * when block device is registered in non blk mq mode, device limits are not
- * honoured. Handle it appropriately.
- */
-static inline
-int pxd_handle_device_limits(struct fuse_req *req, uint32_t *size, uint64_t *off,
-		unsigned int op)
-{
-	return 0;
-}
-
 static int pxd_read_request(struct fuse_req *req, uint32_t size, uint64_t off,
 			uint32_t minor, uint32_t flags)
 {
-	int rc;
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) || defined(REQ_PREFLUSH)
-    rc = pxd_handle_device_limits(req, &size, &off, REQ_OP_READ);
-#else
-    rc = pxd_handle_device_limits(req, &size, &off, 0);
-#endif
-	if (rc) {
-		return rc;
-	}
-
 	req->in.h.opcode = PXD_READ;
 	req->end = pxd_process_read_reply_q;
 	pxd_req_misc(req, size, off, minor, flags);
@@ -599,17 +577,6 @@ static int pxd_read_request(struct fuse_req *req, uint32_t size, uint64_t off,
 static int pxd_write_request(struct fuse_req *req, uint32_t size, uint64_t off,
 			uint32_t minor, uint32_t flags)
 {
-	int rc;
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) || defined(REQ_PREFLUSH)
-    rc = pxd_handle_device_limits(req, &size, &off, REQ_OP_WRITE);
-#else
-    rc = pxd_handle_device_limits(req, &size, &off, REQ_WRITE);
-#endif
-	if (rc) {
-		return rc;
-	}
-
 	req->in.h.opcode = PXD_WRITE;
 	req->end = pxd_process_write_reply_q;
 
@@ -624,17 +591,6 @@ static int pxd_write_request(struct fuse_req *req, uint32_t size, uint64_t off,
 static int pxd_discard_request(struct fuse_req *req, uint32_t size, uint64_t off,
 			uint32_t minor, uint32_t flags)
 {
-	int rc;
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) || defined(REQ_PREFLUSH)
-	rc = pxd_handle_device_limits(req, &size, &off, REQ_OP_DISCARD);
-#else
-	rc = pxd_handle_device_limits(req, &size, &off, REQ_DISCARD);
-#endif
-	if (rc) {
-		return rc;
-	}
-
 	req->in.h.opcode = PXD_DISCARD;
 	req->end = pxd_process_write_reply_q;
 
@@ -642,27 +598,17 @@ static int pxd_discard_request(struct fuse_req *req, uint32_t size, uint64_t off
 	return 0;
 }
 
-static int pxd_write_same_request(struct fuse_req *req, uint32_t size, uint64_t off,
-			uint32_t minor, uint32_t flags)
+static int pxd_write_zeroes_request(struct fuse_req *req, uint32_t size, uint64_t off,
+                                   uint32_t minor, uint32_t flags)
 {
-	int rc;
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && (defined(__EL8__) || defined(__SUSE_EQ_SP5__)))
-	rc = pxd_handle_device_limits(req, &size, &off, REQ_OP_WRITE_ZEROES);
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) || defined(REQ_PREFLUSH)
-	rc = pxd_handle_device_limits(req, &size, &off, REQ_OP_WRITE_SAME);
+    req->in.h.opcode = PXD_WRITE_ZEROES;
+#ifdef __PXD_BIO_MAKEREQ__
+    req->end = pxd_process_write_reply;
 #else
-	rc = pxd_handle_device_limits(req, &size, &off, REQ_WRITE_SAME);
+    req->end = pxd_process_write_reply_q;
 #endif
-	if (rc) {
-		return rc;
-	}
-
-	req->in.h.opcode = PXD_WRITE_SAME;
-	req->end = pxd_process_write_reply_q;
-
-	pxd_req_misc(req, size, off, minor, flags);
-	return 0;
+    pxd_req_misc(req, size, off, minor, flags);
+    return 0;
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) || defined(REQ_PREFLUSH)
@@ -670,14 +616,9 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 			uint32_t minor, uint32_t op, uint32_t flags)
 {
 	int rc;
-
 	switch (op) {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && (defined(__EL8__) || defined(__SUSE_EQ_SP5__)))
 	case REQ_OP_WRITE_ZEROES:
-#else
-	case REQ_OP_WRITE_SAME:
-#endif
-		rc = pxd_write_same_request(req, size, off, minor, flags);
+		rc = pxd_write_zeroes_request(req, size, off, minor, flags);
 		break;
 	case REQ_OP_WRITE:
 		rc = pxd_write_request(req, size, off, minor, flags);
@@ -708,14 +649,9 @@ static int pxd_request(struct fuse_req *req, uint32_t size, uint64_t off,
 {
 	int rc;
 
-	switch (flags & (REQ_WRITE | REQ_DISCARD | REQ_WRITE_SAME)) {
+	switch (flags & (REQ_WRITE | REQ_DISCARD)) {
 	case REQ_WRITE:
-		/* FALLTHROUGH */
-	case (REQ_WRITE | REQ_WRITE_SAME):
-		if (flags & REQ_WRITE_SAME)
-			rc = pxd_write_same_request(req, size, off, minor, flags);
-		else
-			rc = pxd_write_request(req, size, off, minor, flags);
+		rc = pxd_write_request(req, size, off, minor, flags);
 		break;
 	case 0:
 		rc = pxd_read_request(req, size, off, minor, flags);
@@ -1169,20 +1105,45 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, unsigned int *blk_mq_queue_
 	blk_queue_logical_block_size(q, PXD_LBS);
 	blk_queue_physical_block_size(q, PXD_LBS);
 #endif
+// Control write_zeroes for kernels that don't use queue_limits API
+// (queue_limits API sets max_write_zeroes_sectors during disk allocation above)
+// Note: __EL8__ is defined for both EL8 and EL9 (see Makefile), so we need
+// explicit RHEL_RELEASE_CODE checks for RHEL 9.x which uses OLD API for < 9.6
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
+#ifdef RHEL_RELEASE_CODE
+#if RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(9, 6)
+	// RHEL < 9.6: set write_zeroes via blk_queue API (not queue_limits)
+	// WriteZero: enable only if capability is set AND fastpath is NOT enabled
+	if (pxd_has_cap(pxd_dev, PXD_DEV_CAP_WRITE_ZEROES) && !fastpath_enabled(pxd_dev)) {
+		blk_queue_max_write_zeroes_sectors(q, pxd_dev->discard_size / SECTOR_SIZE);
+	} else {
+		blk_queue_max_write_zeroes_sectors(q, 0);
+	}
+#endif
+#elif !(LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && defined(__EL8__)))
+	// Non-RHEL kernels that don't use queue_limits API
+	// WriteZero: enable only if capability is set AND fastpath is NOT enabled
+	if (pxd_has_cap(pxd_dev, PXD_DEV_CAP_WRITE_ZEROES) && !fastpath_enabled(pxd_dev)) {
+		blk_queue_max_write_zeroes_sectors(q, pxd_dev->discard_size / SECTOR_SIZE);
+	} else {
+		blk_queue_max_write_zeroes_sectors(q, 0);
+	}
+#endif
+#endif
 
 	if (pxd_dev->discard_size > 0) {
 		DISCARD_ENABLE(q);
 	}
 
-    q->limits.discard_granularity = PXD_MAX_DISCARD_GRANULARITY;
-    q->limits.discard_alignment = PXD_MAX_DISCARD_GRANULARITY;
+    q->limits.discard_granularity = pxd_dev->discard_granularity;
+    q->limits.discard_alignment = pxd_dev->discard_granularity;
     q->limits.max_discard_sectors = pxd_dev->discard_size / SECTOR_SIZE;
 
-    // given unaligned discards are ignored at replica targets, it cannot be guaranteed zeroes after discard
+    // given unaligned discards are ignored at targets, it cannot be guaranteed zeroes after discard
     // so never commit to zeroes being returned after a discard.
     // this flag and behavior got deprecated
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0)
-    q->limits.discard_zeroes_data = 0;
+	q->limits.discard_zeroes_data = 0;
 #endif
 
 	/* Enable flush support. */
@@ -1248,7 +1209,7 @@ struct pxd_device* find_pxd_device(struct pxd_context *ctx, uint64_t dev_id)
 }
 
 static int __pxd_update_path(struct pxd_device *pxd_dev, struct pxd_update_path_out *update_path);
-ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
+ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_v2_out *add)
 {
 	struct pxd_context *ctx = container_of(fc, struct pxd_context, fc);
 	struct pxd_device *pxd_dev = NULL;
@@ -1270,6 +1231,7 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 		} else {
 			disableFastPath(pxd_dev, false);
 		}
+
 		return pxd_dev->minor | (fastpath_active(pxd_dev) << MINORBITS);
 	}
 
@@ -1318,15 +1280,26 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_ext_out *add)
 		pxd_dev->queue_depth = add->queue_depth;
 	}
 
+	// Store discard_granularity: use specified value or default
+	if (add->discard_granularity > 0) {
+		pxd_dev->discard_granularity = add->discard_granularity;
+	} else {
+		pxd_dev->discard_granularity = PXD_MAX_DISCARD_GRANULARITY;
+	}
+
 	if (add->discard_size == 0) {
 		pxd_dev->discard_size = 0; // disabled
-	} else if (add->discard_size <= PXD_MAX_DISCARD_GRANULARITY)
-		pxd_dev->discard_size = PXD_MAX_DISCARD_GRANULARITY; // unaligned make it minimum aligned
+	} else if (add->discard_size <= pxd_dev->discard_granularity)
+		pxd_dev->discard_size = pxd_dev->discard_granularity; // unaligned make it minimum aligned
 	else
-		pxd_dev->discard_size = ALIGN(add->discard_size, PXD_MAX_DISCARD_GRANULARITY); // aligned
+		pxd_dev->discard_size = ALIGN(add->discard_size, pxd_dev->discard_granularity); // aligned
 
-	printk(KERN_INFO"Device %llu added %px with mode %#x fastpath %d npath %lu (discard size: %u)\n",
-			add->dev_id, pxd_dev, add->open_mode, add->enable_fp, add->paths.count, pxd_dev->discard_size);
+	// Store device capabilities
+	pxd_dev->capabilities = add->capabilities;
+
+	printk(KERN_INFO"Device %llu added %px with mode %#x fastpath %d npath %lu (discard size: %u, discard_granularity: %u, capabilities: 0x%x)\n",
+			add->dev_id, pxd_dev, add->open_mode, add->enable_fp, add->paths.count, pxd_dev->discard_size,
+			pxd_dev->discard_granularity, pxd_dev->capabilities);
 
 	// initializes fastpath context part of pxd_dev
 	err = pxd_fastpath_init(pxd_dev);

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -48,6 +48,8 @@ struct pxd_device {
 	bool fastpath; // this is persistent, how the block device registered with kernel
 	unsigned int queue_depth; // sysfs attribute bdev io queue depth
 	unsigned int discard_size;
+	unsigned int discard_granularity; // discard granularity in bytes
+	unsigned int capabilities;  // Capability flags (PXD_CAP_*)
 
 #define PXD_ACTIVE(pxd_dev)  (atomic_read(&pxd_dev->ncount))
 	// [global] total active requests
@@ -99,6 +101,12 @@ bool fastpath_enabled(struct pxd_device *pxd_dev) {
 static inline
 bool fastpath_active(struct pxd_device *pxd_dev) {
 	return pxd_dev->fp.fastpath;
+}
+
+// Check if device has a specific capability
+static inline
+bool pxd_has_cap(struct pxd_device *pxd_dev, unsigned int cap) {
+	return (pxd_dev->capabilities & cap) != 0;
 }
 
 void pxd_check_q_congested(struct pxd_device *pxd_dev);

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -93,7 +93,6 @@ int pxd_device_congested(void *, int);
 // return the io count processed by a thread
 int get_thread_count(int id);
 
-void pxd_fastpath_adjust_limits(struct pxd_device *pxd_dev, struct request_queue *topque);
 int pxd_suspend_state(struct pxd_device *pxd_dev);
 int pxd_debug_switch_fastpath(struct pxd_device*);
 int pxd_debug_switch_nativepath(struct pxd_device*);


### PR DESCRIPTION
* PWX-45369 support writezero opcode to support discard on writezero (#366)

* PWX-45369 use discard_size instead of discard_granularity for max_write_zeroes_sectors (#427)


Cherry-pick from main.

---------

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

