### PR TITLE
PWX-49986: Driver failover on PX down

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -693,21 +693,19 @@ bool pxd_process_ioswitch_complete(struct fuse_conn *fc, struct fuse_req *req,
 	trace_pxd_ioswitch_complete(pxd_dev->dev_id, pxd_dev->minor, req->in.h.opcode);
 
 	if (req->in.h.opcode == PXD_FAILOVER_TO_USERSPACE) {
-		// if the status is successful, then reissue IO to userspace
-		// else fail IO to complete.
-		disableFastPath(pxd_dev, true);
-
+		// Splice failQ and clear active_failover atomically: avoids the
+		// orphan race where a late add lands on failQ after the splice
+		// but before the gate clears.
 		spin_lock_irqsave(&pxd_dev->fp.fail_lock, flags);
 		list_splice(&pxd_dev->fp.failQ, &ios);
 		INIT_LIST_HEAD(&pxd_dev->fp.failQ);
-		pxd_dev->fp.active_failover = false;
+		smp_store_release(&pxd_dev->fp.active_failover, false);
 		spin_unlock_irqrestore(&pxd_dev->fp.fail_lock, flags);
 	}
 
-	// reopen the suspended device
 	pxd_request_resume_internal(pxd_dev);
 
-	// reissue any failed IOs from local list
+	// status=0 -> reroute to slowpath; non-zero -> -EIO. No-op for FALLBACK.
 	pxd_reissuefailQ(pxd_dev, &ios, status);
 
 	return true;
@@ -754,19 +752,36 @@ int pxd_initiate_failover(struct pxd_device *pxd_dev)
 {
 	int rc;
 
-	if (!fastpath_active(pxd_dev)) {
-		// already in native path
-		return -EINVAL;
+	// Failover already in progress - second and later callers no-op.
+	if (READ_ONCE(pxd_dev->fp.active_failover)) {
+		return 0;
 	}
 
-	// Check if device is detached/removed - early exit
+	// Device already in native (orphan case from pxd_io_failover, or a
+	// State B caller). Splice any pending failQ entries and reissue
+	// them on the slowpath locally - no marker round-trip needed since
+	// the device is already in the target state. Return 0 (idempotent
+	// success) rather than -EINVAL so PX-storage and pxd_io_failover
+	// see "already converged" without treating it as an error.
+	if (!fastpath_active(pxd_dev)) {
+		struct list_head ios;
+		unsigned long flags;
+		INIT_LIST_HEAD(&ios);
+		spin_lock_irqsave(&pxd_dev->fp.fail_lock, flags);
+		list_splice_init(&pxd_dev->fp.failQ, &ios);
+		spin_unlock_irqrestore(&pxd_dev->fp.fail_lock, flags);
+		pxd_reissuefailQ(pxd_dev, &ios, 0);
+		return 0;
+	}
+
 	if (pxd_dev->removing || !pxd_dev->exported) {
 		printk(KERN_WARNING "device %llu failover failed: device detached\n", pxd_dev->dev_id);
 		return -ENODEV;
 	}
 
+	// Single-thread gate: only the cmpxchg winner proceeds.
 	if (atomic_cmpxchg(&pxd_dev->fp.ioswitch_active, 0, 1) != 0) {
-		return 0; // already initiated, skip it.
+		return 0;
 	}
 
 	rc = pxd_request_suspend_internal(pxd_dev, false, true);
@@ -777,10 +792,23 @@ int pxd_initiate_failover(struct pxd_device *pxd_dev)
 
 	rc = pxd_initiate_ioswitch(pxd_dev, PXD_FAILOVER_TO_USERSPACE);
 	if (rc) {
-		pxd_request_resume(pxd_dev);
+		// _internal pairs with pxd_request_suspend_internal above;
+		// pxd_request_resume() would no-op (app_suspend was never set)
+		// and leak the blk_mq_quiesce.
+		pxd_request_resume_internal(pxd_dev);
 		atomic_set(&pxd_dev->fp.ioswitch_active, 0);
+		return rc;
 	}
-	return rc;
+
+	// Canonical setter. Cleared in pxd_process_ioswitch_complete under
+	// fail_lock together with the failQ splice (atomic flip with drain).
+	smp_store_release(&pxd_dev->fp.active_failover, true);
+
+	// disable fastpath -> new IOs take native, ordered behind the queued
+	// failover req in the fuse channel. failQ drains in the completer.
+	disableFastPath(pxd_dev, true);
+
+	return 0;
 }
 
 int pxd_initiate_fallback(struct pxd_device *pxd_dev)
@@ -966,15 +994,24 @@ static blk_status_t pxd_queue_rq(struct blk_mq_hw_ctx *hctx,
 	struct fp_root_context *fproot = &req->fproot;
 	fp_root_context_init(fproot);
 
-	// rcu read side critical section can't sleep
-	// fastpath_queue_work -> kthread_queue_work
-	// and kthread_queue_work won't sleep since it
-	// acquires a spinlock (see : https://elixir.bootlin.com/linux/v6.13.7/source/kernel/kthread.c#L1030)
+	// Failover orchestration gate.
+	// rcu_read_lock keeps fp.fastpath stable across the gate check and
+	// fastpath_queue_work dispatch. fastpath_queue_work is non-sleeping.
 	rcu_read_lock();
 	if (READ_ONCE(pxd_dev->fp.fastpath)) {
-		// route through fastpath
-		// while in blkmq mode: cannot directly process IO from this thread... involves
-		// recursive BIO submission to the backing devices, causing deadlock.
+		// Failover-in-progress gate: park on failQ until the completer
+		// drains it post-PX-ack. Only checked while fp.fastpath is still
+		// true; once disableFastPath runs we fall through to native.
+		if (READ_ONCE(pxd_dev->fp.active_failover)) {
+			unsigned long flags;
+			spin_lock_irqsave(&pxd_dev->fp.fail_lock, flags);
+			list_add_tail(&fproot->wait, &pxd_dev->fp.failQ);
+			spin_unlock_irqrestore(&pxd_dev->fp.fail_lock, flags);
+			rcu_read_unlock();
+			return BLK_STS_OK;
+		}
+		// blkmq: cannot process IO from this thread, would recursively
+		// submit to backing devices and deadlock.
 		fastpath_queue_work(&fproot->work, false);
 		rcu_read_unlock();
 		return BLK_STS_OK;
@@ -1766,6 +1803,138 @@ static void pxdctx_set_connected(struct pxd_context *ctx, bool enable)
 	}
 }
 
+// pxdctx_reset_fastpath - tear down fastpath per device.
+// Backstop path (pxd_abort_context). Snapshot+refcount because
+// pxd_fastpath_reset_device -> blk_mq_quiesce_queue can sleep, so
+// ctx->lock must be dropped per device. Doesn't touch pxd_dev->connected
+// (allow_disconnected=0 already gates IO at that layer).
+static void pxdctx_reset_fastpath(struct pxd_context *ctx)
+{
+	size_t ndevs;
+	struct pxd_device **snap_list;
+	struct pxd_device *pxd_dev;
+	size_t i = 0;
+	size_t j;
+
+	// step 1: count entries under ctx->lock
+	spin_lock(&ctx->lock);
+	ndevs = ctx->num_devices;
+	spin_unlock(&ctx->lock);
+
+	// step 2: allocate snapshot list (may sleep, not under lock)
+	snap_list = kcalloc(ndevs, sizeof(*snap_list), GFP_KERNEL);
+
+	if (snap_list) {
+		// step 3: fill snapshot with refcounted device pointers
+		spin_lock(&ctx->lock);
+		list_for_each_entry(pxd_dev, &ctx->list, node) {
+			if (i >= ndevs) {
+				pr_warn("%s: ctx->list has more entries than snap_list, ignoring extra entries, devID : %llu minor %d\n",
+					__func__, pxd_dev->dev_id, pxd_dev->minor);
+				break;
+			}
+			get_device(&pxd_dev->dev);
+			snap_list[i++] = pxd_dev;
+		}
+		spin_unlock(&ctx->lock);
+
+		// step 4: walk the snapshot without ctx->lock; safe to sleep
+		for (j = 0; j < i; j++) {
+			pxd_fastpath_reset_device(snap_list[j]);
+			put_device(&snap_list[j]->dev);
+		}
+
+		// step 5: free snapshot
+		kfree(snap_list);
+		return;
+	}
+
+	// kcalloc failed: one-at-a-time pickup, O(n^2) but allocation-free.
+	// We can't use pxd_dev->connected as the "already processed" sentinel
+	// (we deliberately don't touch it), so use fastpath_active() instead:
+	// pxd_fastpath_reset_device clears fp.fastpath via disableFastPath,
+	// which makes the candidate predicate false on subsequent iterations.
+	for (;;) {
+		struct pxd_device *picked = NULL;
+
+		spin_lock(&ctx->lock);
+		list_for_each_entry(pxd_dev, &ctx->list, node) {
+			if (fastpath_enabled(pxd_dev) && fastpath_active(pxd_dev)) {
+				get_device(&pxd_dev->dev);
+				picked = pxd_dev;
+				break;
+			}
+		}
+		spin_unlock(&ctx->lock);
+
+		if (!picked) {
+			// no fastpath-active devices left
+			break;
+		}
+
+		pxd_fastpath_reset_device(picked);
+		put_device(&picked->dev);
+	}
+}
+
+// pxdctx_initiate_failover - drive the failover protocol per fastpath-active
+// device on this ctx by calling pxd_initiate_failover() on each. Used by
+// pxd_control_release() to ensure PX-down goes through the same single-entry
+// failover API as IO-error and PX-storage ioctl paths.
+//
+// pxd_initiate_failover may sleep (blk_mq_quiesce_queue, sync workers), so
+// we use snapshot+refcount: capture devices under ctx->lock, drop the lock,
+// then iterate. We filter to fastpath_active devices at snapshot time so
+// native-path and already-failed-over devices don't take a spurious failover
+// round-trip (pxd_initiate_failover no longer self-filters). A device that
+// flips fp.fastpath false between snapshot and call still proceeds through
+// pxd_initiate_failover - it'll take one round-trip but the failover state
+// machine handles it correctly.
+//
+// Caller must run this BEFORE flipping fc->connected to 0 - pxd_initiate_ioswitch
+// gates on fc->connected and would skip the fuse req otherwise.
+static void pxdctx_initiate_failover(struct pxd_context *ctx)
+{
+	size_t ndevs;
+	struct pxd_device **snap_list;
+	struct pxd_device *pxd_dev;
+	size_t i = 0;
+	size_t j;
+
+	spin_lock(&ctx->lock);
+	ndevs = ctx->num_devices;
+	spin_unlock(&ctx->lock);
+
+	snap_list = kcalloc(ndevs, sizeof(*snap_list), GFP_KERNEL);
+	if (!snap_list) {
+		// kcalloc failed; fastpath stays armed, abort_work is backstop.
+		pr_warn("%s: ctx %d kcalloc failed; failover not initiated\n",
+			__func__, ctx->id);
+		return;
+	}
+
+	spin_lock(&ctx->lock);
+	list_for_each_entry(pxd_dev, &ctx->list, node) {
+		if (i >= ndevs) {
+			pr_warn("%s: ctx->list grew past snap_list; devID %llu minor %d skipped\n",
+				__func__, pxd_dev->dev_id, pxd_dev->minor);
+			break;
+		}
+		if (!fastpath_active(pxd_dev)) {
+			continue;
+		}
+		get_device(&pxd_dev->dev);
+		snap_list[i++] = pxd_dev;
+	}
+	spin_unlock(&ctx->lock);
+
+	for (j = 0; j < i; j++) {
+		pxd_initiate_failover(snap_list[j]);
+		put_device(&snap_list[j]->dev);
+	}
+	kfree(snap_list);
+}
+
 static struct pxd_device *dev_to_pxd_dev(struct device *dev)
 {
 	return container_of(dev, struct pxd_device, dev);
@@ -2356,13 +2525,19 @@ static int pxd_control_release(struct inode *inode, struct file *file)
 		return 0;
 	}
 
+	// Drive failover through the single pxd_initiate_failover API for every
+	// fastpath-active device. fuse req queues into fc->processing while
+	// fc->connected is still 1; replayed by fuse_restart_requests on reopen.
+	pxdctx_initiate_failover(ctx);
+
 	spin_lock(&ctx->lock);
 	if (READ_ONCE(ctx->fc.connected) == 0) {
 		pxd_printk("%s: not opened\n", __func__);
 	} else {
 		WRITE_ONCE(ctx->fc.connected, 0);
 	}
-
+	// Backstop: at T+pxd_timeout_secs flip allow_disconnected=0, fail
+	// queued fuse reqs, run pxdctx_reset_fastpath -> failQ -EIOs.
 	schedule_delayed_work(&ctx->abort_work, pxd_timeout_secs * HZ);
 	spin_unlock(&ctx->lock);
 
@@ -2402,7 +2577,10 @@ static void pxd_abort_context(struct work_struct *work)
 	spin_lock(&fc->lock);
 	fuse_end_queued_requests(fc);
 	spin_unlock(&fc->lock);
-	pxdctx_set_connected(ctx, false);
+
+	// Tear down fastpath per device (also fails any leftover failQ IOs
+	// via the defensive __pxd_abortfailQ inside pxd_fastpath_reset_device).
+	pxdctx_reset_fastpath(ctx);
 }
 
 static int pxd_context_init(struct pxd_context *ctx, int i)

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -563,53 +563,31 @@ static void pxd_io_failover(struct kthread_work *work) {
         struct fp_root_context *fproot =
             container_of(work, struct fp_root_context, work);
         struct pxd_device *pxd_dev = fproot_to_pxd(fproot);
-        bool cleanup = false;
-        bool reroute = false;
         int rc;
         unsigned long flags;
 
         BUG_ON(fproot->magic != FP_ROOT_MAGIC);
         BUG_ON(pxd_dev->magic != PXD_DEV_MAGIC);
 
+        // Enqueue and call. pxd_initiate_failover handles the three cases
+        // internally: in-progress (no-op), orphan/native (splice+reissue
+        // locally, return 0), or leader (full failover round-trip).
         spin_lock_irqsave(&pxd_dev->fp.fail_lock, flags);
-        if (!pxd_dev->fp.active_failover) {
-                if (pxd_dev->fp.fastpath) {
-                        pxd_dev->fp.active_failover = true;
-                        list_add_tail(&fproot->wait, &pxd_dev->fp.failQ);
-                        cleanup = true;
-                } else {
-                        reroute = true;
-                }
-        } else {
-                list_add_tail(&fproot->wait, &pxd_dev->fp.failQ);
-        }
+        list_add_tail(&fproot->wait, &pxd_dev->fp.failQ);
         spin_unlock_irqrestore(&pxd_dev->fp.fail_lock, flags);
 
-        if (cleanup) {
-                trace_pxd_initiate_failover(pxd_dev->dev_id, pxd_dev->minor, FAILOVER_REASON_IOFAILURE);
-                rc = pxd_initiate_failover(pxd_dev);
-                // If userspace cannot be informed of a failover event, force
-                // abort all IO.
-                if (rc) {
-                        printk_ratelimited(
-                            KERN_ERR
-                            "%s: pxd%llu: failover failed %d, aborting IO\n",
-                            __func__, pxd_dev->dev_id, rc);
-                        spin_lock_irqsave(&pxd_dev->fp.fail_lock, flags);
-                        __pxd_abortfailQ(pxd_dev);
-                        pxd_dev->fp.active_failover = false;
-                        spin_unlock_irqrestore(&pxd_dev->fp.fail_lock, flags);
-                }
-        } else if (reroute) {
-                printk_ratelimited(KERN_ERR
-                                   "%s: pxd%llu: resuming IO in native path.\n",
-                                   __func__, pxd_dev->dev_id);
-                atomic_inc(&pxd_dev->fp.nslowPath);
-                clone_cleanup(fproot);
-                trace_pxd_reroute_slowpath_transition(pxd_dev->dev_id, pxd_dev->minor, TRANSITION_PXD_IO_FAILOVER, rq_data_dir(fproot_to_request(fproot)), 
-                        req_op(fproot_to_request(fproot)), blk_rq_pos(fproot_to_request(fproot)) * SECTOR_SIZE, blk_rq_bytes(fproot_to_request(fproot)),
-                        fproot_to_request(fproot)->nr_phys_segments, fproot_to_request(fproot)->cmd_flags);
-                pxdmq_reroute_slowpath(fproot_to_fuse_request(fproot));
+        trace_pxd_initiate_failover(pxd_dev->dev_id, pxd_dev->minor, FAILOVER_REASON_IOFAILURE);
+        rc = pxd_initiate_failover(pxd_dev);
+        // Non-zero only on real failure (-ENODEV removing, -ENOMEM,
+        // -ENOTCONN). Orphan case returns 0 after local reissue.
+        if (rc) {
+                printk_ratelimited(
+                    KERN_ERR
+                    "%s: pxd%llu: failover failed %d, aborting IO\n",
+                    __func__, pxd_dev->dev_id, rc);
+                spin_lock_irqsave(&pxd_dev->fp.fail_lock, flags);
+                __pxd_abortfailQ(pxd_dev);
+                spin_unlock_irqrestore(&pxd_dev->fp.fail_lock, flags);
         }
 }
 

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -741,13 +741,27 @@ out_file_failed:
 }
 
 // reset device called during device cleanup actions from any internal state.
-// consider node wipe, device remove while suspended etc.
+// consider node wipe, device remove while suspended etc. Also invoked from
+// the abort_work backstop (pxd_abort_context) via pxdctx_reset_fastpath()
+// at T+pxd_timeout_secs when PX never reopened the control fd.
+//
+// Important: this function never requeues IO. Any IO that hasn't already
+// completed must be failed here. Requeueing to native path is unsafe in
+// the node-wipe / device-remove case because:
+//   - the device may be going away, so references held by requeued IOs
+//     would keep the pxd_device alive indefinitely;
+//   - calling threads can end up in D state waiting on IO that will never
+//     complete because the very thing that would complete it (PX userspace
+//     servicing the fuse channel) is the thing being torn down.
+// Routing to native is only safe inside pxd_process_ioswitch_complete after
+// a real PX ack of PXD_FAILOVER_TO_USERSPACE.
 void pxd_fastpath_reset_device(struct pxd_device *pxd_dev)
 {
 	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
 	struct pxd_context *ctx = pxd_dev->ctx;
 	struct fuse_conn *fc = &ctx->fc;
 	struct fuse_req *req;
+	unsigned long flags;
 	bool ioswitch_active;
 
 	if (!fastpath_enabled(pxd_dev)) {
@@ -757,7 +771,10 @@ void pxd_fastpath_reset_device(struct pxd_device *pxd_dev)
 	disableFastPath(pxd_dev, true);
 
 	ioswitch_active = atomic_read(&fp->ioswitch_active);
-	// abort any inflight ioswitch
+	// abort any inflight ioswitch.
+	// On request_end with error, pxd_process_ioswitch_complete fires and
+	// calls pxd_reissuefailQ(.., status != 0) which fails every failQ IO
+	// with -EIO - exactly the behavior we want here.
 	if (ioswitch_active) {
 		req = request_find(fc, pxd_dev->fp.switch_uid);
 		if (!IS_ERR_OR_NULL(req)) {
@@ -775,6 +792,20 @@ void pxd_fastpath_reset_device(struct pxd_device *pxd_dev)
 		trace_pxd_fastpath_reset_device(pxd_dev->dev_id, pxd_dev->minor,
 			ioswitch_active, 0);
 	}
+
+	// Defensive backstop: if there's no in-flight ioswitch (so the
+	// completer path above did not run, or it ran but failed to find the
+	// req), failQ may still hold IOs. Fail them with -EIO so callers in
+	// D state on these requests are released; never requeue.
+	spin_lock_irqsave(&fp->fail_lock, flags);
+	if (!list_empty(&fp->failQ)) {
+		printk(KERN_WARNING "pxd device %llu: reset with %s failQ; failing all\n",
+			pxd_dev->dev_id,
+			ioswitch_active ? "leftover" : "non-empty");
+		__pxd_abortfailQ(pxd_dev);
+		fp->active_failover = false;
+	}
+	spin_unlock_irqrestore(&fp->fail_lock, flags);
 
 	// resume from userspace IO suspends
 	pxd_request_resume(pxd_dev);

--- a/test/pxd_fastpath_test.cc
+++ b/test/pxd_fastpath_test.cc
@@ -1,6 +1,8 @@
 #include <algorithm>
+#include <atomic>
 #include <boost/iostreams/device/file_descriptor.hpp>
 #include <boost/lexical_cast.hpp>
+#include <chrono>
 #include <fcntl.h>
 #include <fstream>
 #include <functional>
@@ -1339,4 +1341,298 @@ TEST_P(PxdFastpathTest, write_zeroes_disabled_fastpath_with_capability)
     dev_remove_fastpath(add_v2.dev_id);
 
     std::cout << "=== Test PASSED: WriteZero disabled for fastpath ===" << std::endl;
+}
+
+// Read the per-device sysfs fastpath attribute (1 = fastpath active, 0 = native).
+static std::string read_fastpath_sysfs(int minor)
+{
+    int minor_num = minor & MINORMASK;
+    std::string path = "/sys/devices/pxd/" + std::to_string(minor_num) + "/fastpath";
+    std::ifstream f(path);
+    std::string status;
+    if (!(f >> status)) return std::string();
+    return status;
+}
+
+// Helper: push an unsolicited PXD_FAILOVER_TO_USERSPACE/PXD_FALLBACK_TO_KERNEL
+// notify into the kernel via the control fd. Mirrors the format used by
+// pxd-storage to drive force-switch from userspace.
+static ssize_t send_ioswitch_notify(int ctl_fd, uint64_t dev_id, int opcode)
+{
+    fuse_out_header oh;
+    pxd_ioswitch req;
+    struct iovec iov[2];
+
+    oh.unique = 0;
+    oh.error = opcode;
+    oh.len = sizeof(oh) + sizeof(req);
+
+    req.dev_id = dev_id;
+
+    iov[0].iov_base = &oh;
+    iov[0].iov_len = sizeof(oh);
+    iov[1].iov_base = &req;
+    iov[1].iov_len = sizeof(req);
+
+    return writev(ctl_fd, iov, 2);
+}
+
+// Reply success to a marker req surfaced from the kernel side.
+static ssize_t ack_marker_req(int ctl_fd, uint64_t unique)
+{
+    fuse_out_header oh;
+    oh.unique = unique;
+    oh.error = 0;
+    oh.len = sizeof(oh);
+    return ::write(ctl_fd, &oh, sizeof(oh));
+}
+
+// Test: PX-storage death (control fd close) on a fastpath-active device.
+//
+// Before PWX-49986, a closed PX control fd left fastpath armed; the next IO
+// error triggered pxd_io_failover but failover could only complete after the
+// abort_work backstop fired at T+PXD_TIMER_SECS_DEFAULT (~10 minutes).
+//
+// After the fix, pxd_control_release drives pxdctx_initiate_failover before
+// flipping fc->connected to 0. This test asserts: (a) close(ctl_fd) returns
+// promptly (no 10-min stall), (b) the device drops out of fastpath as soon
+// as the close returns (sysfs reflects fp.fastpath = 0).
+TEST_P(PxdFastpathTest, px_storage_death_triggers_immediate_failover)
+{
+    BackingDeviceType device_type = GetParam();
+    std::string backing_str = (device_type == BackingDeviceType::BACKING_FILE)
+                                 ? "backing file"
+                                 : "loop device";
+    std::cout << "=== Test: PX-storage death triggers immediate failover ("
+              << backing_str << ") ===" << std::endl;
+
+    pxd_add_ext_out add_ext;
+    add_ext.dev_id = 400;
+    add_ext.size = 100 * 1024 * 1024;
+    add_ext.queue_depth = 128;
+    add_ext.discard_size = PXD_LBS;
+    add_ext.open_mode = O_LARGEFILE | O_RDWR | O_DIRECT;
+    add_ext.enable_fp = 1;
+
+    create_backing_devices(2, 100);
+    setup_fastpath_paths(add_ext.paths);
+
+    std::string device_name;
+    int minor;
+    dev_add_fastpath(add_ext, minor, device_name);
+
+    ASSERT_EQ(read_fastpath_sysfs(minor), "1")
+        << "Device should be in fastpath before PX-storage death";
+
+    perform_io_test(device_name);
+
+    auto t0 = std::chrono::steady_clock::now();
+    close(ctl_fd);
+    ctl_fd = -1;
+    auto t1 = std::chrono::steady_clock::now();
+    long close_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
+    std::cout << "ctl_fd close took " << close_ms << " ms" << std::endl;
+
+    // 10s ceiling: pxd_initiate_failover's suspend path has up to a 60s
+    // sync wait, but with no in-flight IOs and a single device the actual
+    // close should complete in well under a second. The point of the
+    // assertion is to catch regressions to the pre-fix 10-minute path.
+    EXPECT_LT(close_ms, 10000)
+        << "ctl_fd close took " << close_ms
+        << " ms - regression: should not wait on the 10-min abort timer";
+
+    // disableFastPath runs inside pxd_initiate_failover, so fp.fastpath
+    // should be cleared by the time close() returns. Allow a small grace
+    // window for sysfs visibility.
+    bool fp_cleared = false;
+    for (int i = 0; i < 50; i++) {
+        if (read_fastpath_sysfs(minor) == "0") {
+            fp_cleared = true;
+            break;
+        }
+        usleep(100000);
+    }
+    EXPECT_TRUE(fp_cleared)
+        << "Device should be in native path after PX-storage death";
+
+    // Reopen control fd so the TearDown path can drive PXD_REMOVE.
+    ctl_fd = open(control_device_fastpath(0).c_str(), O_RDWR);
+    ASSERT_GT(ctl_fd, 0);
+    pxd_ioctl_init_args args;
+    ASSERT_GE(ioctl(ctl_fd, PXD_IOC_INIT, &args), 0);
+}
+
+// Test: userspace-driven force switch (failover -> fallback) while IOs flow.
+//
+// Validates the full driver-side switch protocol when PX-storage explicitly
+// requests the path change while application IO is in flight:
+//   1. Continuous writer thread issues O_DIRECT pwrites against the fastpath
+//      device. Before failover, those bypass the fuse channel entirely.
+//   2. PXD_FAILOVER_TO_USERSPACE notify forces failover. We expect a
+//      PXD_FAILOVER_TO_USERSPACE marker fuse req surfaced on ctl_fd, and
+//      subsequent PXD_WRITE reqs once the marker is acked (writes now flow
+//      through fuse on the native path).
+//   3. PXD_FALLBACK_TO_KERNEL notify forces fallback marker - we ack that too.
+TEST_P(PxdFastpathTest, force_failover_fallback_while_io_flows)
+{
+    BackingDeviceType device_type = GetParam();
+    std::string backing_str = (device_type == BackingDeviceType::BACKING_FILE)
+                                 ? "backing file"
+                                 : "loop device";
+    std::cout << "=== Test: Force failover/fallback while IOs flow ("
+              << backing_str << ") ===" << std::endl;
+
+    pxd_add_ext_out add_ext;
+    add_ext.dev_id = 401;
+    add_ext.size = 100 * 1024 * 1024;
+    add_ext.queue_depth = 128;
+    add_ext.discard_size = PXD_LBS;
+    add_ext.open_mode = O_LARGEFILE | O_RDWR | O_DIRECT;
+    add_ext.enable_fp = 1;
+
+    create_backing_devices(2, 100);
+    setup_fastpath_paths(add_ext.paths);
+
+    std::string device_name;
+    int minor;
+    dev_add_fastpath(add_ext, minor, device_name);
+
+    ASSERT_EQ(read_fastpath_sysfs(minor), "1")
+        << "Device should be in fastpath at test start";
+
+    std::atomic<int> failover_markers{0};
+    std::atomic<int> fallback_markers{0};
+    std::atomic<int> native_writes{0};
+    std::atomic<int> native_reads{0};
+    std::atomic<int> other_reqs{0};
+    std::atomic<bool> drainer_stop{false};
+
+    // Drainer thread plays the PX-storage role: replies to marker reqs and
+    // services any IOs that surface on the fuse channel (those imply the
+    // device is in native mode).
+    std::thread drainer([&]() {
+        struct rdwr_in rdwr;
+        while (!drainer_stop) {
+            int ret = wait_msg(1);
+            if (ret == -ETIMEDOUT || ret != 0) continue;
+
+            ssize_t n = read(ctl_fd, &rdwr, sizeof(rdwr));
+            if (n <= 0) continue;
+
+            switch (rdwr.in.opcode) {
+            case PXD_FAILOVER_TO_USERSPACE:
+                ack_marker_req(ctl_fd, rdwr.in.unique);
+                failover_markers++;
+                break;
+            case PXD_FALLBACK_TO_KERNEL:
+                ack_marker_req(ctl_fd, rdwr.in.unique);
+                fallback_markers++;
+                break;
+            case PXD_WRITE:
+                native_writes++;
+                finish_io(&rdwr);
+                break;
+            case PXD_READ:
+                native_reads++;
+                finish_io(&rdwr);
+                break;
+            default:
+                other_reqs++;
+                fail_io(&rdwr);
+            }
+        }
+    });
+
+    std::atomic<bool> io_stop{false};
+    std::atomic<int> io_ok{0};
+    std::atomic<int> io_err{0};
+    std::thread io_thread([&]() {
+        int fd = open(device_name.c_str(), O_RDWR | O_DIRECT);
+        if (fd < 0) return;
+        auto buf = aligned_buffer_fastpath(4096);
+        init_pattern_fastpath(buf.get(), 4096);
+
+        uint64_t off = 0;
+        while (!io_stop) {
+            ssize_t w = pwrite(fd, buf.get(), 4096, off % (50 * 1024 * 1024));
+            if (w == 4096) {
+                io_ok++;
+            } else {
+                io_err++;
+            }
+            off += 4096;
+            // Brief pause keeps the test from being dominated by IO churn.
+            usleep(1000);
+        }
+        close(fd);
+    });
+
+    // Let IOs flow on the fastpath for a moment.
+    sleep(1);
+
+    // Baseline: nothing should have hit the fuse channel while in fastpath.
+    int baseline_native_writes = native_writes.load();
+    EXPECT_EQ(baseline_native_writes, 0)
+        << "Expected zero fuse PXD_WRITE while in fastpath";
+
+    // Force failover.
+    ssize_t w = send_ioswitch_notify(ctl_fd, add_ext.dev_id,
+                                     PXD_FAILOVER_TO_USERSPACE);
+    ASSERT_GT(w, 0) << "PXD_FAILOVER_TO_USERSPACE notify failed: "
+                    << strerror(errno);
+
+    // Failover marker should surface and be acked.
+    for (int i = 0; i < 100; i++) {
+        if (failover_markers >= 1) break;
+        usleep(100000);
+    }
+    ASSERT_GE(failover_markers.load(), 1)
+        << "Failover marker was never surfaced to userspace";
+
+    // disableFastPath ran inside pxd_initiate_failover - sysfs should reflect
+    // native path now.
+    bool fp_cleared = false;
+    for (int i = 0; i < 50; i++) {
+        if (read_fastpath_sysfs(minor) == "0") {
+            fp_cleared = true;
+            break;
+        }
+        usleep(100000);
+    }
+    EXPECT_TRUE(fp_cleared) << "fastpath should be disabled after failover";
+
+    // Let IOs land on the native path for a moment.
+    sleep(1);
+    EXPECT_GT(native_writes.load(), baseline_native_writes)
+        << "Expected PXD_WRITE through fuse after failover";
+
+    // Force fallback marker. The marker itself does not re-arm fastpath
+    // (PX-storage drives that via the separate path-setup protocol), so we
+    // just verify the kernel surfaces the marker and accepts an ack.
+    w = send_ioswitch_notify(ctl_fd, add_ext.dev_id, PXD_FALLBACK_TO_KERNEL);
+    ASSERT_GT(w, 0) << "PXD_FALLBACK_TO_KERNEL notify failed: "
+                    << strerror(errno);
+
+    for (int i = 0; i < 100; i++) {
+        if (fallback_markers >= 1) break;
+        usleep(100000);
+    }
+    ASSERT_GE(fallback_markers.load(), 1)
+        << "Fallback marker was never surfaced to userspace";
+
+    // Tear down threads in the safe order: writer first (so no more reqs are
+    // queued), then drainer (so it doesn't race dev_remove's own cleaner on
+    // ctl_fd).
+    io_stop = true;
+    io_thread.join();
+    drainer_stop = true;
+    drainer.join();
+
+    std::cout << "Counters: failover=" << failover_markers.load()
+              << " fallback=" << fallback_markers.load()
+              << " native_writes=" << native_writes.load()
+              << " native_reads=" << native_reads.load()
+              << " io_ok=" << io_ok.load() << " io_err=" << io_err.load()
+              << std::endl;
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #PWX-49986

**Special notes for your reviewer**:
## PX down and up ##

```
[Mon Jun 15 11:46:02 2026] Device 116755982984640259 added ffff89e7d66e1000 with mode 0x40002 fastpath 1 npath 0 (discard size: 2097152, discard_granularity: 1048576, capabilities: 0x0)
[Mon Jun 15 11:46:02 2026] device 116755982984640259 setting up fastpath target with mode 0x48002(LARW), paths 0
[Mon Jun 15 11:46:02 2026] For pxd device 116755982984640259 IO suspended
[Mon Jun 15 11:46:02 2026] For pxd device 116755982984640259 IO resumed
[Mon Jun 15 11:46:02 2026] device 116755982984640259 setup through nativepath (0)
[Mon Jun 15 11:46:02 2026] device 116755982984640259 initiated fallback
[Mon Jun 15 11:46:02 2026] For pxd device 116755982984640259 IO suspended
[Mon Jun 15 11:46:04 2026] device 116755982984640259 setting up fastpath target with mode 0x48002(LARW), paths 1
[Mon Jun 15 11:46:04 2026] For pxd device 116755982984640259 IO already suspended(2)
[Mon Jun 15 11:46:04 2026] For pxd device 116755982984640259 IO already suspended(3)
[Mon Jun 15 11:46:04 2026] device 116755982984640259:0, inode 5740 mode 0x48002
[Mon Jun 15 11:46:04 2026] device[116755982984640259:0] is a block device - inode 5740
[Mon Jun 15 11:46:04 2026] For pxd device 116755982984640259 IO still suspended(2)
[Mon Jun 15 11:46:04 2026] pxd_dev 116755982984640259 fastpath 1 mode 0x48002 setting up with 1 backing volumes, [ffff89e826cb9b00,0000000000000000,0000000000000000]
[Mon Jun 15 11:46:04 2026] For pxd device 116755982984640259 IO still suspended(1)
[Mon Jun 15 11:46:04 2026] dev116755982984640259 completed setting up 1 paths
[Mon Jun 15 11:46:04 2026] device 116755982984640259 completed ioswitch 8209 with status 0
[Mon Jun 15 11:46:04 2026] For pxd device 116755982984640259 IO resumed
[Mon Jun 15 11:46:04 2026] device 116755982984640259 resumed IO from userspace
[Mon Jun 15 11:46:20 2026] EXT4-fs (pxd!pxd116755982984640259): mounted filesystem 0e94ac50-adf5-47cc-8ffe-37ff1dfe529f r/w with ordered data mode. Quota mode: none.
[Mon Jun 15 11:48:23 2026] device 116755982984640259 called to enable IO
[Mon Jun 15 11:48:23 2026] device 116755982984640259 initiated failover
[Mon Jun 15 11:48:23 2026] For pxd device 116755982984640259 IO suspended
[Mon Jun 15 11:48:23 2026] device 116755982984640259 suspended IO from userspace
[Mon Jun 15 11:48:23 2026] For pxd device 116755982984640259 IO already suspended(2)
[Mon Jun 15 11:48:23 2026] For pxd device 116755982984640259 IO still suspended(1)
[Mon Jun 15 11:48:23 2026] device 116755982984640259 completed ioswitch 8208 with status 0
[Mon Jun 15 11:48:23 2026] For pxd device 116755982984640259 IO resumed
[Mon Jun 15 11:48:23 2026] device 116755982984640259 resumed IO from userspace
[Mon Jun 15 11:48:23 2026] pxd_reissuefailQ: pxd116755982984640259: resuming IO in native path.
[Mon Jun 15 11:48:23 2026] pxd_reissuefailQ: pxd116755982984640259: resuming IO in native path.
[Mon Jun 15 11:48:23 2026] pxd_reissuefailQ: pxd116755982984640259: resuming IO in native path.
[Mon Jun 15 11:48:23 2026] pxd_reissuefailQ: pxd116755982984640259: resuming IO in native path.
[Mon Jun 15 11:48:23 2026] pxd_reissuefailQ: pxd116755982984640259: resuming IO in native path.
[Mon Jun 15 11:48:23 2026] pxd_reissuefailQ: pxd116755982984640259: resuming IO in native path.
[Mon Jun 15 11:48:23 2026] pxd_reissuefailQ: pxd116755982984640259: resuming IO in native path.
[Mon Jun 15 11:48:23 2026] pxd_reissuefailQ: pxd116755982984640259: resuming IO in native path.
[Mon Jun 15 11:48:23 2026] pxd_reissuefailQ: pxd116755982984640259: resuming IO in native path.
[Mon Jun 15 11:48:23 2026] pxd_reissuefailQ: pxd116755982984640259: resuming IO in native path.




root@ip-10-13-175-47:~# pxctl v c vol1 --nodes dc9dcaa3-b93b-4a54-a26f-54fb5d98b386 -s 50 --fastpath
Volume successfully created: 116755982984640259
root@ip-10-13-175-47:~# pxctl host attach vol1
Volume successfully attached at: /dev/pxd/pxd116755982984640259
root@ip-10-13-175-47:~#
root@ip-10-13-175-47:~# pxctl v i -e vol1
        Volume                   :  116755982984640259
        Name                     :  vol1
        Size                     :  50 GiB
        Format                   :  ext4
        HA                       :  1
        IO Priority              :  LOW
        Creation time            :  Jun 15 11:45:25 UTC 2026
        Shared                   :  no
        Status                   :  up
        State                    :  Attached: dc9dcaa3-b93b-4a54-a26f-54fb5d98b386 (10.13.175.47) (fastpath active)
        Last Attached            :  Jun 15 11:45:38 UTC 2026
        Device Path              :  /dev/pxd/pxd116755982984640259
        Mount Options            :  discard
        Reads                    :  34
        Reads MS                 :  2248
        Bytes Read               :  344064
        Writes                   :  0
        Writes MS                :  0
        Bytes Written            :  0
        IOs in progress          :  0
        Bytes used               :  261 MiB
        Replica sets on nodes:
                Set 0
                  Node           : 10.13.175.47
                   Pool UUID     : ece6eeb6-0300-45bf-aea4-58181704b11f
        Replication Status       :  Up

        Displaying extended volume state:
        Fastpath preferred      : true
        Fastpath promoted       : true
        Fastpath dirty          : false
        Fastpath force failover : false
        Fastpath attached       : FASTPATH_ACTIVE
        Fastpath coordinator    : dc9dcaa3-b93b-4a54-a26f-54fb5d98b386
        Fastpath replicas       : 1
        Fastpath replica property follows:
                Replica : 0
                        On Node         : dc9dcaa3-b93b-4a54-a26f-54fb5d98b386
                        Protocol        : FASTPATH_PROTO_NVMEOF_TCP
                        Secure          : true
                        Exported        : true
                                Target  : /dev/pwx0/116755982984640259
                                Source  : /dev/pwx0/116755982984640259
                                Type    : Block device
                        Imported        : true
                                Mapped local device: /dev/pwx0/116755982984640259
root@ip-10-13-175-47:~# mkdir /var/lib/osd/mounts/vol1
root@ip-10-13-175-47:~# pxctl host mount --path /var/lib/osd/mounts/vol1 vol1
Volume vol1 successfully mounted at /var/lib/osd/mounts/vol1
root@ip-10-13-175-47:~# systemctl stop portworx
root@ip-10-13-175-47:~# systemctl start portworx

After PX start in px storage
57539:Jun 15 11:48:00 ip-10-13-175-47.pwx.purestorage.com portworx[343061]: time="2026-06-15 11:48:00Z" level=NOTE msg="operator(): dev 116755982984640259 attached in fastpath, but needs failover after daemon restart"
root@ip-10-13-175-47:~#


```

## Abort timeout in nativepath ##

```
rting 1 process
fio: io_u error on file /var/lib/osd/mounts/vol1/f: Input/output error: read offset=803389440, buflen=4096
fio: io_u error on file /var/lib/osd/mounts/vol1/f: Input/output error: read offset=803364864, buflen=4096
fio: io_u error on file /var/lib/osd/mounts/vol1/f: Input/output error: read offset=803368960, buflen=4096
fio: io_u error on file /var/lib/osd/mounts/vol1/f: Input/output error: read offset=803373056, buflen=4096
fio: io_u error on file /var/lib/osd/mounts/vol1/f: Input/output error: read offset=803377152, buflen=4096
fio: io_u error on file /var/lib/osd/mounts/vol1/f: Input/output error: read offset=803381248, buflen=4096
fio: io_u error on file /var/lib/osd/mounts/vol1/f: Input/output error: read offset=803385344, buflen=4096
fio: io_u error on file /var/lib/osd/mounts/vol1/f: Input/output error: write offset=802533376, buflen=4096
fio: pid=352548, err=5/file:io_u.c:1845, func=io_u error, error=Input/output error

iops-test: (groupid=0, jobs=1): err= 5 (file:io_u.c:1845, func=io_u error, error=Input/output error): pid=352548: Mon Jun 15 12:17:02 2026
  read: IOPS=311, BW=1244KiB/s (1274kB/s)(766MiB/630404msec)
    slat (usec): min=8, max=418, avg=14.79, stdev=11.64
    clat (usec): min=25, max=7000, avg=724.54, stdev=270.07
     lat (usec): min=33, max=7010, avg=739.53, stdev=270.42
    clat percentiles (usec):
     |  1.00th=[   85],  5.00th=[  355], 10.00th=[  420], 20.00th=[  502],
     | 30.00th=[  594], 40.00th=[  668], 50.00th=[  725], 60.00th=[  783],
     | 70.00th=[  848], 80.00th=[  922], 90.00th=[ 1020], 95.00th=[ 1123],
     | 99.00th=[ 1450], 99.50th=[ 1696], 99.90th=[ 2343], 99.95th=[ 2704],
     | 99.99th=[ 4359]
   bw (  KiB/s): min=30312, max=49416, per=100.00%, avg=35658.59, stdev=6641.94, samples=44
   iops        : min= 7578, max=12354, avg=8914.64, stdev=1660.47, samples=44
  write: IOPS=310, BW=1243KiB/s (1273kB/s)(765MiB/630404msec); 0 zone resets
    slat (usec): min=8, max=536, avg=15.80, stdev=12.86
    clat (usec): min=2, max=5199, avg=140.84, stdev=91.63
     lat (usec): min=51, max=5208, avg=156.84, stdev=91.70
    clat percentiles (usec):
     |  1.00th=[   61],  5.00th=[   77], 10.00th=[   85], 20.00th=[   96],
     | 30.00th=[  105], 40.00th=[  114], 50.00th=[  123], 60.00th=[  133],
     | 70.00th=[  145], 80.00th=[  165], 90.00th=[  204], 95.00th=[  258],
     | 99.00th=[  461], 99.50th=[  668], 99.90th=[ 1123], 99.95th=[ 1319],
     | 99.99th=[ 2376]
   bw (  KiB/s): min=30016, max=50128, per=100.00%, avg=35621.66, stdev=6710.90, samples=44
   iops        : min= 7504, max=12532, avg=8905.41, stdev=1677.72, samples=44
  lat (usec)   : 4=0.04%, 10=0.01%, 20=0.01%, 50=0.24%, 100=12.63%
  lat (usec)   : 250=35.99%, 500=10.52%, 750=17.51%, 1000=17.16%
  lat (msec)   : 2=5.81%, 4=0.10%, 10=0.01%
  cpu          : usr=0.23%, sys=1.06%, ctx=172903, majf=0, minf=103
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=100.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.1%, 4=100.0%, 8=0.1%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=196141,195932,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=8

Run status group 0 (all jobs):
   READ: bw=1244KiB/s (1274kB/s), 1244KiB/s-1244KiB/s (1274kB/s-1274kB/s), io=766MiB (803MB), run=630404-630404msec
  WRITE: bw=1243KiB/s (1273kB/s), 1243KiB/s-1243KiB/s (1273kB/s-1273kB/s), io=765MiB (803MB), run=630404-630404msec

Disk stats (read/write):
  pxd!pxd116755982984640259: ios=196134/195939, merge=0/5, ticks=138093/22262, in_queue=160358, util=100.00%
root@ip-10-13-175-47:~#

2935:[Mon Jun 15 12:17:25 2026] I/O error, dev pxd/pxd116755982984640259, sector 1896800 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
2936:[Mon Jun 15 12:17:25 2026] I/O error, dev pxd/pxd116755982984640259, sector 50595440 op 0x1:(WRITE) flags 0x9800 phys_seg 2 prio class 2
2937:[Mon Jun 15 12:17:25 2026] I/O error, dev pxd/pxd116755982984640259, sector 1896752 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
2938:[Mon Jun 15 12:17:25 2026] Aborting journal on device pxd!pxd116755982984640259-8.
2939:[Mon Jun 15 12:17:25 2026] I/O error, dev pxd/pxd116755982984640259, sector 1896760 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
2940:[Mon Jun 15 12:17:25 2026] I/O error, dev pxd/pxd116755982984640259, sector 50593792 op 0x1:(WRITE) flags 0x29800 phys_seg 1 prio class 2
2941:[Mon Jun 15 12:17:25 2026] I/O error, dev pxd/pxd116755982984640259, sector 1896768 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
2942:[Mon Jun 15 12:17:25 2026] Buffer I/O error on dev pxd/pxd116755982984640259, logical block 6324224, lost sync page write
2943:[Mon Jun 15 12:17:25 2026] I/O error, dev pxd/pxd116755982984640259, sector 1896776 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
2944:[Mon Jun 15 12:17:25 2026] JBD2: I/O error when updating journal superblock for pxd!pxd116755982984640259-8.
2945:[Mon Jun 15 12:17:25 2026] I/O error, dev pxd/pxd116755982984640259, sector 1896784 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
2946:[Mon Jun 15 12:17:25 2026] I/O error, dev pxd/pxd116755982984640259, sector 1896792 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
2947:[Mon Jun 15 12:17:25 2026] I/O error, dev pxd/pxd116755982984640259, sector 1895128 op 0x1:(WRITE) flags 0x8800 phys_seg 1 prio class 2
2948:[Mon Jun 15 12:17:25 2026] pxd fastpath device 116755982984640259 reset complete
root@ip-10-13-175-47:~#
root@ip-10-13-175-47:~#

```

## Abort timeout in fastpath ##
```
fio: io_u error on file /var/lib/osd/mounts/vol1/f: Input/output error: read offset=674299904, buflen=4096
fio: io_u error on file /var/lib/osd/mounts/vol1/f: Input/output error: read offset=674304000, buflen=4096
fio: io_u error on file /var/lib/osd/mounts/vol1/f: Input/output error: read offset=674308096, buflen=4096
fio: io_u error on file /var/lib/osd/mounts/vol1/f: Input/output error: read offset=674312192, buflen=4096
fio: io_u error on file /var/lib/osd/mounts/vol1/f: Input/output error: read offset=674316288, buflen=4096
fio: io_u error on file /var/lib/osd/mounts/vol1/f: Input/output error: write offset=673841152, buflen=4096
fio: io_u error on file /var/lib/osd/mounts/vol1/f: Input/output error: write offset=673845248, buflen=4096
fio: io_u error on file /var/lib/osd/mounts/vol1/f: Input/output error: write offset=673849344, buflen=4096
fio: pid=355408, err=5/file:io_u.c:1845, func=io_u error, error=Input/output error

iops-test: (groupid=0, jobs=1): err= 5 (file:io_u.c:1845, func=io_u error, error=Input/output error): pid=355408: Mon Jun 15 12:43:47 2026
  read: IOPS=257, BW=1028KiB/s (1053kB/s)(643MiB/640449msec)
    slat (usec): min=6, max=3723, avg=11.52, stdev=11.07
    clat (usec): min=95, max=11179, avg=591.64, stdev=232.34
     lat (usec): min=189, max=11188, avg=603.38, stdev=232.00
    clat percentiles (usec):
     |  1.00th=[  258],  5.00th=[  302], 10.00th=[  338], 20.00th=[  396],
     | 30.00th=[  453], 40.00th=[  515], 50.00th=[  570], 60.00th=[  619],
     | 70.00th=[  685], 80.00th=[  758], 90.00th=[  873], 95.00th=[  963],
     | 99.00th=[ 1205], 99.50th=[ 1385], 99.90th=[ 1991], 99.95th=[ 2507],
     | 99.99th=[ 3654]
   bw (  KiB/s): min=23600, max=33896, per=100.00%, avg=26876.12, stdev=3301.47, samples=49
   iops        : min= 5900, max= 8474, avg=6719.02, stdev=825.36, samples=49
  write: IOPS=256, BW=1027KiB/s (1052kB/s)(643MiB/640449msec); 0 zone resets
    slat (usec): min=6, max=319, avg=12.40, stdev= 6.52
    clat (usec): min=264, max=11067, avg=573.45, stdev=149.02
     lat (usec): min=293, max=11076, avg=586.07, stdev=148.45
    clat percentiles (usec):
     |  1.00th=[  371],  5.00th=[  412], 10.00th=[  437], 20.00th=[  474],
     | 30.00th=[  498], 40.00th=[  529], 50.00th=[  553], 60.00th=[  578],
     | 70.00th=[  611], 80.00th=[  652], 90.00th=[  725], 95.00th=[  799],
     | 99.00th=[ 1045], 99.50th=[ 1221], 99.90th=[ 1729], 99.95th=[ 2057],
     | 99.99th=[ 3818]
   bw (  KiB/s): min=23024, max=33688, per=100.00%, avg=26857.80, stdev=3332.11, samples=49
   iops        : min= 5756, max= 8422, avg=6714.45, stdev=833.03, samples=49
  lat (usec)   : 100=0.01%, 250=0.36%, 500=33.67%, 750=51.61%, 1000=11.89%
  lat (msec)   : 2=2.40%, 4=0.07%, 10=0.01%, 20=0.01%
  cpu          : usr=0.19%, sys=0.78%, ctx=170659, majf=0, minf=63
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=100.0%, 16=0.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.1%, 4=100.0%, 8=0.1%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     issued rwts: total=164629,164515,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=8

Run status group 0 (all jobs):
   READ: bw=1028KiB/s (1053kB/s), 1028KiB/s-1028KiB/s (1053kB/s-1053kB/s), io=643MiB (674MB), run=640449-640449msec
  WRITE: bw=1027KiB/s (1052kB/s), 1027KiB/s-1027KiB/s (1052kB/s-1052kB/s), io=643MiB (674MB), run=640449-640449msec

Disk stats (read/write):
  pxd!pxd116755982984640259: ios=164624/164513, merge=0/0, ticks=94830/90762, in_queue=185593, util=100.00%
root@ip-10-13-175-47:~#


2987:[Mon Jun 15 12:44:10 2026] For pxd device 116755982984640259 IO suspended
2988:[Mon Jun 15 12:44:10 2026] For pxd device 116755982984640259 IO resumed
2989:[Mon Jun 15 12:44:10 2026] pxd device 116755982984640259: reset with non-empty failQ; failing all
2990:[Mon Jun 15 12:44:10 2026] I/O error, dev pxd/pxd116755982984640259, sector 1627392 op 0x1:(WRITE) flags 0x8800 phys_seg 1 prio class 2
2991:[Mon Jun 15 12:44:10 2026] I/O error, dev pxd/pxd116755982984640259, sector 1628288 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
2992:[Mon Jun 15 12:44:10 2026] I/O error, dev pxd/pxd116755982984640259, sector 1628296 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
2993:[Mon Jun 15 12:44:10 2026] I/O error, dev pxd/pxd116755982984640259, sector 1627400 op 0x1:(WRITE) flags 0x8800 phys_seg 1 prio class 2
2994:[Mon Jun 15 12:44:10 2026] I/O error, dev pxd/pxd116755982984640259, sector 1628304 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
2995:[Mon Jun 15 12:44:10 2026] I/O error, dev pxd/pxd116755982984640259, sector 1628312 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
2996:[Mon Jun 15 12:44:10 2026] I/O error, dev pxd/pxd116755982984640259, sector 1628320 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
2997:[Mon Jun 15 12:44:10 2026] I/O error, dev pxd/pxd116755982984640259, sector 1627408 op 0x1:(WRITE) flags 0x8800 phys_seg 1 prio class 2
2998:[Mon Jun 15 12:44:10 2026] pxd fastpath device 116755982984640259 reset complete
```