### PR TITLE
add oracle UEK 6.12 compatibility fix

### DIFF
--- a/pxd.c
+++ b/pxd.c
@@ -1096,7 +1096,7 @@ static int pxd_init_disk(struct pxd_device *pxd_dev, unsigned int *blk_mq_queue_
 	blk_queue_logical_block_size(q, PXD_LBS);
 	blk_queue_physical_block_size(q, PXD_LBS);
 #endif
-#elif LINUX_VERSION_CODE < KERNEL_VERSION(5,14,0) || (LINUX_VERSION_CODE < KERNEL_VERSION(6,9,0) && !defined(__EL8__) || defined(__ORACLE_UEK__))
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(5,14,0) || (LINUX_VERSION_CODE < KERNEL_VERSION(6,9,0) && !defined(__EL8__) || (defined(__ORACLE_UEK__) && LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0)))
 	blk_queue_max_hw_sectors(q, PXD_MAX_IO / SECTOR_SIZE);
 	blk_queue_max_segment_size(q, SEGMENT_SIZE);
 	blk_queue_max_segments(q, (PXD_MAX_IO / PXD_LBS));


### PR DESCRIPTION
**What this PR does / why we need it**:

Kernel comapatibility changes for oracle UEK 6.12.

### Build Output:
```
make  -C /usr/src/kernels/6.12.0-204.92.4.3.el9uek.x86_64  M=/root/px-fuse modules
make[1]: Entering directory '/usr/src/kernels/6.12.0-204.92.4.3.el9uek.x86_64'
Kernel version 6.12 supports fastpath.
Kernel version 6.12 supports blkmq driver model.
  CC [M]  /root/px-fuse/pxd.o
  CC [M]  /root/px-fuse/dev.o
  CC [M]  /root/px-fuse/iov_iter.o
  CC [M]  /root/px-fuse/px_version.o
  CC [M]  /root/px-fuse/kiolib.o
  CC [M]  /root/px-fuse/pxd_bio_blkmq.o
  CC [M]  /root/px-fuse/pxd_fastpath.o
  LD [M]  /root/px-fuse/px.o
Kernel version 6.12 supports fastpath.
Kernel version 6.12 supports blkmq driver model.
  MODPOST /root/px-fuse/Module.symvers
  CC [M]  /root/px-fuse/px.mod.o
  CC [M]  /root/px-fuse/.module-common.o
  LD [M]  /root/px-fuse/px.ko
  BTF [M] /root/px-fuse/px.ko
Skipping BTF generation for /root/px-fuse/px.ko due to unavailability of vmlinux
make[1]: Leaving directory '/usr/src/kernels/6.12.0-204.92.4.3.el9uek.x86_64'
```

### Run Output:

```
# make pxd_test
Kernel version 6.12 supports fastpath.
Kernel version 6.12 supports blkmq driver model.
Building Tests ...
g++ -I. -std=c++11 test/pxd_test.cc test/pxd_fastpath_test.cc -lgtest -lboost_iostreams -lpthread -o test/pxd_test
```



**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

