### PR TITLE
Ln/fpdetach - handle control fd close and fastpath failover correctly.

### DIFF
--- a/FASTPATH_CONTROL_FLOWS.md
+++ b/FASTPATH_CONTROL_FLOWS.md
@@ -1,0 +1,636 @@
+# pxd fastpath: control flows and invariants
+
+Scope: how the px_fuse kernel driver drives the fastpath / native-path IO
+state machine, and what invariants the code maintains when multiple flows
+race. Files touched: pxd.c, pxd_bio_blkmq.c, pxd_fastpath.c, pxd_core.h.
+
+The invariants below are what the recent refactor added; the flows are
+what the driver was already doing, restated with the invariants in mind.
+
+Naming reminder:
+  ctx            = struct pxd_context, one per pxd-control-N device
+  pxd_dev        = struct pxd_device,  one per exported /dev/pxd/pxdN
+  fc             = &ctx->fc, the fuse_conn attached to that ctx
+  failover_work  = per-ctx work_struct, scheduled by pxd_control_release
+  abort_work     = per-ctx delayed_work, scheduled T + pxd_timeout_secs
+                   after pxd_control_release
+  freeze         = ctx-scoped quiescent window enforced by
+                   pxd_fp_freeze_start / pxd_fp_freeze_end (module-local;
+                   NOT kernel workqueue freeze - see pxd_fastpath.c
+                   comments for why that primitive is not usable from a
+                   module).
+
+
+## Part 1. Independent operations
+
+Each subsection describes one operation triggered from userspace or from
+a timer, running in isolation.
+
+
+### 1.1 Device attach
+
+Trigger: PXD_ADD / PXD_ADD_EXT / PXD_ADD_EXT_V2 fuse op on ctl_fd.
+
+Flow (pxd.c pxd_add):
+  1. kzalloc(pxd_device); pxd_dev->connected = true; pxd_dev->fastpath =
+     enable_fp; INIT_WORK(&pxd_dev->remove_work, pxd_finish_remove).
+  2. Allocate minor, register gendisk, add to ctx->list.
+  3. If enable_fp, backing paths arrive via a separate
+     PXD_UPDATE_PATH ioctl. pxd_init_fastpath_target opens the backing
+     files, sets fp->fastpath = true.
+
+Post-condition: device is on ctx->list; fp.fastpath reflects whether
+fastpath is armed.
+
+
+### 1.2 Device detach
+
+Trigger: PXD_REMOVE fuse op, or PXD_IOC_DETACH_DEVICE ioctl (from any
+context - detach can be issued via a tool control fd, e.g. ctx-10).
+
+Flow (pxd.c pxd_remove_dev -> pxd_finish_remove):
+  1. Under ctx->lock + pxd_dev->lock: check exported / open_count /
+     force. Set removing = true (WRITE_ONCE). schedule_work(remove_work).
+  2. schedule_timeout(500ms) waiting on pxd_dev->remove_wait, so the
+     removal is bounded even if finish_remove hangs.
+  3. pxd_finish_remove (async):
+     a. pxd_fastpath_reset_device(skip_sync=true, fail_io=true).
+        Disables fastpath and drains failQ via __pxd_abortfailQ.
+     b. blk_freeze_queue_start; pxd_mark_device_dead (sets QUEUE_FLAG_
+        DYING / blk_mark_disk_dead per kernel version).
+     c. pxd_free_disk; device_unregister (waits for external
+        get_device() refs to drop).
+     d. Removes from ctx->list; wakes remove_wait.
+
+Post-condition: pxd_dev fully unregistered; kfree happens after the
+last put_device.
+
+Deliberate non-behaviour: pxd_finish_remove does NOT touch
+pxd_dev->connected. That flag is a ctx-scope connectivity signal owned
+by _pxd_setup / freeze windows; removal is a device-lifecycle event and
+should not race the ctx state machine.
+
+
+### 1.3 Fastpath IO error -> pxd_io_failover
+
+Trigger: fastpath IO error on the backing device (fp_handle_io error
+path calls pxd_failover_initiate).
+
+Flow (pxd_bio_blkmq.c pxd_io_failover):
+  Entry check: if READ_ONCE(ctx->fp_freeze) is set, park the fproot on
+  pxd_dev->fp.failQ under fp.fail_lock and return. See invariant 2.
+
+  Otherwise, four-way branch on state:
+    (a) !pxd_dev->connected                : hard-fail with -EIO
+    (b) !ctx->fc.connected                 : disableFastPath(skip_sync=
+                                             true), reroute to slowpath
+                                             via pxdmq_reroute_slowpath
+    (c) both connected                     : list_add to failQ,
+                                             pxd_initiate_failover
+                                             (coordinated switch)
+    (fallback) pxd_initiate_failover fails : __pxd_abortfailQ
+
+Branches (a) and (c) do not need the freeze because the state they read
+was mutated inside a completed freeze window (invariant 1). Branch (b)
+calls disableFastPath which is concurrency-safe on its own (see 1.7).
+
+
+### 1.4 Control fd close (userspace exits or crashes)
+
+Trigger: last close() of /dev/pxd/pxd-control-N.
+
+Flow (pxd.c pxd_control_release):
+  1. Under ctx->lock: WRITE_ONCE(fc.connected, 0). Order matters -
+     see invariant 6.
+  2. schedule_delayed_work(&ctx->abort_work, pxd_timeout_secs * HZ).
+     This is the backstop that fires if userspace never reopens.
+  3. schedule_work(&ctx->failover_work). Runs async.
+
+pxd_failover_work (async):
+  1. pxd_fp_freeze_start(ctx).
+  2. pxdctx_reset_fastpath(ctx, fail_io=false). For each device on
+     ctx->list: snap+refcount, flush_work(remove_work), skip if
+     removing, otherwise pxd_fastpath_reset_device(skip_sync=true,
+     fail_io=false).
+  3. pxd_fp_freeze_end(ctx, fail_io=false). Drains any pxd_io_failover
+     items that parked between step 2's failQ drain and the gate clear,
+     reissuing them to native via pxd_reissuefailQ(status=0).
+
+Post-condition: every fastpath device on this ctx is on the native
+path. Requests already queued in fc->pending / fc->processing remain
+queued (they'll be handled on reopen or aborted at T + pxd_timeout_secs).
+
+
+### 1.5 Control fd open (userspace reconnects)
+
+Trigger: open() of /dev/pxd/pxd-control-N.
+
+Flow (pxd.c pxd_control_open):
+  1. Access control: comm-name whitelist (px-storage, pxd, pxd_test,
+     etc.).
+  2. Refuse if fc.connected == 1 already (double-open).
+  3. cancel_delayed_work_sync(&ctx->abort_work) - cancels the backstop
+     if it hasn't fired.
+  4. flush_work(&ctx->failover_work) - waits for a failover_work that
+     was scheduled by a prior close() to complete.
+  5. fuse_restart_requests(fc) - re-queues requests that were in
+     flight when the fd closed.
+  6. pxd_fp_freeze_start(ctx).
+  7. Under ctx->lock: reset pxd_timeout_secs, WRITE_ONCE(fc.connected,
+     1), WRITE_ONCE(fc.allow_disconnected, 1).
+  8. pxdctx_set_connected(ctx) - iterates devices, _pxd_setup(true)
+     under pxd_dev->lock, sets pxd_dev->connected = true for each.
+  9. pxd_fp_freeze_end(ctx, fail_io=false). Any pxd_io_failover items
+     that parked during the reopen get reissued to native (userspace
+     is now up, they'll be serviced through the fuse queue).
+
+Post-condition: fc.connected = 1, allow_disconnected = 1, every
+non-removing device on ctx->list has connected = true, no parked items
+on failQ.
+
+
+### 1.6 Abort timeout
+
+Trigger: ctx->abort_work fires (T + pxd_timeout_secs after
+pxd_control_release, if pxd_control_open didn't cancel it).
+
+Flow (pxd.c pxd_abort_context):
+  1. BUG_ON(fc.connected)  - abort must not fire while connected.
+  2. WRITE_ONCE(fc.allow_disconnected, 0).
+  3. synchronize_rcu() - waits for readers of allow_disconnected to
+     exit their rcu_read_lock sections (dev.c fuse_request_send_nowait).
+  4. Under fc->lock: fuse_end_queued_requests(fc). Walks
+     fc->pending and fc->processing, ends each request with
+     -ECONNABORTED via req->end (pxd_process_write/read_reply_q ->
+     blk_mq_end_request).
+  5. pxd_fp_freeze_start(ctx).
+  6. pxdctx_reset_fastpath(ctx, fail_io=true). Same iteration as 1.4
+     but _pxd_setup(false) clears pxd_dev->connected and
+     __pxd_abortfailQ aborts every leftover failQ entry with -EIO.
+  7. pxd_fp_freeze_end(ctx, fail_io=true). Aborts stragglers with
+     -EIO (matching the hard-fail semantic).
+
+Post-condition: every request that was in flight is completed with
+error; every pxd_dev on this ctx has connected = false; the pxd_dev
+records still exist but reject new IO at pxd_open (returns -ENXIO).
+
+
+### 1.7 disableFastPath (per-device fastpath teardown)
+
+Trigger: called from many sites - pxdctx_reset_fastpath, pxd_io_failover
+branch (b), pxd_finish_remove, pxd_fastpath_vol_cleanup,
+pxd_debug_switch_nativepath, pxd_init_fastpath_target's error unwind.
+
+Flow (pxd_fastpath.c disableFastPath):
+  1. If fastpath was never enabled or nfd == 0: normalize state and
+     return.
+  2. prev = xchg(&fp->fastpath, false). See invariant 3.
+     If prev == false, another caller is already handling the disable
+     (or has finished); return immediately.
+  3. Winner path:
+     a. pxd_suspend_io(pxd_dev) - freezes blk_mq queue and waits for
+        in-flight requests to drain.
+     b. synchronize_rcu() - waits for existing rcu_read_lock readers of
+        fp->fastpath (from pxd_queue_rq) to finish.
+     c. fastpath_flush_work() - drains fastpath kthread workers
+        excluding the current one (see invariant 4).
+     d. Optional wait_for_sync.
+     e. For each slot i in [0, MAX_PXD_BACKING_DEVS):
+          f = xchg(&fp->file[i], NULL);
+          if (f) filp_close(f, NULL);
+        Only the caller that xchg's out a non-NULL pointer closes it.
+        No double-close.
+     f. fp->nfd = 0. pxd_resume_io.
+
+Post-condition: fp->fastpath = false, all backing files closed, all
+slots NULL, blk_mq queue accepting new IO through the native path.
+
+
+## Part 2. Concurrent operations and invariants
+
+The invariants are what makes the flows in Part 1 compose safely.
+
+
+### Invariant 1 - state-mutation lives inside a freeze window
+
+Every write to a decision-carrying state variable
+  pxd_dev->connected
+  pxd_dev->fp.fastpath (true -> false)
+  ctx->fc.connected
+runs inside a matched pxd_fp_freeze_start / pxd_fp_freeze_end pair.
+
+Exceptions and why they're safe:
+  - pxd_add's plain init writes (pxd_dev->connected = true,
+    pxd_dev->fastpath = ...): the device is not on ctx->list yet, no
+    reader can find it.
+  - enableFastPath sets fp->fastpath = true. It's called from
+    pxd_init_fastpath_target which runs from an ioctl path serialized
+    by userspace attach ordering; concurrent enableFastPath/
+    disableFastPath doesn't happen in practice.
+  - fc.connected 1 -> 0 in pxd_control_release is written under
+    ctx->lock BEFORE the freeze is scheduled (see invariant 6).
+
+Corollary: a reader (pxd_io_failover) that observes any of these
+variables outside a freeze window sees fully post-transition state;
+inside a freeze window it parks.
+
+
+### Invariant 2 - pxd_io_failover parks on failQ during freeze
+
+pxd_io_failover checks READ_ONCE(ctx->fp_freeze) at entry. If set, it
+takes fp.fail_lock, re-checks the gate, and list_add_tail's the fproot
+on pxd_dev->fp.failQ.
+
+Rationale: the reader must NOT commit to a branch decision while state
+is transient. Parking on failQ is preferable to hard-failing because
+the ctx-teardown code drains failQ in a mode appropriate to the
+transition:
+  - failover_work path (fail_io=false): pxd_reissuefailQ(status=0) ->
+    native
+  - abort_work path   (fail_io=true) : __pxd_abortfailQ -> -EIO
+
+Freeze_end has a second-pass drain to catch items parked between
+pxdctx_reset_fastpath's initial drain and the gate-clear.
+
+Note fproot->wait linkage is shared with branch (c). A single fproot is
+either parked-during-freeze or on-failQ-via-branch-(c), never both,
+because the gate check runs first and returns on park.
+
+
+### Invariant 3 - disableFastPath is single-owner via xchg, no locks
+
+Multiple callers reach disableFastPath simultaneously (documented in
+1.7). Ownership is arbitrated by:
+
+  prev = xchg(&fp->fastpath, false);
+  if (!prev) return;
+
+Exactly one caller sees prev = true and executes the suspend / RCU /
+flush / file-close sequence. Every other caller returns immediately
+having observed fp->fastpath = false (which is the only post-condition
+callers need).
+
+Files are closed with a matching xchg:
+
+  struct file *f = xchg(&fp->file[i], NULL);
+  if (f) filp_close(f, NULL);
+
+Even if a caller sneaks past the ownership gate through a
+manufactured race, only the one who xchg's out the non-NULL pointer
+closes it. No double-close reachable.
+
+Locks are deliberately NOT used here. A mutex around disableFastPath
+would deadlock: caller A holds mutex and blocks in pxd_suspend_io
+waiting for the blk_mq freeze counter to hit zero; caller B on a
+fastpath worker holds an rq ref (via pxd_io_failover) and blocks
+trying to take the mutex; circular wait.
+
+xchg is atomic, full-barrier, and arch-agnostic (defined by every arch
+Linux supports via asm/cmpxchg.h). It works on any word-sized lvalue
+including plain struct pointer fields.
+
+
+### Invariant 4 - fastpath_flush_work never self-flushes
+
+fastpath_flush_work iterates every pxfp kthread_worker and calls
+kthread_flush_worker on each. If invoked from within a work item
+running on one of those very workers, self-flush would deadlock:
+kthread_flush_worker enqueues a barrier and wait_for_completion's on
+it; the barrier can only run after the current work returns; the
+current work can only return after the completion fires.
+
+Fix: skip the worker whose ->task == current. This surfaces on the
+branch (b) path (pxd_io_failover -> disableFastPath ->
+fastpath_flush_work) but the fix is universal.
+
+Consequence: work items queued on the current worker AFTER the current
+one are not drained by this flush. That's acceptable because
+kthread_worker is single-threaded per worker - those items don't run
+until we return, by which time all file slots have been xchg'd to
+NULL and any dereferencer must handle NULL.
+
+
+### Invariant 5 - list iteration snapshots devices with get_device
+
+pxdctx_reset_fastpath (and pxd_fp_freeze_end's drain) never dereferences
+pxd_dev while holding ctx->lock across a sleeping call. Pattern:
+
+  1. Under ctx->lock, count and allocate snap_list; walk ctx->list;
+     bounds-check first, removing-check next, get_device last; store
+     into snap_list.
+  2. Release ctx->lock.
+  3. For each snap: flush_work(remove_work) to wait for any in-flight
+     pxd_finish_remove; re-check removing; process; put_device.
+
+flush_work on remove_work is always safe because INIT_WORK is done in
+pxd_add (not deferred to pxd_remove_dev), so the work_struct is never
+uninitialised memory.
+
+Removing is checked twice: once under ctx->lock (bail without ref) and
+once after flush_work (bail with put_device). This prevents any window
+where we mutate a device that is being removed.
+
+
+### Invariant 6 - fc.connected transitions before failover_work is scheduled
+
+pxd_control_release ordering:
+
+  spin_lock(&ctx->lock);
+  WRITE_ONCE(fc.connected, 0);
+  schedule_delayed_work(&abort_work, ...);
+  spin_unlock(&ctx->lock);
+  schedule_work(&failover_work);
+
+pxd_failover_work's invariant is WARN_ON_ONCE(fc.connected). If we
+scheduled the work before the write, a kworker could pick it up in the
+tiny window and observe fc.connected == 1. Doing the write first
+closes that race by construction.
+
+pxd_control_open's write (fc.connected 0 -> 1) is inside its own
+freeze window, so pxd_io_failover racing the reconnect parks on failQ
+and is reissued to native at freeze_end.
+
+
+### What is NOT protected by the freeze
+
+These are managed by their own mechanisms; the freeze protocol does not
+apply:
+
+  - pxd_dev->exported, pxd_dev->removing, pxd_dev->open_count:
+    pxd_dev->lock (spinlock). Their transitions don't affect
+    fastpath IO branch decisions.
+  - ctx->fc.allow_disconnected: FUSE's own RCU. Writers pair
+    WRITE_ONCE with synchronize_rcu; readers pair READ_ONCE with
+    rcu_read_lock (dev.c fuse_request_send_nowait).
+  - pxd_dev->fp.fastpath false -> true (enableFastPath): userspace
+    serializes attach; no concurrent racers observed.
+  - Fastpath IO's own bio submission (fp_handle_io): natively serial
+    per rq, protected by blk_mq freeze during teardown via
+    pxd_suspend_io.
+
+
+## Part 3. Named concurrent scenarios and how the invariants keep them safe
+
+### A. Fastpath IO error during failover_work
+
+Timeline:
+  T0: continuous fastpath IO to failing range triggers pxd_io_failover
+      work items on kthread workers.
+  T1: userspace close(ctl_fd) -> pxd_control_release:
+      fc.connected=0; schedule failover_work.
+  T2: failover_work runs freeze_start: fp_freeze=1, flushes kthread
+      workers (drains items queued before T1).
+  T3: freeze_start returns. pxdctx_reset_fastpath switches each device
+      to native and drains failQ.
+  T4: freeze_end drains any items parked between T3 and T4, reissuing
+      them to native.
+
+pxd_io_failover items queued after T2 see fp_freeze=1, park. Never
+observe mid-transition state. Never hard-fail during a transition
+that would otherwise legitimately re-route them.
+
+
+### B. Detach concurrent with control fd close
+
+Timeline:
+  Thread A: close(ctl_fd)                 -> pxd_control_release
+  Thread B: PXD_IOC_DETACH_DEVICE ioctl   -> pxd_remove_dev
+
+pxd_remove_dev sets removing=true under lock and schedules remove_work
+(which will run pxd_finish_remove). pxd_control_release schedules
+failover_work.
+
+Both work items run async. failover_work's pxdctx_reset_fastpath
+iterates ctx->list. For the racing device:
+  - If removing was already true when snap_list was built: skip the
+    device entirely (no ref taken, no work done on it).
+  - Otherwise: get_device, snap. Then outside ctx->lock,
+    flush_work(remove_work) waits for pxd_finish_remove to finish (if
+    it's already running or scheduled). After flush_work returns,
+    re-check removing: if true (pxd_finish_remove ran), skip. Otherwise
+    do the reset.
+
+pxd_finish_remove's own pxd_fastpath_reset_device -> disableFastPath is
+concurrency-safe (invariant 3) against a possible concurrent
+disableFastPath from failover_work or pxd_io_failover branch (b).
+
+
+### C. Rapid close+reopen while fastpath IO is failing
+
+Timeline:
+  T0: close(ctl_fd)                       -> schedule failover_work
+  T1: open(ctl_fd)                        -> pxd_control_open
+      - cancel_delayed_work_sync(abort_work)
+      - flush_work(failover_work)         [waits for T0's work]
+      - freeze_start; state writes;
+        pxdctx_set_connected; freeze_end
+  T2: close(ctl_fd) again                 -> new failover_work
+  ...
+
+flush_work at T1 ensures the previous freeze cycle has fully completed
+before pxd_control_open enters its own freeze cycle. Two freeze cycles
+never overlap on the same ctx. pxd_io_failover items racing either
+freeze park on failQ and get reissued to native at the appropriate
+freeze_end.
+
+
+### D. Detach with active ioswitch (coordinated failover in flight)
+
+Timeline:
+  T0: fastpath IO error -> pxd_io_failover branch (c) adds fproot to
+      failQ, calls pxd_initiate_failover which sends a fuse switch
+      request. Waits for PX ack via req->end callback.
+  T1: PXD_REMOVE arrives. pxd_remove_dev sets removing, schedules
+      remove_work.
+  T2: pxd_finish_remove runs pxd_fastpath_reset_device. That function
+      handles an active ioswitch: overrides the switch req to
+      PXD_FAILOVER_TO_USERSPACE with error -EIO and request_end's it,
+      which triggers pxd_process_ioswitch_complete to fail the failQ
+      IOs.
+  T3: __pxd_abortfailQ (defensive backstop inside
+      pxd_fastpath_reset_device) drains any leftover failQ entries.
+
+The in-flight ioswitch is resolved to error; failover doesn't complete
+to userspace but the driver reaches a consistent state. Device removal
+proceeds normally.
+
+
+## Part 4. Design contract
+
+The invariants in Part 2 are contracts that specific classes of code
+must uphold. Below is the contract stated in terms of design behaviour,
+independent of any particular call site.
+
+
+### 4.1 Writer contract for decision-carrying state
+
+Decision-carrying state fields:
+  pxd_dev->connected
+  pxd_dev->fp.fastpath  (true -> false transitions)
+  ctx->fc.connected
+
+Contract:
+  Any write to a decision-carrying field executes inside a matched
+  pxd_fp_freeze_start / pxd_fp_freeze_end pair on the same ctx. The
+  write itself uses WRITE_ONCE.
+
+Implication:
+  A decision-carrying field is either fully-pre-transition or
+  fully-post-transition from the perspective of any reader that is not
+  currently parked. There is no observable intermediate value.
+
+Exceptions permitted:
+  1. Initialising writes performed before the object is discoverable
+     (e.g. pxd_add sets pxd_dev->connected = true before the device
+     is added to ctx->list).
+  2. Writes that are irrelevant to fastpath IO branching (e.g.
+     enableFastPath sets fp.fastpath = true; this transitions the
+     device INTO a state where reads become meaningful, so no reader
+     has yet committed to an obsolete value).
+  3. Writes serialised by a stronger mechanism the freeze protocol
+     defers to (e.g. FUSE's own RCU protocol around
+     fc->allow_disconnected).
+
+
+### 4.2 Reader contract for branch decisions
+
+Definition: a branch-decision reader is any code that reads one or
+more decision-carrying fields and dispatches based on their values.
+pxd_io_failover is the canonical example.
+
+Contract:
+  Before observing any decision-carrying field, the reader observes
+  ctx->fp_freeze via READ_ONCE. If the gate is set, the reader parks
+  the work item on the device's pxd_dev->fp.failQ under fp.fail_lock,
+  re-checks the gate under the same lock, and returns without
+  branching. The gate check under lock is required to prevent the
+  freeze-end drain from missing an item that was mid-park.
+
+Implication:
+  A branch-decision reader never observes a mid-transition value.
+  Every observation is either fully-pre-transition (started before
+  freeze_start's flush) or fully-post-transition (parked, then
+  drained by pxdctx_reset_fastpath or freeze_end).
+
+The failQ linkage (fproot->wait) is shared between the park path and
+branch (c). A single fproot is on the list for exactly one reason at
+a time; the gate check ordering (park path runs before branch
+selection) enforces this.
+
+
+### 4.3 Concurrency contract for disableFastPath
+
+Contract:
+  disableFastPath is safe under arbitrary concurrent invocation on
+  the same pxd_dev. Ownership is arbitrated by xchg on fp->fastpath.
+  Exactly one caller executes the suspend / RCU / flush / file-close
+  sequence per transition; all other callers observe the transition
+  as already complete on return.
+
+  Backing file slots (fp->file[i]) are claimed by xchg to NULL. A
+  file is closed exactly once, by the caller that xchg's the
+  non-NULL pointer out.
+
+Implication:
+  New call sites for disableFastPath require no additional
+  serialisation. Locks around the call would be actively harmful,
+  because disableFastPath calls pxd_suspend_io which waits on the
+  blk_mq freeze counter; any lock held across that wait risks
+  circular wait with a fastpath work item that holds an rq ref and
+  is itself trying to enter disableFastPath.
+
+
+### 4.4 Self-flush contract for fastpath_flush_work
+
+Contract:
+  fastpath_flush_work is safe to call from any context, including
+  from within a fastpath kthread_worker's work function. When called
+  from a fastpath worker, that worker is not itself flushed; only
+  peer workers are drained.
+
+Implication:
+  Any code path that reaches fastpath_flush_work (directly or via
+  disableFastPath) can be reached from a fastpath work item without
+  causing self-deadlock. The follow-up work queued after the current
+  work item on the same worker is not drained by this call, but the
+  code that follows fastpath_flush_work (e.g. the file-close loop in
+  disableFastPath) must be robust against that follow-up work
+  observing NULL file slots after the xchg clears them.
+
+
+### 4.5 Iteration contract for ctx->list
+
+Contract:
+  Iteration over ctx->list that performs any operation which may
+  sleep, allocate, or synchronise with other subsystems on a per-
+  device basis executes as: (i) snapshot device pointers under
+  ctx->lock with get_device, (ii) drop ctx->lock, (iii) process each
+  snap entry outside ctx->lock, (iv) put_device on each snap. During
+  the snapshot pass, bounds checks precede removing checks precede
+  get_device so that a partial iteration does not leak references.
+
+Implication:
+  Per-device operations may sleep (pxd_suspend_io, disableFastPath,
+  pxd_reissuefailQ) without holding ctx->lock. Concurrent add / remove
+  of unrelated devices on the same ctx is safe. A device that begins
+  removal after the snapshot is captured is caught by the second
+  removing check under flush_work(remove_work) and skipped.
+
+
+### 4.6 Scheduling ordering contract for failover_work
+
+Contract:
+  pxd_control_release writes fc->connected = 0 before it schedules
+  failover_work. Any workqueue worker that picks up failover_work
+  observes fc->connected == 0 on entry. pxd_failover_work asserts
+  this with WARN_ON_ONCE.
+
+Implication:
+  Code that examines fc->connected inside pxd_failover_work may rely
+  on the value being 0. Similarly for pxd_abort_context.
+
+
+### 4.7 Drain paths for queued fuse requests
+
+Two drain paths exist for IO that landed on the fuse slow path (via
+pxd_io_failover branch (b) or pxd_reissuefailQ) while userspace was
+disconnected:
+
+  Path 1 (abort backstop):
+    At T + pxd_timeout_secs after close, abort_work runs
+    fuse_end_queued_requests. Every request on fc->pending or
+    fc->processing is ended with -ECONNABORTED. The block layer
+    completes waiting IO submitters.
+
+  Path 2 (userspace reconnect and drain):
+    pxd_control_open calls fuse_restart_requests, which moves
+    requests from fc->processing back to fc->pending. Userspace
+    subsequently reads ctl_fd, receives each request, and responds
+    (with success or error). The block layer completes IO submitters
+    based on the response.
+
+Implication:
+  Callers that queue IO on the fuse slow path do not need a private
+  timeout. Either the userspace reconnect (nominal case) or
+  abort_work (backstop) will unblock any waiter. Test code that
+  wants deterministic termination sets pxd_timeout_secs to the
+  driver minimum (30s) so path 1 activates quickly.
+
+
+### 4.8 Lifecycle contract for pxd_dev
+
+Contract:
+  pxd_dev remains addressable to any code path that took get_device
+  on it, until that code path calls put_device. pxd_finish_remove
+  runs pxd_fastpath_reset_device to normalise per-device state
+  (fp.fastpath, failQ, backing files) but does not modify ctx-scope
+  connectivity fields (pxd_dev->connected). The final put_device
+  from device_unregister waits for all outstanding refs before the
+  pxd_dev is kfreed.
+
+Implication:
+  Removal is orthogonal to ctx connectivity. Concurrent transitions
+  (control fd close, abort, reopen) do not need to know about
+  in-flight removal; the freeze snap+refcount pattern serialises
+  correctly with pxd_finish_remove via flush_work(remove_work) and
+  the removing check.

--- a/FASTPATH_CONTROL_FLOWS.md
+++ b/FASTPATH_CONTROL_FLOWS.md
@@ -237,9 +237,9 @@ inside a freeze window it parks.
 
 ### Invariant 2 - pxd_io_failover parks on failQ during freeze
 
-pxd_io_failover checks READ_ONCE(ctx->fp_freeze) at entry. If set, it
-takes fp.fail_lock, re-checks the gate, and list_add_tail's the fproot
-on pxd_dev->fp.failQ.
+pxd_io_failover checks the gate at entry with smp_load_acquire. If set,
+it takes fp.fail_lock, re-checks the gate under the lock, and
+list_add_tail's the fproot on pxd_dev->fp.failQ.
 
 Rationale: the reader must NOT commit to a branch decision while state
 is transient. Parking on failQ is preferable to hard-failing because
@@ -251,6 +251,26 @@ transition:
 
 Freeze_end has a second-pass drain to catch items parked between
 pxdctx_reset_fastpath's initial drain and the gate-clear.
+
+Memory ordering:
+  Writer side (pxd_fp_freeze_start / pxd_fp_freeze_end) uses
+  smp_store_release on the gate. All state stores performed inside the
+  freeze window are visible before the gate transition.
+
+  Reader side (pxd_io_failover) uses smp_load_acquire on the outer
+  gate check. If the reader observes gate=0, it also observes every
+  state store the writer released before the gate; the subsequent
+  plain READ_ONCE reads of pxd_dev->connected and ctx->fc.connected
+  cannot observe a mid-transition value. On x86 the acquire/release
+  compile to the same instructions as READ_ONCE/WRITE_ONCE; on arm64
+  they emit ldar/stlr; on ppc, lwsync-wrapped std/ld. Plain
+  WRITE_ONCE/READ_ONCE alone is insufficient on weak archs because
+  the CPU can reorder the subsequent state loads before the gate load.
+
+The inner re-check under fp.fail_lock uses plain READ_ONCE because
+spin_lock is a full barrier on all Linux archs; it provides an
+implicit acquire against anything the writer released before its own
+fail_lock acquire in the drain loop.
 
 Note fproot->wait linkage is shared with branch (c). A single fproot is
 either parked-during-freeze or on-failQ-via-branch-(c), never both,

--- a/pxd.c
+++ b/pxd.c
@@ -1462,8 +1462,16 @@ static void pxd_finish_remove(struct work_struct *work)
 	 * consumers (snap_list captures in a freeze window, sysfs opens,
 	 * in-flight IO). Those consumers make their own decisions based on
 	 * whatever ctx-level state exists at the time; the removal path
-	 * shouldn't second-guess them. */
-	pxd_fastpath_reset_device(pxd_dev, true /* skip sync */, true /* fail io */);
+	 * shouldn't second-guess them.
+	 *
+	 * skip_sync=false: PXD_REMOVE is the user-driven happy-path detach.
+	 * The backing fds we own may hold dirty page-cache pages / pending
+	 * writeback the user cared about (they issued IO that we accepted).
+	 * wait_for_sync() calls vfs_fsync() on each fp->file[i] directly -
+	 * it does NOT go through userspace or fc, so it is safe here.
+	 * We skip sync only for broken/error/decommission paths (see the
+	 * comment header on pxd_fastpath_reset_device). */
+	pxd_fastpath_reset_device(pxd_dev, false /* skip sync */, true /* fail io */);
 
 	/* Make sure the req_fn isn't called anymore even if the device hangs around */
 	if (pxd_dev->disk && pxd_dev->disk->queue){
@@ -1693,6 +1701,13 @@ static void _pxd_setup(struct pxd_device *pxd_dev, bool enable)
 		spin_lock(&pxd_dev->lock);
 		WRITE_ONCE(pxd_dev->connected, false);
 		spin_unlock(&pxd_dev->lock);
+		/* Only reached from the hard-fail path (pxd_abort_context via
+		 * pxdctx_reset_fastpath fail_io=true). skip_sync=true because
+		 * we are aborting all in-flight IO with -EIO; persisting the
+		 * driver's backing-fd cache first is not the point of the
+		 * operation. This is rule (b) from disableFastPath's contract:
+		 * hard-fail teardown. It is NOT because userspace is gone -
+		 * wait_for_sync is driver-local and never talks to userspace. */
 		pxd_fastpath_reset_device(pxd_dev, true /* skip sync */, true /* fail io */);
 	} else {
 		printk(KERN_NOTICE "device %llu called to enable IO\n", pxd_dev->dev_id);
@@ -1719,11 +1734,14 @@ static void pxdctx_set_connected(struct pxd_context *ctx)
 //
 // Called from two places:
 //   1. failover_work (fail_io=false): control fd just closed. Switch each
-//      fastpath device to native path and reissue queued failQ IOs. Uses
-//      skip_sync=true because userspace is already gone and wait_for_sync
-//      would hang.
+//      fastpath device to native path and reissue queued failQ IOs.
+//      Uses skip_sync=false (see the skip_sync policy comment inside
+//      this function): backing store is healthy, its writes must be
+//      flushed before the fd is closed.
 //   2. abort_work   (fail_io=true):  abort timer expired. Hard-fail every
-//      IO on every device (connected := false; abortfailQ).
+//      IO on every device (connected := false; abortfailQ). Uses
+//      skip_sync=true: hard-fail teardown, syncing before aborting is
+//      pointless.
 //
 // Snapshot+refcount pattern: pxd_fastpath_reset_device may sleep
 // (blk_mq_quiesce_queue via pxd_suspend_io), so ctx->lock must be dropped
@@ -1735,9 +1753,32 @@ static void pxdctx_reset_fastpath(struct pxd_context *ctx, bool fail_io)
 	struct pxd_device *pxd_dev;
 	size_t i = 0;
 	size_t j;
-	/* Sync-and-fail semantics: failover_work path must not wait for sync
-	 * (userspace is gone). Abort path can (and should) skip sync too. */
-	const bool skip_sync = true;
+	/* skip_sync policy inside pxdctx_reset_fastpath:
+	 *
+	 * skip_sync controls whether disableFastPath does a vfs_fsync() on
+	 * each backing fd (fp->file[i]) before closing it. The sync is
+	 * DRIVER-LOCAL - it goes through the vfs directly on files the
+	 * driver owns; it does NOT depend on ctx->fc.connected or userspace
+	 * being alive. Whether it can hang depends only on the backing
+	 * filesystem/device servicing the fsync.
+	 *
+	 * Rule: skip sync only when the sync would be meaningless -
+	 *   (a) backing storage is broken (fastpath IO already errored out)
+	 *   (b) hard-fail teardown - we are aborting every in-flight IO
+	 *       with -EIO, so persisting the driver's private cache first
+	 *       is not the point of the operation
+	 *   (c) whole-node decommission (pxd_nodewipe_cleanup)
+	 * In every other case we must sync so writes that userspace already
+	 * confirmed as accepted are durable on the backing store before we
+	 * drop our reference to it.
+	 *
+	 * Inside this function:
+	 *   fail_io=true  (from abort_work): rule (b). skip_sync=true.
+	 *   fail_io=false (from failover_work): soft mode switch from
+	 *     fastpath to native; backing store is still healthy and its
+	 *     writes must survive the switch. skip_sync=false.
+	 */
+	const bool skip_sync = fail_io;
 
 	// _pxd_setup with enable=false would call pxd_fastpath_reset_device which would
 	// call blk_mq_quiesce_queue as part of pxd_suspend_io. but blk_mq_quiesce_queue could

--- a/pxd.c
+++ b/pxd.c
@@ -87,6 +87,7 @@ module_param(pxd_detect_zero_writes, uint, 0644);
 module_param(pxd_num_fpthreads, uint, 0644);
 
 static void pxd_abort_context(struct work_struct *work);
+static void pxd_finish_remove(struct work_struct *work);
 static int pxd_nodewipe_cleanup(struct pxd_context *ctx);
 static int pxd_bus_add_dev(struct pxd_device *pxd_dev);
 static ssize_t pxd_remove_dev(struct fuse_conn *fc, uint64_t dev_id, bool force);
@@ -703,7 +704,7 @@ bool pxd_process_ioswitch_complete(struct fuse_conn *fc, struct fuse_req *req,
 		spin_unlock_irqrestore(&pxd_dev->fp.fail_lock, flags);
 	}
 
-	pxd_request_resume_internal(pxd_dev);
+	pxd_resume_io(pxd_dev);
 
 	// status=0 -> reroute to slowpath; non-zero -> -EIO. No-op for FALLBACK.
 	pxd_reissuefailQ(pxd_dev, &ios, status);
@@ -784,18 +785,19 @@ int pxd_initiate_failover(struct pxd_device *pxd_dev)
 		return 0;
 	}
 
-	rc = pxd_request_suspend_internal(pxd_dev, false, true);
-	if (rc) {
-		atomic_set(&pxd_dev->fp.ioswitch_active, 0);
-		return rc;
+	pxd_suspend_io(pxd_dev);
+	rc = wait_for_sync(pxd_dev, false);
+	if (unlikely(rc) && rc != -EINVAL && rc != -EIO) {
+		printk(KERN_ERR"device %llu sync failed %d, continuing with disable\n",
+				pxd_dev->dev_id, rc);
 	}
 
 	rc = pxd_initiate_ioswitch(pxd_dev, PXD_FAILOVER_TO_USERSPACE);
 	if (rc) {
-		// _internal pairs with pxd_request_suspend_internal above;
+		// _internal pairs with pxd_suspend_io above;
 		// pxd_request_resume() would no-op (app_suspend was never set)
 		// and leak the blk_mq_quiesce.
-		pxd_request_resume_internal(pxd_dev);
+		pxd_resume_io(pxd_dev);
 		atomic_set(&pxd_dev->fp.ioswitch_active, 0);
 		return rc;
 	}
@@ -834,15 +836,11 @@ int pxd_initiate_fallback(struct pxd_device *pxd_dev)
 
 	trace_pxd_initiate_fallback(pxd_dev->dev_id, pxd_dev->minor);
 
-	rc = pxd_request_suspend_internal(pxd_dev, true, false);
-	if (rc) {
-		atomic_set(&pxd_dev->fp.ioswitch_active, 0);
-		return rc;
-	}
+	pxd_suspend_io(pxd_dev);
 
 	rc = pxd_initiate_ioswitch(pxd_dev, PXD_FALLBACK_TO_KERNEL);
 	if (rc) {
-		pxd_request_resume_internal(pxd_dev);
+		pxd_resume_io(pxd_dev);
 		atomic_set(&pxd_dev->fp.ioswitch_active, 0);
 	}
 	return rc;
@@ -1298,6 +1296,11 @@ ssize_t pxd_add(struct fuse_conn *fc, struct pxd_add_v2_out *add)
 	pxd_dev->size = add->size;
 	pxd_dev->mode = add->open_mode;
 	pxd_dev->fastpath = add->enable_fp;
+	/* Initialize remove_work up-front so pxdctx_reset_fastpath can safely
+	 * call flush_work() on any device in the list, whether or not remove
+	 * has ever been scheduled. Zero-initialised work_struct is UB with
+	 * flush_work on lockdep-enabled kernels. */
+	INIT_WORK(&pxd_dev->remove_work, pxd_finish_remove);
 
 	// congestion init
 	init_waitqueue_head(&pxd_dev->suspend_wq);
@@ -1452,7 +1455,15 @@ static void pxd_finish_remove(struct work_struct *work)
 	struct pxd_device *pxd_dev = container_of(work, struct pxd_device, remove_work);
 	pr_info("%s: dev %llu\n", __func__, pxd_dev->dev_id);
 
-	pxd_fastpath_reset_device(pxd_dev);
+	/* Do NOT touch pxd_dev->connected here. That flag is a ctx-scope
+	 * connectivity signal (owned by _pxd_setup / freeze windows). At this
+	 * point the device is being unregistered from the kernel; pxd_dev is
+	 * kept alive only by outstanding get_device() refs from concurrent
+	 * consumers (snap_list captures in a freeze window, sysfs opens,
+	 * in-flight IO). Those consumers make their own decisions based on
+	 * whatever ctx-level state exists at the time; the removal path
+	 * shouldn't second-guess them. */
+	pxd_fastpath_reset_device(pxd_dev, true /* skip sync */, true /* fail io */);
 
 	/* Make sure the req_fn isn't called anymore even if the device hangs around */
 	if (pxd_dev->disk && pxd_dev->disk->queue){
@@ -1521,13 +1532,11 @@ static ssize_t pxd_remove_dev(struct fuse_conn *fc, uint64_t dev_id, bool force)
 	}
 
 	if (!pxd_dev->removing) {
-		if (atomic_cmpxchg(&pxd_dev->fp.ioswitch_active, 1, 0) != 0) {
-			printk(KERN_ERR "device %llu detach: failed to acquire ioswitch_active\n", pxd_dev->dev_id);
-			err = -EBUSY;
-			goto out_lock;
-		}
-		pxd_dev->removing = true;
-		INIT_WORK(&pxd_dev->remove_work, pxd_finish_remove);
+		/* removing is written under pxd_dev->lock (held here) and read
+		 * lock-free elsewhere; use WRITE_ONCE to match those readers. */
+		WRITE_ONCE(pxd_dev->removing, true);
+		/* remove_work is INIT_WORK'd once in pxd_add so pxdctx_reset_fastpath
+		 * can safely flush_work it before removal is ever scheduled. */
 		schedule_work(&pxd_dev->remove_work);
 	}
 	get_device(&pxd_dev->dev);
@@ -1682,36 +1691,53 @@ static void _pxd_setup(struct pxd_device *pxd_dev, bool enable)
 	if (!enable) {
 		printk(KERN_NOTICE "device %llu called to disable IO\n", pxd_dev->dev_id);
 		spin_lock(&pxd_dev->lock);
-		pxd_dev->connected = false;
+		WRITE_ONCE(pxd_dev->connected, false);
 		spin_unlock(&pxd_dev->lock);
-		pxd_fastpath_reset_device(pxd_dev);
+		pxd_fastpath_reset_device(pxd_dev, true /* skip sync */, true /* fail io */);
 	} else {
 		printk(KERN_NOTICE "device %llu called to enable IO\n", pxd_dev->dev_id);
 		spin_lock(&pxd_dev->lock);
-		pxd_dev->connected = true;
+		WRITE_ONCE(pxd_dev->connected, true);
 		spin_unlock(&pxd_dev->lock);
 	}
 }
 
-static void pxdctx_set_connected(struct pxd_context *ctx, bool enable)
+static void pxdctx_set_connected(struct pxd_context *ctx)
 {
 	struct list_head *cur;
+
+	spin_lock(&ctx->lock);
+	list_for_each(cur, &ctx->list) {
+		struct pxd_device *pxd_dev = container_of(cur, struct pxd_device, node);
+
+		_pxd_setup(pxd_dev, true);
+	}
+	spin_unlock(&ctx->lock);
+}
+
+// pxdctx_reset_fastpath - tear down fastpath per device.
+//
+// Called from two places:
+//   1. failover_work (fail_io=false): control fd just closed. Switch each
+//      fastpath device to native path and reissue queued failQ IOs. Uses
+//      skip_sync=true because userspace is already gone and wait_for_sync
+//      would hang.
+//   2. abort_work   (fail_io=true):  abort timer expired. Hard-fail every
+//      IO on every device (connected := false; abortfailQ).
+//
+// Snapshot+refcount pattern: pxd_fastpath_reset_device may sleep
+// (blk_mq_quiesce_queue via pxd_suspend_io), so ctx->lock must be dropped
+// per device. See in-line comments below for the exact steps and races.
+static void pxdctx_reset_fastpath(struct pxd_context *ctx, bool fail_io)
+{
 	size_t ndevs;
 	struct pxd_device **snap_list;
 	struct pxd_device *pxd_dev;
 	size_t i = 0;
 	size_t j;
-
-	if (enable) {
-		spin_lock(&ctx->lock);
-		list_for_each(cur, &ctx->list) {
-			struct pxd_device *pxd_dev = container_of(cur, struct pxd_device, node);
-
-			_pxd_setup(pxd_dev, enable);
-		}
-		spin_unlock(&ctx->lock);
-		return;
-	}
+	/* Sync-and-fail semantics: failover_work path must not wait for sync
+	 * (userspace is gone). Abort path can (and should) skip sync too. */
+	const bool skip_sync = true;
 
 	// _pxd_setup with enable=false would call pxd_fastpath_reset_device which would
 	// call blk_mq_quiesce_queue as part of pxd_suspend_io. but blk_mq_quiesce_queue could
@@ -1720,7 +1746,7 @@ static void pxdctx_set_connected(struct pxd_context *ctx, bool enable)
 	// 1. with ctx->lock held, get the number of entries in ctx->list
 	// 2. without ctx->lock held, allocate memory for the snapshot list
 	// 3. with ctx->lock held, copy the entries from ctx->list to the snapshot list and increment their refcount
-	// 4. without ctx->lock held, call _pxd_setup with enable=false for each entry in the snapshot list 
+	// 4. without ctx->lock held, call _pxd_setup with enable=false for each entry in the snapshot list
 	//    and then decrement their refcount
 	// 5. without ctx->lock held, free the memory allocated in step 2.
 	//
@@ -1745,7 +1771,13 @@ static void pxdctx_set_connected(struct pxd_context *ctx, bool enable)
 	snap_list = kcalloc(ndevs, sizeof(*snap_list), GFP_KERNEL);
 
 	if (snap_list) {
-		// step 3
+		// step 3: snapshot devices under ctx->lock. Order of the three
+		// checks matters:
+		//   a) bounds check FIRST - if ctx->list grew, we skip without
+		//      taking a ref (previous code leaked here).
+		//   b) removing check under ctx->lock but before get_device so
+		//      we don't briefly own a ref for a device we won't touch.
+		//   c) get_device last, exactly matched by put_device in step 4.
 		spin_lock(&ctx->lock);
 		list_for_each_entry(pxd_dev, &ctx->list, node) {
 			if (i >= ndevs) {
@@ -1753,7 +1785,9 @@ static void pxdctx_set_connected(struct pxd_context *ctx, bool enable)
 					pxd_dev->dev_id, pxd_dev->minor);
 				break;
 			}
-			// increment the refcount because of the possibility of parallel pxd_finish_remove
+			if (READ_ONCE(pxd_dev->removing)) {
+				continue;
+			}
 			get_device(&pxd_dev->dev);
 			snap_list[i++] = pxd_dev;
 		}
@@ -1761,10 +1795,26 @@ static void pxdctx_set_connected(struct pxd_context *ctx, bool enable)
 
 		// step 4
 		for (j = 0; j < i; j++) {
-			_pxd_setup(snap_list[j], false);
-			put_device(&snap_list[j]->dev);
-		}
+			struct pxd_device *snap = snap_list[j];
+			/* remove_work is INIT_WORK'd in pxd_add so this is always
+			 * safe, even for devices that never entered removal. If
+			 * removal is in flight, we wait for it here. */
+			flush_work(&snap->remove_work);
 
+			if (READ_ONCE(snap->removing)) {
+				put_device(&snap->dev);
+				continue;
+			}
+
+			if (fail_io) {
+				/* abort_work path - fail all ios */
+				_pxd_setup(snap, false);
+			} else if (fastpath_active(snap)) {
+				/* failover_work path - route io to native */
+				pxd_fastpath_reset_device(snap, skip_sync, false /* fail io */);
+			}
+			put_device(&snap->dev);
+		}
 		// step 5
 		kfree(snap_list);
 		return;
@@ -1772,23 +1822,38 @@ static void pxdctx_set_connected(struct pxd_context *ctx, bool enable)
 
 	// unlikely scenario where kcalloc fails
 	// handle one-by-one, zero allocation but O(n^2)
+	//
+	// Sentinel for "already processed":
+	//   fail_io=true:  picking requires pxd_dev->connected==true; we set
+	//                  it to false while holding pxd_dev->lock so the next
+	//                  iteration skips this device.
+	//   fail_io=false: picking requires fastpath_active(); disableFastPath
+	//                  (inside pxd_fastpath_reset_device) clears
+	//                  fp.fastpath under WRITE_ONCE, so next iteration
+	//                  skips.
 	for (;;) {
 		struct pxd_device *picked = NULL;
 
 		spin_lock(&ctx->lock);
 		list_for_each_entry(pxd_dev, &ctx->list, node) {
-			spin_lock(&pxd_dev->lock);
-			// connected = false => already processed
-			// connected = true => not processed yet
-			if (pxd_dev->connected) {
-				pxd_dev->connected = false;
+			if (fail_io) { /* abort_work path */
+				spin_lock(&pxd_dev->lock);
+				if (READ_ONCE(pxd_dev->connected)) {
+					WRITE_ONCE(pxd_dev->connected, false);
+					spin_unlock(&pxd_dev->lock);
+					get_device(&pxd_dev->dev);
+					picked = pxd_dev;
+					break;
+				}
 				spin_unlock(&pxd_dev->lock);
-				// increment refcount
+				continue;
+			}
+			/* failover_work path: only fastpath devices are of interest */
+			if (fastpath_active(pxd_dev)) {
 				get_device(&pxd_dev->dev);
 				picked = pxd_dev;
 				break;
 			}
-			spin_unlock(&pxd_dev->lock);
 		}
 		spin_unlock(&ctx->lock);
 
@@ -1797,142 +1862,19 @@ static void pxdctx_set_connected(struct pxd_context *ctx, bool enable)
 			break;
 		}
 
-		_pxd_setup(picked, false);
-		// decrement refcount
-		put_device(&picked->dev);
-	}
-}
-
-// pxdctx_reset_fastpath - tear down fastpath per device.
-// Backstop path (pxd_abort_context). Snapshot+refcount because
-// pxd_fastpath_reset_device -> blk_mq_quiesce_queue can sleep, so
-// ctx->lock must be dropped per device. Doesn't touch pxd_dev->connected
-// (allow_disconnected=0 already gates IO at that layer).
-static void pxdctx_reset_fastpath(struct pxd_context *ctx)
-{
-	size_t ndevs;
-	struct pxd_device **snap_list;
-	struct pxd_device *pxd_dev;
-	size_t i = 0;
-	size_t j;
-
-	// step 1: count entries under ctx->lock
-	spin_lock(&ctx->lock);
-	ndevs = ctx->num_devices;
-	spin_unlock(&ctx->lock);
-
-	// step 2: allocate snapshot list (may sleep, not under lock)
-	snap_list = kcalloc(ndevs, sizeof(*snap_list), GFP_KERNEL);
-
-	if (snap_list) {
-		// step 3: fill snapshot with refcounted device pointers
-		spin_lock(&ctx->lock);
-		list_for_each_entry(pxd_dev, &ctx->list, node) {
-			if (i >= ndevs) {
-				pr_warn("%s: ctx->list has more entries than snap_list, ignoring extra entries, devID : %llu minor %d\n",
-					__func__, pxd_dev->dev_id, pxd_dev->minor);
-				break;
-			}
-			get_device(&pxd_dev->dev);
-			snap_list[i++] = pxd_dev;
-		}
-		spin_unlock(&ctx->lock);
-
-		// step 4: walk the snapshot without ctx->lock; safe to sleep
-		for (j = 0; j < i; j++) {
-			pxd_fastpath_reset_device(snap_list[j]);
-			put_device(&snap_list[j]->dev);
-		}
-
-		// step 5: free snapshot
-		kfree(snap_list);
-		return;
-	}
-
-	// kcalloc failed: one-at-a-time pickup, O(n^2) but allocation-free.
-	// We can't use pxd_dev->connected as the "already processed" sentinel
-	// (we deliberately don't touch it), so use fastpath_active() instead:
-	// pxd_fastpath_reset_device clears fp.fastpath via disableFastPath,
-	// which makes the candidate predicate false on subsequent iterations.
-	for (;;) {
-		struct pxd_device *picked = NULL;
-
-		spin_lock(&ctx->lock);
-		list_for_each_entry(pxd_dev, &ctx->list, node) {
-			if (fastpath_enabled(pxd_dev) && fastpath_active(pxd_dev)) {
-				get_device(&pxd_dev->dev);
-				picked = pxd_dev;
-				break;
-			}
-		}
-		spin_unlock(&ctx->lock);
-
-		if (!picked) {
-			// no fastpath-active devices left
-			break;
-		}
-
-		pxd_fastpath_reset_device(picked);
-		put_device(&picked->dev);
-	}
-}
-
-// pxdctx_initiate_failover - drive the failover protocol per fastpath-active
-// device on this ctx by calling pxd_initiate_failover() on each. Used by
-// pxd_control_release() to ensure PX-down goes through the same single-entry
-// failover API as IO-error and PX-storage ioctl paths.
-//
-// pxd_initiate_failover may sleep (blk_mq_quiesce_queue, sync workers), so
-// we use snapshot+refcount: capture devices under ctx->lock, drop the lock,
-// then iterate. We filter to fastpath_active devices at snapshot time so
-// native-path and already-failed-over devices don't take a spurious failover
-// round-trip (pxd_initiate_failover no longer self-filters). A device that
-// flips fp.fastpath false between snapshot and call still proceeds through
-// pxd_initiate_failover - it'll take one round-trip but the failover state
-// machine handles it correctly.
-//
-// Caller must run this BEFORE flipping fc->connected to 0 - pxd_initiate_ioswitch
-// gates on fc->connected and would skip the fuse req otherwise.
-static void pxdctx_initiate_failover(struct pxd_context *ctx)
-{
-	size_t ndevs;
-	struct pxd_device **snap_list;
-	struct pxd_device *pxd_dev;
-	size_t i = 0;
-	size_t j;
-
-	spin_lock(&ctx->lock);
-	ndevs = ctx->num_devices;
-	spin_unlock(&ctx->lock);
-
-	snap_list = kcalloc(ndevs, sizeof(*snap_list), GFP_KERNEL);
-	if (!snap_list) {
-		// kcalloc failed; fastpath stays armed, abort_work is backstop.
-		pr_warn("%s: ctx %d kcalloc failed; failover not initiated\n",
-			__func__, ctx->id);
-		return;
-	}
-
-	spin_lock(&ctx->lock);
-	list_for_each_entry(pxd_dev, &ctx->list, node) {
-		if (i >= ndevs) {
-			pr_warn("%s: ctx->list grew past snap_list; devID %llu minor %d skipped\n",
-				__func__, pxd_dev->dev_id, pxd_dev->minor);
-			break;
-		}
-		if (!fastpath_active(pxd_dev)) {
+		flush_work(&picked->remove_work);
+		if (READ_ONCE(picked->removing)) {
+			put_device(&picked->dev);
 			continue;
 		}
-		get_device(&pxd_dev->dev);
-		snap_list[i++] = pxd_dev;
+		if (fail_io) {
+			_pxd_setup(picked, false);
+		} else {
+			/* just reset io path to native path*/
+			pxd_fastpath_reset_device(picked, skip_sync, false /* fail io */);
+		}
+		put_device(&picked->dev);
 	}
-	spin_unlock(&ctx->lock);
-
-	for (j = 0; j < i; j++) {
-		pxd_initiate_failover(snap_list[j]);
-		put_device(&snap_list[j]->dev);
-	}
-	kfree(snap_list);
 }
 
 static struct pxd_device *dev_to_pxd_dev(struct device *dev)
@@ -2334,7 +2276,7 @@ static int pxd_nodewipe_cleanup(struct pxd_context *ctx)
 	list_for_each(cur, &ctx->list) {
 		struct pxd_device *pxd_dev = container_of(cur, struct pxd_device, node);
 
-		pxd_fastpath_reset_device(pxd_dev);
+		pxd_fastpath_reset_device(pxd_dev, true /*skip sync*/, true /* fail io */);
 	}
 	spin_unlock(&ctx->lock);
 
@@ -2496,7 +2438,16 @@ static int pxd_control_open(struct inode *inode, struct file *file)
 
 	// abort work cannot be active while restarting requests
 	cancel_delayed_work_sync(&ctx->abort_work);
+	flush_work(&ctx->failover_work);// wait for it to complete
 	fuse_restart_requests(fc);
+
+	/* Reconnect is a decision-carrying state transition. Wrap the state
+	 * writes (fc.connected 0->1 and pxd_dev->connected false->true via
+	 * pxdctx_set_connected) in a freeze so any pxd_io_failover work
+	 * that races the reopen parks on failQ, and gets reissued to
+	 * native at freeze_end (they can go through the native path;
+	 * userspace is now up so it will service them via fuse). */
+	pxd_fp_freeze_start(ctx);
 
 	spin_lock(&ctx->lock);
 	pxd_timeout_secs = PXD_TIMER_SECS_DEFAULT;
@@ -2506,7 +2457,12 @@ static int pxd_control_open(struct inode *inode, struct file *file)
 	WRITE_ONCE(fc->allow_disconnected, 1);
 	file->private_data = fc;
 
-	pxdctx_set_connected(ctx, true);
+	pxdctx_set_connected(ctx);
+
+	/* fail_io=false: reissue any parked items to native. Userspace is up
+	 * (fc.connected=1); the reissued IOs will get serviced through the
+	 * fuse queue like any other native-path IO. */
+	pxd_fp_freeze_end(ctx, false /* fail io */);
 
 	++ctx->open_seq;
 
@@ -2525,11 +2481,14 @@ static int pxd_control_release(struct inode *inode, struct file *file)
 		return 0;
 	}
 
-	// Drive failover through the single pxd_initiate_failover API for every
-	// fastpath-active device. fuse req queues into fc->processing while
-	// fc->connected is still 1; replayed by fuse_restart_requests on reopen.
-	pxdctx_initiate_failover(ctx);
-
+	/* Flip fc.connected to 0 FIRST, then schedule failover_work.
+	 *
+	 * Ordering matters: pxd_failover_work asserts
+	 * BUG_ON(READ_ONCE(fc.connected)). If we scheduled the work before
+	 * writing fc.connected, a kworker could pick it up in the tiny
+	 * window before the write and panic. Doing the write first also
+	 * means any pxd_io_failover racing this close sees ctx->fc.connected
+	 * == 0 and takes the safe local-reroute branch. */
 	spin_lock(&ctx->lock);
 	if (READ_ONCE(ctx->fc.connected) == 0) {
 		pxd_printk("%s: not opened\n", __func__);
@@ -2540,6 +2499,9 @@ static int pxd_control_release(struct inode *inode, struct file *file)
 	// queued fuse reqs, run pxdctx_reset_fastpath -> failQ -EIOs.
 	schedule_delayed_work(&ctx->abort_work, pxd_timeout_secs * HZ);
 	spin_unlock(&ctx->lock);
+
+	/* Now safe to schedule failover_work; fc.connected == 0 guaranteed. */
+	schedule_work(&ctx->failover_work);
 
 	trace_pxd_close_ctrl_fd(ctx->id);
 	printk(KERN_INFO "%s: pxd-control-%d(%lld) close OK\n", __func__, ctx->id,
@@ -2556,6 +2518,36 @@ MODULE_ALIAS("devname:pxd-control");
 
 static void pxd_fuse_conn_release(struct fuse_conn *conn)
 {
+}
+
+static void pxd_failover_work(struct work_struct *work)
+{
+	struct pxd_context *ctx = container_of(work, struct pxd_context,
+		failover_work);
+
+	/* pxd_control_release writes fc.connected=0 before scheduling us, so
+	 * this should always hold. Kept as WARN not BUG - a spurious execute
+	 * (e.g. from cancel/reschedule races) should log, not panic. */
+	WARN_ON_ONCE(READ_ONCE(ctx->fc.connected));
+	printk(KERN_ERR "PXD_FAILOVER (%s:%u): initiating fastpath failover...",
+		ctx->name, ctx->id);
+
+	/* Create a ctx-scoped quiescent window for the fastpath->native
+	 * transition:
+	 *   1. freeze_start sets ctx->fp_freeze so any pxd_io_failover work
+	 *      item entering the failover state machine parks on its
+	 *      device's failQ (list_add via fproot->wait) and returns.
+	 *      Then flushes all fastpath kthread workers + gwq so items
+	 *      that started before the gate went up complete first.
+	 *   2. pxdctx_reset_fastpath switches each fastpath device to
+	 *      native and drains its failQ via pxd_reissuefailQ(status=0).
+	 *   3. freeze_end clears the gate and drains any items that parked
+	 *      between step 2's drain and step 3's clear. fail_io=false so
+	 *      those stragglers are reissued to native (matching the
+	 *      transition target). */
+	pxd_fp_freeze_start(ctx);
+	pxdctx_reset_fastpath(ctx, false /* fail io */);
+	pxd_fp_freeze_end(ctx, false /* fail io */);
 }
 
 static void pxd_abort_context(struct work_struct *work)
@@ -2580,7 +2572,14 @@ static void pxd_abort_context(struct work_struct *work)
 
 	// Tear down fastpath per device (also fails any leftover failQ IOs
 	// via the defensive __pxd_abortfailQ inside pxd_fastpath_reset_device).
-	pxdctx_reset_fastpath(ctx);
+	// Wrap in the freeze window so any late pxd_io_failover work items on
+	// the fastpath kthread_workers park on failQ (see pxd_io_failover)
+	// and get aborted along with the rest. fail_io=true tells freeze_end
+	// to abort straggler parked items with -EIO (consistent with the hard
+	// teardown semantic of abort_work).
+	pxd_fp_freeze_start(ctx);
+	pxdctx_reset_fastpath(ctx, true /* fail io */);
+	pxd_fp_freeze_end(ctx, true /* fail io */);
 }
 
 static int pxd_context_init(struct pxd_context *ctx, int i)
@@ -2610,6 +2609,7 @@ static int pxd_context_init(struct pxd_context *ctx, int i)
 	ctx->miscdev.name = ctx->name;
 	ctx->miscdev.fops = &ctx->fops;
 	INIT_DELAYED_WORK(&ctx->abort_work, pxd_abort_context);
+	INIT_WORK(&ctx->failover_work, pxd_failover_work);
 	return 0;
 }
 
@@ -2617,6 +2617,7 @@ static void pxd_context_destroy(struct pxd_context *ctx)
 {
 	misc_deregister(&ctx->miscdev);
 	cancel_delayed_work_sync(&ctx->abort_work);
+	cancel_work_sync(&ctx->failover_work);
 	if (ctx->id < pxd_num_contexts_exported) {
 		fuse_abort_conn(&ctx->fc);
 		fuse_conn_put(&ctx->fc);

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -584,14 +584,23 @@ err:
 //  (c) otherwise: userspace is up; drive the standard coordinated failover
 //      via pxd_initiate_failover.
 //
-// All shared-flag reads use READ_ONCE. Writers (pxd_control_release,
-// _pxd_setup, pxd_fp_freeze_start/end) use WRITE_ONCE. This is a compiler
-// barrier only, matching the RCU protocol disableFastPath already uses on
-// fp.fastpath. On x86 aligned int/bool loads are atomic; on other archs
-// READ_ONCE/WRITE_ONCE prevent torn/fused accesses. Cross-CPU ordering
-// with respect to the freeze gate is provided by smp_wmb() in
-// pxd_fp_freeze_start/end and by the fastpath kthread flush that follows
-// the gate set.
+// Cross-CPU memory ordering:
+//   The freeze gate uses acquire/release semantics.
+//     Writer pxd_fp_freeze_start / pxd_fp_freeze_end: smp_store_release.
+//     Reader (this function): smp_load_acquire on the outer gate check.
+//   Because every state store to pxd_dev->connected, ctx->fc.connected,
+//   and pxd_dev->fp.fastpath (true->false) happens inside a freeze
+//   window, the acquire on the gate implicitly orders our subsequent
+//   plain READ_ONCE reads of those fields. Weak archs (arm64, ppc,
+//   riscv) require this pairing; plain WRITE_ONCE/READ_ONCE would let
+//   the CPU speculate the state loads before the gate load and observe
+//   a mid-transition combination. On x86 (TSO) acquire/release compile
+//   to the same instructions as READ_ONCE/WRITE_ONCE plus a compiler
+//   barrier.
+//
+//   The inner re-check under fp.fail_lock uses plain READ_ONCE:
+//   spin_lock is a full memory barrier on every Linux arch and
+//   subsumes acquire for this call site.
 static void pxd_io_failover(struct kthread_work *work) {
         struct fp_root_context *fproot =
             container_of(work, struct fp_root_context, work);
@@ -605,11 +614,26 @@ static void pxd_io_failover(struct kthread_work *work) {
         BUG_ON(fproot->magic != FP_ROOT_MAGIC);
         BUG_ON(pxd_dev->magic != PXD_DEV_MAGIC);
 
-	/* Park during ctx freeze. Re-check the gate under fp.fail_lock so
-	 * pxd_fp_freeze_end can't clear the gate + drain failQ in between
-	 * our READ_ONCE and our list_add. If gate was cleared while we
-	 * were racing, we fall through and take a normal branch below. */
-	if (READ_ONCE(ctx->fp_freeze)) {
+	/* Park during ctx freeze.
+	 *
+	 * smp_load_acquire pairs with smp_store_release in
+	 * pxd_fp_freeze_start/end. Two properties this pairing gives us:
+	 *   1. If we observe fp_freeze == 1, subsequent loads/stores on
+	 *      this CPU do not reorder before it - so our list_add under
+	 *      fail_lock cannot be speculated ahead of the gate check.
+	 *   2. If we observe fp_freeze == 0 (post-freeze_end), we also
+	 *      observe every state store the writer made before releasing
+	 *      the gate - specifically pxd_dev->connected and
+	 *      ctx->fc.connected. That is what makes the plain
+	 *      READ_ONCE'd reads below safe against mid-transition
+	 *      observation on weak archs (arm64, ppc, riscv).
+	 *
+	 * The inner re-check inside fp.fail_lock can use plain READ_ONCE:
+	 * spin_lock is a full barrier on all Linux archs, so any state
+	 * the writer published before its own fail_lock acquire in the
+	 * drain loop is visible to us here.
+	 */
+	if (smp_load_acquire(&ctx->fp_freeze)) {
 		spin_lock_irqsave(&pxd_dev->fp.fail_lock, flags);
 		if (READ_ONCE(ctx->fp_freeze)) {
 			list_add_tail(&fproot->wait, &pxd_dev->fp.failQ);
@@ -619,6 +643,9 @@ static void pxd_io_failover(struct kthread_work *work) {
 		spin_unlock_irqrestore(&pxd_dev->fp.fail_lock, flags);
 	}
 
+	/* Both loads are ordered after the smp_load_acquire above, so
+	 * they observe the writer's paired smp_store_release view of
+	 * these fields. No additional barrier needed here. */
 	dev_conn = READ_ONCE(pxd_dev->connected);
 	ctx_conn = READ_ONCE(ctx->fc.connected) != 0;
 
@@ -639,7 +666,13 @@ static void pxd_io_failover(struct kthread_work *work) {
 	// (b) userspace not available now, switch io path to native locally
 	if (!ctx_conn) {
 		/* userspace down - can queue directly without failover request.
-		 * skip_sync=true: no userspace to sync through; avoid hanging. */
+		 *
+		 * skip_sync=true: we reach this branch because a fastpath IO
+		 * just errored (that is what queued pxd_io_failover). The
+		 * backing target is by construction unreliable at this moment,
+		 * so a vfs_fsync on it is meaningless. Rule (a) - broken
+		 * backing - not "userspace is gone". wait_for_sync() itself
+		 * does NOT go through userspace; it is driver-local. */
 		struct fuse_req* req = fproot_to_fuse_request(fproot);
 		disableFastPath(pxd_dev, true /* skip sync */);
                 atomic_inc(&pxd_dev->fp.nslowPath);

--- a/pxd_bio_blkmq.c
+++ b/pxd_bio_blkmq.c
@@ -177,8 +177,14 @@ void pxd_suspend_io(struct pxd_device *pxd_dev) {
 
 void pxd_resume_io(struct pxd_device *pxd_dev) {
         bool wakeup;
-        int curr = atomic_dec_return(&pxd_dev->fp.suspend);
         struct pxd_fastpath_extension *fp = &pxd_dev->fp;
+        int curr = atomic_dec_if_positive(&fp->suspend);
+
+        if (curr < 0) {
+                printk(KERN_WARNING "pxd device %llu: resume with suspend count already 0; ignoring\n",
+                       pxd_dev->dev_id);
+                return;
+        }
 
         wakeup = (curr == 0);
         if (wakeup) {
@@ -559,16 +565,90 @@ err:
 }
 
 // failover handling
+//
+// Three-way branch + park-during-freeze:
+//  (park) ctx->fp_freeze == 1:
+//      a ctx-scoped teardown/reopen is in progress. Do not commit to a
+//      branch decision - the state we'd observe is transient. Park the
+//      fproot on this device's failQ (same list branch (c) uses).
+//      pxd_fp_freeze_end / pxdctx_reset_fastpath drain failQ with the
+//      correct mode (reissue-native for soft path, abort for hard path).
+//      We do NOT call pxd_initiate_failover from here.
+//  (a) pxd_dev->connected == false:
+//      abort_work already ran; userspace has been down past the timeout.
+//      Fail IO with -EIO.
+//  (b) ctx->fc.connected == 0 (userspace down, still within abort timer):
+//      switch this device to native slowpath locally without a coordinated
+//      failover request, and re-queue the IO through fuse (which holds it
+//      until userspace reconnects or allow_disconnected flips to 0).
+//  (c) otherwise: userspace is up; drive the standard coordinated failover
+//      via pxd_initiate_failover.
+//
+// All shared-flag reads use READ_ONCE. Writers (pxd_control_release,
+// _pxd_setup, pxd_fp_freeze_start/end) use WRITE_ONCE. This is a compiler
+// barrier only, matching the RCU protocol disableFastPath already uses on
+// fp.fastpath. On x86 aligned int/bool loads are atomic; on other archs
+// READ_ONCE/WRITE_ONCE prevent torn/fused accesses. Cross-CPU ordering
+// with respect to the freeze gate is provided by smp_wmb() in
+// pxd_fp_freeze_start/end and by the fastpath kthread flush that follows
+// the gate set.
 static void pxd_io_failover(struct kthread_work *work) {
         struct fp_root_context *fproot =
             container_of(work, struct fp_root_context, work);
         struct pxd_device *pxd_dev = fproot_to_pxd(fproot);
+        struct pxd_context *ctx = pxd_dev->ctx;
         int rc;
         unsigned long flags;
+        bool dev_conn;
+        bool ctx_conn;
 
         BUG_ON(fproot->magic != FP_ROOT_MAGIC);
         BUG_ON(pxd_dev->magic != PXD_DEV_MAGIC);
 
+	/* Park during ctx freeze. Re-check the gate under fp.fail_lock so
+	 * pxd_fp_freeze_end can't clear the gate + drain failQ in between
+	 * our READ_ONCE and our list_add. If gate was cleared while we
+	 * were racing, we fall through and take a normal branch below. */
+	if (READ_ONCE(ctx->fp_freeze)) {
+		spin_lock_irqsave(&pxd_dev->fp.fail_lock, flags);
+		if (READ_ONCE(ctx->fp_freeze)) {
+			list_add_tail(&fproot->wait, &pxd_dev->fp.failQ);
+			spin_unlock_irqrestore(&pxd_dev->fp.fail_lock, flags);
+			return;
+		}
+		spin_unlock_irqrestore(&pxd_dev->fp.fail_lock, flags);
+	}
+
+	dev_conn = READ_ONCE(pxd_dev->connected);
+	ctx_conn = READ_ONCE(ctx->fc.connected) != 0;
+
+	// (a) hard-fail: device disconnected past the abort timeout
+	if (!dev_conn) {
+		/* fail right away */
+		struct fuse_req* req = fproot_to_fuse_request(fproot);
+                clone_cleanup(fproot);
+#ifndef __PX_BLKMQ__
+                blk_end_request(req->rq, -EIO, blk_rq_bytes(req->rq));
+                fuse_request_free(req);
+#else
+                blk_mq_end_request(req->rq, BLK_STS_IOERR);
+#endif
+		return;
+	}
+
+	// (b) userspace not available now, switch io path to native locally
+	if (!ctx_conn) {
+		/* userspace down - can queue directly without failover request.
+		 * skip_sync=true: no userspace to sync through; avoid hanging. */
+		struct fuse_req* req = fproot_to_fuse_request(fproot);
+		disableFastPath(pxd_dev, true /* skip sync */);
+                atomic_inc(&pxd_dev->fp.nslowPath);
+                clone_cleanup(fproot);
+		pxdmq_reroute_slowpath(req);
+		return;
+	}
+
+	// (c) inform userspace about active io path failover
         // Enqueue and call. pxd_initiate_failover handles the three cases
         // internally: in-progress (no-op), orphan/native (splice+reissue
         // locally, return 0), or leader (full failover round-trip).

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -39,11 +39,27 @@ struct pxd_context {
 	 * after clearing the gate to catch items that parked between the
 	 * reset_fastpath drain and the gate clear.
 	 *
-	 * Read by pxd_io_failover with READ_ONCE, written by
-	 * pxd_fp_freeze_start/end with WRITE_ONCE. Compiler barrier only; on
-	 * x86 aligned int reads are atomic. Cross-CPU visibility ordering is
-	 * provided by smp_wmb() in freeze_start/end and by the fastpath
-	 * kthread flush that follows the gate set.
+	 * Memory ordering (weak-arch correctness):
+	 *   Writer (pxd_fp_freeze_start/end): smp_store_release. All state
+	 *     mutations performed inside the freeze window (pxd_dev->connected
+	 *     and ctx->fc.connected via _pxd_setup / pxdctx_set_connected,
+	 *     pxd_dev->fp.fastpath via disableFastPath) are published before
+	 *     the gate transition.
+	 *   Reader (pxd_io_failover): smp_load_acquire. If the reader
+	 *     observes gate=0 (post-freeze-end), it also observes every
+	 *     state mutation the writer made. This is what makes the
+	 *     subsequent plain READ_ONCE on pxd_dev->connected and
+	 *     ctx->fc.connected safe against mid-transition observation on
+	 *     arm64/ppc/riscv. On x86 (TSO) the acquire/release lower to
+	 *     the same instructions as WRITE_ONCE/READ_ONCE plus a
+	 *     compiler barrier.
+	 *
+	 * Not atomic_t: single-writer (only the ctx-transition callbacks
+	 * failover_work / abort_work / pxd_control_open write it, and those
+	 * do not overlap thanks to flush_work in pxd_control_open + delayed
+	 * scheduling of abort_work + serial invocation of failover_work).
+	 * atomic_t would be misleading - there is no read-modify-write on
+	 * this field.
 	 */
 	int fp_freeze;
 

--- a/pxd_core.h
+++ b/pxd_core.h
@@ -21,6 +21,31 @@ struct pxd_context {
 	int id;
 	struct miscdevice miscdev;
 	struct delayed_work abort_work;
+	struct work_struct failover_work;
+
+	/* Ctx-scoped fastpath freeze gate.
+	 *
+	 * When set, a pxd_io_failover work item entering the failover state
+	 * machine does NOT pick branch (a)/(b)/(c). Instead it parks the
+	 * fproot on that device's existing pxd_dev->fp.failQ (using
+	 * fproot->wait, same linkage branch (c) uses) and returns without
+	 * calling pxd_initiate_failover. It does NOT hard-fail and does NOT
+	 * block the kthread worker.
+	 *
+	 * The ctx-teardown code (pxdctx_reset_fastpath called from
+	 * pxd_failover_work / pxd_abort_context) drains each device's failQ
+	 * with the appropriate mode (reissue-to-native for the soft path,
+	 * abort for the hard path). pxd_fp_freeze_end also drains once more
+	 * after clearing the gate to catch items that parked between the
+	 * reset_fastpath drain and the gate clear.
+	 *
+	 * Read by pxd_io_failover with READ_ONCE, written by
+	 * pxd_fp_freeze_start/end with WRITE_ONCE. Compiler barrier only; on
+	 * x86 aligned int reads are atomic. Cross-CPU visibility ordering is
+	 * provided by smp_wmb() in freeze_start/end and by the fastpath
+	 * kthread flush that follows the gate set.
+	 */
+	int fp_freeze;
 
 	uint64_t open_seq;
 };

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -342,13 +342,19 @@ struct workqueue_struct* fastpath_workqueue(void)
  */
 void pxd_fp_freeze_start(struct pxd_context *ctx)
 {
-	WRITE_ONCE(ctx->fp_freeze, 1);
-	/* Order gate-set ahead of the flush; readers of fp_freeze in
-	 * pxd_io_failover use READ_ONCE and pair with this. */
-	smp_wmb();
+	/* smp_store_release: any prior store on this CPU is visible before
+	 * the gate=1 store. Reader on another CPU that observes gate=1 via
+	 * smp_load_acquire sees all those prior stores too. Not strictly
+	 * necessary at freeze_start (there are no interesting prior stores
+	 * to publish), but matches the release/acquire pairing readers use
+	 * and is idiomatic. */
+	smp_store_release(&ctx->fp_freeze, 1);
 	/* Drain: any pxd_io_failover kthread work already running gets to
 	 * complete with pre-freeze state. New pxd_io_failover work queued
-	 * after this write observes fp_freeze=1 and parks. */
+	 * after this write observes fp_freeze=1 and parks. Both flushes
+	 * take spinlocks internally, so they also provide the full memory
+	 * barrier that guarantees the gate=1 store is globally visible
+	 * before we start touching device state. */
 	fastpath_flush_work();
 	if (gwq != NULL) {
 		flush_workqueue(gwq);
@@ -365,15 +371,24 @@ void pxd_fp_freeze_end(struct pxd_context *ctx, bool fail_io)
 	unsigned long flags;
 	struct list_head ios;
 
-	/* Clear the gate. New pxd_io_failover items entering after this
-	 * observe fp_freeze=0 and take the normal (a)/(b)/(c) branches.
-	 * They do NOT touch failQ under the park path.
+	/* Clear the gate.
 	 *
-	 * Ordering: smp_wmb before the write so writers who set device
-	 * state during the freeze window are visible to readers who see
-	 * fp_freeze=0. */
-	smp_wmb();
-	WRITE_ONCE(ctx->fp_freeze, 0);
+	 * smp_store_release: publishes every state mutation performed
+	 * between pxd_fp_freeze_start and this call (pxd_dev->connected,
+	 * pxd_dev->fp.fastpath transitions, ctx->fc.connected changes)
+	 * atomically w.r.t. the gate. A reader on another CPU that
+	 * observes fp_freeze=0 via smp_load_acquire is guaranteed to see
+	 * all of those writes. This is what makes the reader in
+	 * pxd_io_failover safe to read pxd_dev->connected and
+	 * ctx->fc.connected with plain READ_ONCE right after the gate
+	 * check - the acquire on the gate carries the ordering for the
+	 * subsequent loads.
+	 *
+	 * On x86 (TSO) this is equivalent to WRITE_ONCE. On arm64 it
+	 * emits stlr; on ppc, lwsync + std. Without the release, weak
+	 * archs can let the reader observe fp_freeze=0 while still
+	 * seeing pre-freeze pxd_dev->connected. */
+	smp_store_release(&ctx->fp_freeze, 0);
 
 	/* Drain any items that parked between pxdctx_reset_fastpath's
 	 * per-device failQ drain and the gate-clear above. Because we're
@@ -735,6 +750,14 @@ int pxd_fastpath_vol_cleanup(struct pxd_device *pxd_dev)
  *   (x86 XCHG, arm64 SWP/LL-SC, ppc/riscv LL-SC, s390 CS). It works
  *   on any word-sized lvalue including plain struct pointer fields;
  *   the fp->file[i] slot qualifies.
+ *
+ * @skipsync: controls whether wait_for_sync() -> vfs_fsync() runs on
+ *   each backing fd before it is closed. The sync is driver-local
+ *   (vfs_fsync on files we own); it is not dependent on userspace or
+ *   ctx state. Callers should set skipsync=true only when the sync
+ *   would be meaningless: fastpath already broken, hard-fail teardown,
+ *   or whole-node decommission. In every other case, sync so writes
+ *   the driver accepted reach durable backing storage before close.
  */
 void disableFastPath(struct pxd_device *pxd_dev, bool skipsync)
 {
@@ -910,8 +933,24 @@ out_file_failed:
 // the abort_work backstop (pxd_abort_context) via pxdctx_reset_fastpath()
 // at T+pxd_timeout_secs when PX never reopened the control fd.
 //
-// All below is true when @fail_io is true, otherwise, IOs are held within failQ waiting for either abort timer to fail them
-// or px-storage to come online and process them.
+// @skip_sync: controls whether disableFastPath calls wait_for_sync() ->
+//   vfs_fsync() on each backing fd before closing it. This is a
+//   DRIVER-LOCAL sync on files the driver owns; it does NOT go through
+//   userspace or ctx->fc. Latency depends only on the backing fs/device.
+//   Skip only when the sync would be meaningless:
+//     (a) fastpath / backing storage is already broken (IO errored out)
+//     (b) hard-fail teardown - every in-flight IO is being aborted with
+//         -EIO, so persisting driver-side cache first is not the point
+//     (c) whole-node decommission
+//   In every other case (soft failover, ordinary PXD_REMOVE) skip_sync
+//   must be false so writes userspace has already had acknowledged reach
+//   durable storage before we drop the backing fd.
+//
+// @fail_io: if true, all queued IO on device will be failed immediately.
+//   Below is true only when fail_io is true; otherwise IOs are held
+//   within failQ waiting for either the abort timer to fail them or
+//   px-storage to come online and process them.
+//
 // Important: this function never requeues IO. Any IO that hasn't already
 // completed must be failed here. Requeueing to native path is unsafe in
 // the node-wipe / device-remove case because:

--- a/pxd_fastpath.c
+++ b/pxd_fastpath.c
@@ -53,8 +53,31 @@ static void fastpath_map_workers(void)
     }
 }
 
+/*
+ * Flush all fastpath kthread workers.
+ *
+ * Called from disableFastPath (and pxd_fp_freeze_start) to drain any
+ * fastpath work items so filp_close is safe. Two things this must NOT
+ * do:
+ *
+ * 1. Self-flush. If we're running as a work item on one of these very
+ *    workers (e.g. pxd_io_failover branch (b) chained into
+ *    disableFastPath), kthread_flush_worker on our own worker enqueues
+ *    a barrier and wait_for_completion's on it. The barrier can only
+ *    run after we return, and we can't return until the completion
+ *    fires - deadlock. Skip the current worker by comparing its
+ *    ->task against `current`.
+ *
+ * 2. Assume it drained follow-up work queued by items it flushed.
+ *    kthread_flush_worker's barrier is enqueued once at call time;
+ *    work items enqueued by a running flushed item land after the
+ *    barrier and are not waited for. That's a limitation of the
+ *    primitive, not this wrapper. Callers must not depend on
+ *    fastpath_flush_work draining chained work.
+ */
 static void fastpath_flush_work(void) {
        int node;
+       struct task_struct *self = current;
 
        for (node = 0; node < MAX_NUMNODES; node++) {
                struct pxfpcontext_per_node *c = &pxfpctxt[node];
@@ -62,7 +85,7 @@ static void fastpath_flush_work(void) {
                        int i;
                        for (i = 0; i < MAX_PXFP_WORKERS_PER_NODE; i++) {
                                struct kthread_worker *worker = c->fpworker[i];
-                               if (worker != NULL) {
+                               if (worker != NULL && worker->task != self) {
                                        kthread_flush_worker(worker);
                                }
                        }
@@ -288,6 +311,145 @@ struct workqueue_struct* fastpath_workqueue(void)
 	return gwq; // only used by non-blkmq code and special cases
 }
 
+/* Ctx-scoped quiescent window for fastpath transitions.
+ *
+ * Kernel workqueues have no module-callable "freeze" primitive
+ * (freeze_workqueues_begin/thaw_workqueues are not EXPORT_SYMBOL'd and
+ * are driven only by the PM subsystem). WQ_FREEZABLE only participates
+ * in system suspend/resume. We implement the freeze semantic ourselves
+ * for the fastpath IO path.
+ *
+ * Invariant enforced by this pair:
+ *   Every writer of pxd_dev->connected, pxd_dev->fp.fastpath, or
+ *   ctx->fc.connected runs INSIDE a freeze window. Every reader that
+ *   makes a branch decision (pxd_io_failover) either observed the
+ *   pre-window state (started before the gate; drained by freeze_start)
+ *   or the post-window state (parked during the window; drained by
+ *   freeze_end or the intervening pxdctx_reset_fastpath). It never
+ *   observes a mid-transition state.
+ *
+ * Park zone: pxd_dev->fp.failQ. When gate is set, pxd_io_failover
+ * simply list_add_tail(&fproot->wait, &pxd_dev->fp.failQ) under
+ * fp.fail_lock and returns. The existing drain functions
+ * (pxd_reissuefailQ / __pxd_abortfailQ) handle the parked items.
+ *
+ * Note during a failover_work/abort_work-driven freeze, ctx->fc.connected
+ * is already 0 (pxd_control_release wrote it before scheduling). So a
+ * fastpath IO error that races the freeze naturally would take branch (b)
+ * or (a); neither uses failQ. The only way an item lands on failQ during
+ * this window is via the park path here. That means the drain in
+ * freeze_end catches only parked items, never mid-branch-(c) items.
+ */
+void pxd_fp_freeze_start(struct pxd_context *ctx)
+{
+	WRITE_ONCE(ctx->fp_freeze, 1);
+	/* Order gate-set ahead of the flush; readers of fp_freeze in
+	 * pxd_io_failover use READ_ONCE and pair with this. */
+	smp_wmb();
+	/* Drain: any pxd_io_failover kthread work already running gets to
+	 * complete with pre-freeze state. New pxd_io_failover work queued
+	 * after this write observes fp_freeze=1 and parks. */
+	fastpath_flush_work();
+	if (gwq != NULL) {
+		flush_workqueue(gwq);
+	}
+}
+
+void pxd_fp_freeze_end(struct pxd_context *ctx, bool fail_io)
+{
+	struct pxd_device *pxd_dev;
+	size_t ndevs;
+	struct pxd_device **snap_list;
+	size_t i = 0;
+	size_t j;
+	unsigned long flags;
+	struct list_head ios;
+
+	/* Clear the gate. New pxd_io_failover items entering after this
+	 * observe fp_freeze=0 and take the normal (a)/(b)/(c) branches.
+	 * They do NOT touch failQ under the park path.
+	 *
+	 * Ordering: smp_wmb before the write so writers who set device
+	 * state during the freeze window are visible to readers who see
+	 * fp_freeze=0. */
+	smp_wmb();
+	WRITE_ONCE(ctx->fp_freeze, 0);
+
+	/* Drain any items that parked between pxdctx_reset_fastpath's
+	 * per-device failQ drain and the gate-clear above. Because we're
+	 * in a failover_work/abort_work path, ctx->fc.connected is still 0,
+	 * so branch (c) can't fire; anything on failQ right now is a parked
+	 * item from the freeze window (see the note in freeze_start).
+	 *
+	 * Use snapshot+refcount to avoid holding ctx->lock across
+	 * pxd_reissuefailQ (which does bio submission through the native
+	 * path and can sleep). */
+	spin_lock(&ctx->lock);
+	ndevs = ctx->num_devices;
+	spin_unlock(&ctx->lock);
+
+	if (ndevs == 0) {
+		return;
+	}
+
+	snap_list = kcalloc(ndevs, sizeof(*snap_list), GFP_KERNEL);
+	if (!snap_list) {
+		/* Best-effort: without allocation we can't do the drain safely.
+		 * The stragglers will be caught by any subsequent teardown or
+		 * by pxd_abort_context's __pxd_abortfailQ if that fires. Log
+		 * loudly so this is visible. */
+		pr_warn("%s: ctx %s: kcalloc failed; parked IOs may linger on failQ\n",
+			__func__, ctx->name);
+		return;
+	}
+
+	spin_lock(&ctx->lock);
+	list_for_each_entry(pxd_dev, &ctx->list, node) {
+		if (i >= ndevs) {
+			break;
+		}
+		if (READ_ONCE(pxd_dev->removing)) {
+			continue;
+		}
+		if (!fastpath_enabled(pxd_dev)) {
+			continue;
+		}
+		get_device(&pxd_dev->dev);
+		snap_list[i++] = pxd_dev;
+	}
+	spin_unlock(&ctx->lock);
+
+	for (j = 0; j < i; j++) {
+		struct pxd_device *dev = snap_list[j];
+
+		INIT_LIST_HEAD(&ios);
+		spin_lock_irqsave(&dev->fp.fail_lock, flags);
+		list_splice_init(&dev->fp.failQ, &ios);
+		spin_unlock_irqrestore(&dev->fp.fail_lock, flags);
+
+		if (list_empty(&ios)) {
+			put_device(&dev->dev);
+			continue;
+		}
+
+		if (fail_io) {
+			/* Hard-fail path: put the items back on failQ under lock
+			 * and run the abort helper (it walks failQ and ends each
+			 * request with -EIO). */
+			spin_lock_irqsave(&dev->fp.fail_lock, flags);
+			list_splice(&ios, &dev->fp.failQ);
+			__pxd_abortfailQ(dev);
+			dev->fp.active_failover = false;
+			spin_unlock_irqrestore(&dev->fp.fail_lock, flags);
+		} else {
+			/* Soft path: reissue to native (status=0). */
+			pxd_reissuefailQ(dev, &ios, 0);
+		}
+		put_device(&dev->dev);
+	}
+	kfree(snap_list);
+}
+
 void pxd_abortfailQ(struct pxd_device *pxd_dev)
 {
 	unsigned long flags;
@@ -377,7 +539,7 @@ int pxd_request_ioswitch(struct pxd_device *pxd_dev, int code)
 }
 
 #define SYNC_TIMEOUT (60000)
-static int wait_for_sync(struct pxd_device *pxd_dev, bool skipsync)
+int wait_for_sync(struct pxd_device *pxd_dev, bool skipsync)
 {
         struct pxd_fastpath_extension *fp = &pxd_dev->fp;
         int i;
@@ -413,69 +575,23 @@ static int wait_for_sync(struct pxd_device *pxd_dev, bool skipsync)
         return 0;
 }
 
-// shall be called internally during iopath switching.
-int pxd_request_suspend_internal(struct pxd_device *pxd_dev,
-		bool skip_flush, bool coe)
-{
-	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
-	int rc;
-
-	if (!fastpath_enabled(pxd_dev)) {
-		return -EINVAL;
-	}
-
-	// check if previous sync instance is still active
-	if (!skip_flush && pxd_sync_work_pending(pxd_dev)) {
-		return -EBUSY;
-	}
-
-	pxd_suspend_io(pxd_dev);
-
-	if (skip_flush || !fp->fastpath) return 0;
-
-	rc = wait_for_sync(pxd_dev, skip_flush);
-	if (rc)
-		goto fail;
-	printk(KERN_NOTICE"device %llu suspended IO from userspace\n", pxd_dev->dev_id);
-	return 0;
-fail:
-	// It is possible replicas are down during failover
-	// ignore and continue
-	if (coe) {
-		printk(KERN_NOTICE"device %llu sync failed %d, continuing with suspend\n",
-				pxd_dev->dev_id, rc);
-		return 0;
-	}
-	pxd_resume_io(pxd_dev);
-	return rc;
-}
-
 // external request to suspend IO on fastpath device
 int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush, bool coe)
 {
-	int rc = 0;
-
 	if (atomic_cmpxchg(&pxd_dev->fp.app_suspend, 0, 1) != 0) {
 		return -EBUSY;
 	}
 
-	rc = pxd_request_suspend_internal(pxd_dev, skip_flush, coe);
-	if (rc) {
-		// reset on failure
-		atomic_set(&pxd_dev->fp.app_suspend, 0);
+	pxd_suspend_io(pxd_dev);
+	if (fastpath_active(pxd_dev)) {
+		int rc = wait_for_sync(pxd_dev, false);
+		if (unlikely(rc) && rc != -EINVAL && rc != -EIO) {
+			printk(KERN_ERR"device %llu sync failed %d, continuing with disable\n",
+					pxd_dev->dev_id, rc);
+		}
 	}
 
-	return rc;
-}
-
-int pxd_request_resume_internal(struct pxd_device *pxd_dev)
-{
-	if (!fastpath_enabled(pxd_dev)) {
-		return -EINVAL;
-	}
-
-	pxd_resume_io(pxd_dev);
-	printk(KERN_NOTICE"device %llu resumed IO from userspace\n", pxd_dev->dev_id);
+	// don't fail
 	return 0;
 }
 
@@ -488,10 +604,8 @@ int pxd_request_resume(struct pxd_device *pxd_dev)
 		return -EINVAL;
 	}
 
-	rc = pxd_request_resume_internal(pxd_dev);
-	if (rc) {
-		atomic_set(&pxd_dev->fp.app_suspend, 1);
-	}
+	pxd_resume_io(pxd_dev);
+	printk(KERN_NOTICE"device %llu resumed IO from userspace\n", pxd_dev->dev_id);
 	return rc;
 }
 
@@ -593,25 +707,70 @@ int pxd_fastpath_vol_cleanup(struct pxd_device *pxd_dev)
 	return 0;
 }
 
+/*
+ * Concurrency model:
+ *   disableFastPath can be reached from multiple call sites concurrently
+ *   for the same device:
+ *     - pxdctx_reset_fastpath (inside a freeze window)
+ *     - pxd_io_failover branch (b) (on a fastpath kthread worker,
+ *       outside the freeze window)
+ *     - pxd_fastpath_vol_cleanup / pxd_debug_switch_nativepath (ioctl)
+ *     - pxd_init_fastpath_target's out_file_failed unwind
+ *     - pxd_finish_remove via pxd_fastpath_reset_device
+ *
+ *   We do NOT hold a mutex across this function because pxd_suspend_io
+ *   waits on the blk_mq freeze counter, and a fastpath work item that
+ *   holds an rq ref may be trying to enter disableFastPath itself
+ *   (branch (b)). That would produce circular wait: A holds mutex and
+ *   waits on B's rq; B holds rq and waits on A's mutex.
+ *
+ *   Instead, ownership is decided by an atomic xchg on fp->fastpath.
+ *   Exactly one caller sees prev=true and runs the full disable
+ *   sequence; every other caller observes fp->fastpath=false and
+ *   returns immediately. The file-close loop uses xchg on each
+ *   fp->file[i] so a stale entry can't be closed twice even if a
+ *   caller sneaks between the top gate and the loop.
+ *
+ *   xchg is atomic and full-barrier on every arch Linux supports
+ *   (x86 XCHG, arm64 SWP/LL-SC, ppc/riscv LL-SC, s390 CS). It works
+ *   on any word-sized lvalue including plain struct pointer fields;
+ *   the fp->file[i] slot qualifies.
+ */
 void disableFastPath(struct pxd_device *pxd_dev, bool skipsync)
 {
 	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
-	int nfd = fp->nfd;
 	int i;
+	bool prev;
 
-	if (!fastpath_enabled(pxd_dev) || !pxd_dev->fp.nfd ||
-			!fastpath_active(pxd_dev)) {
-		pxd_dev->fp.nfd = 0;
-		pxd_dev->fp.fastpath = false;
+	/* If the device was never configured for fastpath (or nfd is
+	 * already zero from a prior teardown), normalize state and exit.
+	 * WRITE_ONCE the gate so any spinning reader observes the value. */
+	if (!fastpath_enabled(pxd_dev) || !fp->nfd) {
+		fp->nfd = 0;
+		WRITE_ONCE(fp->fastpath, false);
 		return;
 	}
 
+	/* Claim ownership. Only the caller that flips true->false runs the
+	 * disable sequence. Others get prev=false and return - fp->fastpath
+	 * is already false from their perspective, which is the sole
+	 * post-condition callers depend on. */
+	prev = xchg(&fp->fastpath, false);
+	if (!prev) {
+		return;
+	}
+
+	/* pxd_suspend_io freezes the blk_mq queue and waits for in-flight
+	 * requests to drop their refs. Combined with the WRITE_ONCE above
+	 * (via xchg) and the RCU grace period below, no new fastpath IO
+	 * can be dispatched and no in-flight fastpath IO is still running
+	 * by the time we get past synchronize_rcu(). */
 	pxd_suspend_io(pxd_dev);
-	WRITE_ONCE(pxd_dev->fp.fastpath, false);
-	// in pxd_queue_rq, if there are existing readers in the RCU read side critical section
-	// synchronize_rcu will wait for them to end (queue to fastpath kthread)
+	/* in pxd_queue_rq, if there are existing readers in the RCU read
+	 * side critical section synchronize_rcu will wait for them to end
+	 * (queue to fastpath kthread). */
 	synchronize_rcu();
-	// at this point, all readers would see pxd_dev->fp.fastpath = false
+	/* at this point, all readers would see fp->fastpath = false */
 	fastpath_flush_work();
 
 	if (PXD_ACTIVE(pxd_dev)) {
@@ -628,10 +787,16 @@ void disableFastPath(struct pxd_device *pxd_dev, bool skipsync)
 		}
 	}
 
-	for (i = 0; i < nfd; i++) {
-		if (fp->file[i] != NULL) {
-			filp_close(fp->file[i], NULL);
-			fp->file[i] = NULL;
+	/* Atomically claim each file slot. Only the caller that xchg's out
+	 * a non-NULL pointer closes it - no double-close even if a stale
+	 * caller past the ownership xchg above (there shouldn't be one,
+	 * but this is belt-and-braces) reaches this loop. Iterate the full
+	 * array rather than nfd, because nfd could race concurrently and
+	 * a NULL slot is a no-op. */
+	for (i = 0; i < MAX_PXD_BACKING_DEVS; i++) {
+		struct file *f = xchg(&fp->file[i], NULL);
+		if (f) {
+			filp_close(f, NULL);
 		}
 	}
 	fp->nfd = 0;
@@ -745,6 +910,8 @@ out_file_failed:
 // the abort_work backstop (pxd_abort_context) via pxdctx_reset_fastpath()
 // at T+pxd_timeout_secs when PX never reopened the control fd.
 //
+// All below is true when @fail_io is true, otherwise, IOs are held within failQ waiting for either abort timer to fail them
+// or px-storage to come online and process them.
 // Important: this function never requeues IO. Any IO that hasn't already
 // completed must be failed here. Requeueing to native path is unsafe in
 // the node-wipe / device-remove case because:
@@ -755,7 +922,7 @@ out_file_failed:
 //     servicing the fuse channel) is the thing being torn down.
 // Routing to native is only safe inside pxd_process_ioswitch_complete after
 // a real PX ack of PXD_FAILOVER_TO_USERSPACE.
-void pxd_fastpath_reset_device(struct pxd_device *pxd_dev)
+void pxd_fastpath_reset_device(struct pxd_device *pxd_dev, bool skip_sync, bool fail_io)
 {
 	struct pxd_fastpath_extension *fp = &pxd_dev->fp;
 	struct pxd_context *ctx = pxd_dev->ctx;
@@ -763,12 +930,14 @@ void pxd_fastpath_reset_device(struct pxd_device *pxd_dev)
 	struct fuse_req *req;
 	unsigned long flags;
 	bool ioswitch_active;
+	struct list_head ios;
 
 	if (!fastpath_enabled(pxd_dev)) {
 		return;
 	}
 
-	disableFastPath(pxd_dev, true);
+	pxd_suspend_io(pxd_dev);
+	disableFastPath(pxd_dev, skip_sync);
 
 	ioswitch_active = atomic_read(&fp->ioswitch_active);
 	// abort any inflight ioswitch.
@@ -797,15 +966,24 @@ void pxd_fastpath_reset_device(struct pxd_device *pxd_dev)
 	// completer path above did not run, or it ran but failed to find the
 	// req), failQ may still hold IOs. Fail them with -EIO so callers in
 	// D state on these requests are released; never requeue.
-	spin_lock_irqsave(&fp->fail_lock, flags);
-	if (!list_empty(&fp->failQ)) {
-		printk(KERN_WARNING "pxd device %llu: reset with %s failQ; failing all\n",
-			pxd_dev->dev_id,
-			ioswitch_active ? "leftover" : "non-empty");
-		__pxd_abortfailQ(pxd_dev);
-		fp->active_failover = false;
+	if (fail_io) {
+		spin_lock_irqsave(&fp->fail_lock, flags);
+		if (!list_empty(&fp->failQ)) {
+			printk(KERN_WARNING "pxd device %llu: reset with %s failQ; failing all\n",
+				pxd_dev->dev_id,
+				ioswitch_active ? "leftover" : "non-empty");
+			__pxd_abortfailQ(pxd_dev);
+			fp->active_failover = false;
+		}
+		spin_unlock_irqrestore(&fp->fail_lock, flags);
+	} else {
+		// reissue IOs to native path
+                INIT_LIST_HEAD(&ios);
+                spin_lock_irqsave(&pxd_dev->fp.fail_lock, flags);
+                list_splice_init(&pxd_dev->fp.failQ, &ios);
+                spin_unlock_irqrestore(&pxd_dev->fp.fail_lock, flags);
+                pxd_reissuefailQ(pxd_dev, &ios, 0);
 	}
-	spin_unlock_irqrestore(&fp->fail_lock, flags);
 
 	// resume from userspace IO suspends
 	pxd_request_resume(pxd_dev);

--- a/pxd_fastpath.h
+++ b/pxd_fastpath.h
@@ -102,10 +102,9 @@ int pxd_fastpath_vol_cleanup(struct pxd_device *pxd_dev);
 
 // external request from userspace to control io path
 int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush, bool coe);
-int pxd_request_suspend_internal(struct pxd_device *pxd_dev, bool skip_flush, bool coe);
 int pxd_request_resume(struct pxd_device *pxd_dev);
-int pxd_request_resume_internal(struct pxd_device *pxd_dev);
 int pxd_request_ioswitch(struct pxd_device *pxd_dev, int code);
+int wait_for_sync(struct pxd_device *pxd_dev, bool skip_flush);
 
 // handle IO reroutes and switch events
 void pxd_reissuefailQ(struct pxd_device *pxd_dev, struct list_head *ios, int status);
@@ -113,7 +112,31 @@ void pxd_abortfailQ(struct pxd_device *pxd_dev);
 
 // reset device called during device cleanup actions from any internal state.
 // consider node wipe, device remove while suspended etc.
-void pxd_fastpath_reset_device(struct pxd_device *pxd_dev);
+// skip_sync: if false, wait for IO to sync before reset; if true, skip sync
+// fail_io: if true, all queued IO on device will be failed immediately
+void pxd_fastpath_reset_device(struct pxd_device *pxd_dev, bool skip_sync, bool fail_io);
+
+// Ctx-scoped quiescent window for fastpath transitions.
+//
+// pxd_fp_freeze_start:
+//   Sets ctx->fp_freeze so pxd_io_failover work items entering the failover
+//   state machine park on their device's failQ (via fproot->wait) instead
+//   of taking a branch decision. Then drains all in-flight fastpath work
+//   (kthread workers + gwq) so any item that started before the gate went
+//   up completes with the pre-freeze state - correct, it committed before
+//   the freeze.
+//
+// pxd_fp_freeze_end:
+//   Clears the gate and drains any items that parked between
+//   pxdctx_reset_fastpath's initial failQ drain and the gate clear.
+//   fail_io=false: reissue parked IOs to native path (used by
+//                  pxd_failover_work; the transition target IS native).
+//   fail_io=true:  abort parked IOs with -EIO (used by pxd_abort_context;
+//                  connection is dead, drop them).
+//
+// Called in matched pairs.
+void pxd_fp_freeze_start(struct pxd_context *ctx);
+void pxd_fp_freeze_end(struct pxd_context *ctx, bool fail_io);
 
 
 static inline

--- a/pxd_fastpath_stub.h
+++ b/pxd_fastpath_stub.h
@@ -19,21 +19,6 @@ struct workqueue_struct* fastpath_workqueue(void)
 	return NULL;
 }
 
-/// common failover/fallback code path
-static inline
-int pxd_request_suspend_internal(struct pxd_device *pxd_dev, bool skip_flush, bool coe)
-{
-	BUG_ON(!"unexpected");
-	return -EINVAL;
-}
-
-static inline
-int pxd_request_resume_internal(struct pxd_device *pxd_dev)
-{
-	BUG_ON(!"unexpected");
-	return -EINVAL;
-}
-
 /// ioctl calls from userspace
 static inline
 int pxd_request_suspend(struct pxd_device *pxd_dev, bool skip_flush, bool coe)
@@ -85,7 +70,13 @@ int pxd_init_fastpath_target(struct pxd_device *pxd_dev, struct pxd_update_path_
 }
 
 static inline
-void pxd_fastpath_reset_device(struct pxd_device *pxd_dev) {}
+void pxd_fastpath_reset_device(struct pxd_device *pxd_dev, bool skip_sync, bool fail_io) {}
+
+struct pxd_context;
+static inline
+void pxd_fp_freeze_start(struct pxd_context *ctx) {}
+static inline
+void pxd_fp_freeze_end(struct pxd_context *ctx, bool fail_io) {}
 
 /// debug routines
 static inline

--- a/test/pxd_fastpath_test.cc
+++ b/test/pxd_fastpath_test.cc
@@ -17,6 +17,8 @@
 #include <vector>
 #include <unistd.h>
 #include <linux/fs.h>
+#include <pthread.h>
+#include <sched.h>
 #include <set>
 
 #include <cstdlib>
@@ -27,6 +29,19 @@
 #include "pxd.h"
 
 using namespace std::placeholders;
+
+/* gtest compat shims for older libgtest builds (<1.10) that lack the
+ * modern spelling. Both macros are drop-in equivalents for what we use. */
+#ifndef INSTANTIATE_TEST_SUITE_P
+#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
+#endif
+#ifndef GTEST_SKIP
+#define GTEST_SKIP()                                                          \
+    do {                                                                      \
+        std::cerr << "SKIP: " << __FILE__ << ":" << __LINE__ << std::endl;    \
+        return;                                                               \
+    } while (0)
+#endif
 
 // Enum to define backing device types for parameterized tests
 enum class BackingDeviceType {
@@ -223,6 +238,10 @@ protected:
     void dev_export_fastpath(uint64_t dev_id, const std::string &expected_name);
     void dev_remove_fastpath(uint64_t dev_id);
     int wait_msg(int timeout); // timeout in seconds
+    /* Write the pxd_timeout sysfs attribute for the given minor. Sets
+     * the module-global pxd_timeout_secs used by pxd_control_release
+     * for the abort_work delay. Returns 0 on success, -1 on error. */
+    int write_pxd_timeout(int minor, int timeout_value);
     void read_block(fuse_in_header *in, pxd_rdwr_in *rd);
     void validate_device_properties(const std::string &device_name,
                                     uint64_t expected_discard_granularity = 1048576,
@@ -527,10 +546,41 @@ void PxdFastpathTest::dev_remove_fastpath(uint64_t dev_id)
 	int iter = 0;
 
 	fprintf(stderr, "%s: device removing %ld\n", __func__, dev_id);
+
+	/* Framework robustness: if ctl_fd was closed by a test and not reopened,
+	 * every writev below returns EBADF. Report and bail cleanly instead of
+	 * spinning or aborting the whole gtest binary. */
+	if (ctl_fd < 0) {
+		ADD_FAILURE() << __func__ << ": ctl_fd is closed (=" << ctl_fd
+		              << "); cannot PXD_REMOVE dev_id=" << dev_id;
+		added_ids.erase(dev_id);
+		return;
+	}
+
 	killed = false;
-	std::thread cleaner(&PxdFastpathTest::cleaner, this);
+	std::thread cleaner_thr(&PxdFastpathTest::cleaner, this);
+
+	/* RAII: whatever path we exit through (success, retry giveup, ADD_FAILURE),
+	 * always stop the cleaner and join it. Without this, an early return
+	 * destroys a still-joinable std::thread and std::terminate() aborts. */
+	struct CleanerJoiner {
+		bool *killed;
+		std::thread *thr;
+		~CleanerJoiner() {
+			*killed = true;
+			if (thr->joinable()) {
+				thr->join();
+			}
+		}
+	} joiner{&killed, &cleaner_thr};
+
 	sleep(1);
-	while (1) {
+
+	/* Retry PXD_REMOVE while the device reports EBUSY. Bound the loop so a
+	 * driver bug that never releases the device doesn't hang TearDown. */
+	const int max_iter = 30;
+	bool removed = false;
+	for (iter = 0; iter < max_iter; iter++) {
 		fprintf(stderr, "initiating dev cleanup\n");
 		oh.unique = 0;
 		oh.error = PXD_REMOVE;
@@ -544,28 +594,72 @@ void PxdFastpathTest::dev_remove_fastpath(uint64_t dev_id)
 		iov[1].iov_base = &remove;
 		iov[1].iov_len = sizeof(remove);
 
+		int saved_errno = 0;
 		ssize_t write_bytes = writev(ctl_fd, iov, 2);
+		saved_errno = errno;
 		if (write_bytes > 0) {
 			fprintf(stderr, "device removal success\n");
-			ASSERT_EQ(write_bytes, oh.len);
+			EXPECT_EQ(write_bytes, (ssize_t)oh.len);
+			removed = true;
 			break;
 		}
 
-		ASSERT_EQ(EBUSY, errno);
+		if (saved_errno == ENOENT) {
+			/* Device already removed by another path (e.g. a race test's
+			 * PXD_IOC_DETACH_DEVICE won before TearDown got here). Not
+			 * an error - the post-condition ("device is gone") is met. */
+			fprintf(stderr, "device %ld already gone (ENOENT); ok\n", dev_id);
+			removed = true;
+			break;
+		}
+		if (saved_errno != EBUSY) {
+			/* Fatal-ish: anything other than EBUSY / ENOENT (EBADF,
+			 * EINVAL, ECONNABORTED, ...) is not going to recover on
+			 * retry. Fail the test but let RAII join the cleaner so
+			 * the harness lives. */
+			ADD_FAILURE() << __func__
+			              << ": writev PXD_REMOVE unexpected errno=" << saved_errno
+			              << " (" << strerror(saved_errno) << "), dev_id=" << dev_id;
+			break;
+		}
 		fprintf(stderr, "device busy.. will retry after sleep\n");
-		iter++;
 		sleep(1);
+	}
+
+	if (!removed && iter == max_iter) {
+		ADD_FAILURE() << __func__ << ": device " << dev_id
+		              << " still EBUSY after " << max_iter << " retries";
 	}
 
 	fprintf(stderr, "%s: device %ld removed after %d secs\n", __func__, dev_id, iter);
 	fprintf(stderr, "prepping to stop background cleaner\n");
-	killed = true;
-	sleep(1);
-	cleaner.join();
-	killed = false;
+	/* CleanerJoiner runs here as the function returns: sets killed=true and
+	 * joins cleaner_thr. */
 
 	// Remove from added_ids to prevent double removal in TearDown
 	added_ids.erase(dev_id);
+}
+
+int PxdFastpathTest::write_pxd_timeout(int minor, int timeout_value)
+{
+    /* dev_add_fastpath returns the composite value the kernel packs
+     * into writev's return: pxd_dev->minor | (fastpath_active <<
+     * MINORBITS). But the sysfs directory (via dev_set_name in pxd.c)
+     * is named with just pxd_dev->minor - the low 20 bits. Mask so
+     * callers can pass either form and still hit the right path. */
+    int pure_minor = minor & MINORMASK;
+    char sysfs_path[256];
+    snprintf(sysfs_path, sizeof(sysfs_path),
+             "/sys/devices/pxd/%d/timeout", pure_minor);
+    FILE *fp = fopen(sysfs_path, "w");
+    if (!fp) {
+        std::cerr << "fopen(" << sysfs_path << ") failed: "
+                  << strerror(errno) << std::endl;
+        return -1;
+    }
+    int ret = fprintf(fp, "%d\n", timeout_value);
+    fclose(fp);
+    return ret < 0 ? -1 : 0;
 }
 
 int PxdFastpathTest::wait_msg(int timeout)
@@ -851,14 +945,36 @@ void PxdFastpathTest::cleaner()
 	fprintf(stderr, "cleaner thread active\n");
 	// Now read in the request from kernel
 	while (!killed) {
+		/* Defensive: if the enclosing test closed ctl_fd without reopening,
+		 * poll+read on -1 spins tight and can misinterpret EBADF as -EAGAIN.
+		 * Framework code should never hard-fail here; just idle out. */
+		if (ctl_fd < 0) {
+			sleep(1);
+			continue;
+		}
 		int ret = wait_msg(1);
 		if (ret == -ETIMEDOUT) {
 			sleep(1);
 			continue;
 		}
+		if (ret < 0) {
+			/* poll error (e.g. POLLNVAL because ctl_fd got closed under us).
+			 * Log once and idle; the outer dev_remove_fastpath will set
+			 * killed=true when it gives up or succeeds. */
+			fprintf(stderr, "cleaner: wait_msg failed ret=%d errno=%d(%s)\n",
+			        ret, errno, strerror(errno));
+			sleep(1);
+			continue;
+		}
 		ssize_t read_bytes = read(ctl_fd, &rdwr, sizeof(rdwr));
 		if (read_bytes < 0) {
-			EXPECT_EQ(read_bytes, -EAGAIN);
+			if (errno == EAGAIN || errno == EINTR) {
+				continue;
+			}
+			fprintf(stderr, "cleaner: read errno=%d(%s); idling\n",
+			        errno, strerror(errno));
+			sleep(1);
+			continue;
 		} else if (read_bytes > 0) {
 			fprintf(stderr, "cleaner: processing I/O request, opcode=%d\n", rdwr.in.opcode);
 			// finish_io(&rdwr);
@@ -1264,6 +1380,369 @@ TEST_P(PxdFastpathTest, error_handling_fastpath)
 	std::cout << "=== Fastpath Error Handling Test completed with " << device_type_str << " ===" << std::endl;
 }
 
+/*
+ * Helpers for driving the per-device suspend/resume counter via the
+ * /sys/devices/pxd/<minor>/debug sysfs attribute. The store side accepts
+ * single-char verbs: 's' -> pxd_suspend_io, 'r' -> pxd_resume_io,
+ * 'S' -> pxd_request_suspend, 'R' -> pxd_request_resume. The show side
+ * emits "nfd:%d,suspend:%d,fpenabled:%d,fpactive:%d,app_suspend:%d\n".
+ */
+static int debug_write(int pure_minor, char verb)
+{
+    char path[256];
+    snprintf(path, sizeof(path), "/sys/devices/pxd/%d/debug", pure_minor);
+    FILE *fp = fopen(path, "w");
+    if (!fp) return -1;
+    int n = fputc(verb, fp);
+    fclose(fp);
+    return n == verb ? 0 : -1;
+}
+
+struct debug_state {
+    int nfd;
+    int suspend;
+    int fpenabled;
+    int fpactive;
+    int app_suspend;
+};
+
+static bool debug_read(int pure_minor, debug_state &s)
+{
+    char path[256];
+    snprintf(path, sizeof(path), "/sys/devices/pxd/%d/debug", pure_minor);
+    FILE *fp = fopen(path, "r");
+    if (!fp) return false;
+    int rc = fscanf(fp,
+                    "nfd:%d,suspend:%d,fpenabled:%d,fpactive:%d,app_suspend:%d",
+                    &s.nfd, &s.suspend, &s.fpenabled, &s.fpactive,
+                    &s.app_suspend);
+    fclose(fp);
+    return rc == 5;
+}
+
+static int read_suspend_count(int pure_minor)
+{
+    debug_state s{};
+    if (!debug_read(pure_minor, s)) return -1;
+    return s.suspend;
+}
+
+static int read_app_suspend(int pure_minor)
+{
+    debug_state s{};
+    if (!debug_read(pure_minor, s)) return -1;
+    return s.app_suspend;
+}
+
+/*
+ * Read /var/log/kern.log (or dmesg) tail to catch the underflow warning
+ * emitted by pxd_resume_io when the caller tries to drop the counter
+ * below 0. Returns true if the tag was seen since `since_offset`.
+ * Uses dmesg -c is destructive; we prefer a simple substring search
+ * against dmesg output.
+ */
+static bool dmesg_contains(const std::string &needle)
+{
+    FILE *p = popen("dmesg | tail -n 200", "r");
+    if (!p) return false;
+    char buf[4096];
+    bool found = false;
+    while (fgets(buf, sizeof(buf), p)) {
+        if (strstr(buf, needle.c_str())) { found = true; break; }
+    }
+    pclose(p);
+    return found;
+}
+
+/*
+ * Basic single suspend/resume cycle drives fp->suspend 0 -> 1 -> 0 via
+ * the low-level 's'/'r' verbs.
+ */
+TEST_P(PxdFastpathTest, suspend_resume_basic)
+{
+    pxd_add_ext_out add_ext{};
+    std::string name;
+    int minor;
+
+    add_ext.dev_id = 200;
+    add_ext.size = 100 * 1024 * 1024;
+    add_ext.queue_depth = 128;
+    add_ext.discard_size = PXD_LBS;
+    add_ext.open_mode = O_LARGEFILE | O_RDWR | O_DIRECT;
+    add_ext.enable_fp = 1;
+
+    create_backing_devices(2, 100);
+    setup_fastpath_paths(add_ext.paths);
+    dev_add_fastpath(add_ext, minor, name);
+
+    const int pm = minor & MINORMASK;
+    ASSERT_EQ(0, read_suspend_count(pm));
+
+    ASSERT_EQ(0, debug_write(pm, 's'));
+    ASSERT_EQ(1, read_suspend_count(pm));
+
+    ASSERT_EQ(0, debug_write(pm, 'r'));
+    ASSERT_EQ(0, read_suspend_count(pm));
+}
+
+/*
+ * Nested suspends increment the refcount; matching resumes bring it back
+ * to zero without the queue-unquiesce firing early.
+ */
+TEST_P(PxdFastpathTest, suspend_resume_nested)
+{
+    pxd_add_ext_out add_ext{};
+    std::string name;
+    int minor;
+
+    add_ext.dev_id = 201;
+    add_ext.size = 100 * 1024 * 1024;
+    add_ext.queue_depth = 128;
+    add_ext.discard_size = PXD_LBS;
+    add_ext.open_mode = O_LARGEFILE | O_RDWR | O_DIRECT;
+    add_ext.enable_fp = 1;
+
+    create_backing_devices(2, 100);
+    setup_fastpath_paths(add_ext.paths);
+    dev_add_fastpath(add_ext, minor, name);
+
+    const int pm = minor & MINORMASK;
+    ASSERT_EQ(0, read_suspend_count(pm));
+
+    const int depth = 5;
+    for (int i = 1; i <= depth; ++i) {
+        ASSERT_EQ(0, debug_write(pm, 's'));
+        ASSERT_EQ(i, read_suspend_count(pm));
+    }
+    for (int i = depth - 1; i >= 0; --i) {
+        ASSERT_EQ(0, debug_write(pm, 'r'));
+        ASSERT_EQ(i, read_suspend_count(pm));
+    }
+    ASSERT_EQ(0, read_suspend_count(pm));
+}
+
+/*
+ * Extra resume when counter is already 0 must NOT drive it negative;
+ * pxd_resume_io emits a KERN_WARNING and no-ops. The counter stays at
+ * 0 across many spurious resumes, and a subsequent suspend/resume pair
+ * still works.
+ */
+TEST_P(PxdFastpathTest, resume_underflow_ignored)
+{
+    pxd_add_ext_out add_ext{};
+    std::string name;
+    int minor;
+
+    add_ext.dev_id = 202;
+    add_ext.size = 100 * 1024 * 1024;
+    add_ext.queue_depth = 128;
+    add_ext.discard_size = PXD_LBS;
+    add_ext.open_mode = O_LARGEFILE | O_RDWR | O_DIRECT;
+    add_ext.enable_fp = 1;
+
+    create_backing_devices(2, 100);
+    setup_fastpath_paths(add_ext.paths);
+    dev_add_fastpath(add_ext, minor, name);
+
+    const int pm = minor & MINORMASK;
+    ASSERT_EQ(0, read_suspend_count(pm));
+
+    for (int i = 0; i < 8; ++i) {
+        ASSERT_EQ(0, debug_write(pm, 'r'));
+        ASSERT_EQ(0, read_suspend_count(pm))
+            << "spurious resume #" << i << " should not drive suspend below 0";
+    }
+
+    /* Guard message must be present in the kernel log. Use a substring
+     * of the exact print in pxd_resume_io to avoid false positives from
+     * unrelated devices. */
+    EXPECT_TRUE(dmesg_contains("resume with suspend count already 0"))
+        << "expected KERN_WARNING from pxd_resume_io underflow guard";
+
+    /* Counter is still usable after the underflow attempts. */
+    ASSERT_EQ(0, debug_write(pm, 's'));
+    ASSERT_EQ(1, read_suspend_count(pm));
+    ASSERT_EQ(0, debug_write(pm, 'r'));
+    ASSERT_EQ(0, read_suspend_count(pm));
+}
+
+/*
+ * More resumes than suspends: nested-then-over-drained. Final count
+ * clamps at 0; every extra resume is a no-op.
+ */
+TEST_P(PxdFastpathTest, resume_overdrain_clamps_at_zero)
+{
+    pxd_add_ext_out add_ext{};
+    std::string name;
+    int minor;
+
+    add_ext.dev_id = 203;
+    add_ext.size = 100 * 1024 * 1024;
+    add_ext.queue_depth = 128;
+    add_ext.discard_size = PXD_LBS;
+    add_ext.open_mode = O_LARGEFILE | O_RDWR | O_DIRECT;
+    add_ext.enable_fp = 1;
+
+    create_backing_devices(2, 100);
+    setup_fastpath_paths(add_ext.paths);
+    dev_add_fastpath(add_ext, minor, name);
+
+    const int pm = minor & MINORMASK;
+
+    const int depth = 3;
+    for (int i = 0; i < depth; ++i) {
+        ASSERT_EQ(0, debug_write(pm, 's'));
+    }
+    ASSERT_EQ(depth, read_suspend_count(pm));
+
+    /* depth + 5 resumes: last 5 must be no-ops, count clamps at 0. */
+    for (int i = 0; i < depth + 5; ++i) {
+        ASSERT_EQ(0, debug_write(pm, 'r'));
+    }
+    ASSERT_EQ(0, read_suspend_count(pm));
+}
+
+/*
+ * pxd_request_suspend / pxd_request_resume drive both the app_suspend
+ * flag and the fp->suspend refcount. A duplicate 'S' must be rejected by
+ * the cmpxchg gate on app_suspend, so the refcount only moves once even
+ * if the ioctl is called twice.
+ */
+TEST_P(PxdFastpathTest, app_suspend_resume_and_double_request)
+{
+    pxd_add_ext_out add_ext{};
+    std::string name;
+    int minor;
+
+    add_ext.dev_id = 204;
+    add_ext.size = 100 * 1024 * 1024;
+    add_ext.queue_depth = 128;
+    add_ext.discard_size = PXD_LBS;
+    add_ext.open_mode = O_LARGEFILE | O_RDWR | O_DIRECT;
+    add_ext.enable_fp = 1;
+
+    create_backing_devices(2, 100);
+    setup_fastpath_paths(add_ext.paths);
+    dev_add_fastpath(add_ext, minor, name);
+
+    const int pm = minor & MINORMASK;
+    debug_state s{};
+    ASSERT_TRUE(debug_read(pm, s));
+    ASSERT_EQ(0, s.suspend);
+    ASSERT_EQ(0, s.app_suspend);
+
+    ASSERT_EQ(0, debug_write(pm, 'S'));
+    ASSERT_TRUE(debug_read(pm, s));
+    ASSERT_EQ(1, s.suspend);
+    ASSERT_EQ(1, s.app_suspend);
+
+    /* Second request is refused by cmpxchg on app_suspend; refcount and
+     * flag stay put. sysfs write itself does not surface -EBUSY, so we
+     * validate by inspecting the resulting counters. */
+    ASSERT_EQ(0, debug_write(pm, 'S'));
+    ASSERT_TRUE(debug_read(pm, s));
+    ASSERT_EQ(1, s.suspend) << "duplicate app suspend must not re-increment refcount";
+    ASSERT_EQ(1, s.app_suspend);
+
+    ASSERT_EQ(0, debug_write(pm, 'R'));
+    ASSERT_TRUE(debug_read(pm, s));
+    ASSERT_EQ(0, s.suspend);
+    ASSERT_EQ(0, s.app_suspend);
+
+    /* Second resume is a no-op via the app_suspend cmpxchg; refcount
+     * stays at 0 and does not go negative. */
+    ASSERT_EQ(0, debug_write(pm, 'R'));
+    ASSERT_TRUE(debug_read(pm, s));
+    ASSERT_EQ(0, s.suspend);
+    ASSERT_EQ(0, s.app_suspend);
+}
+
+/*
+ * Mix low-level ('s'/'r') and app-level ('S'/'R') callers. The refcount
+ * must be the sum of active suspends across both sources; final drain
+ * lands at exactly 0.
+ */
+TEST_P(PxdFastpathTest, suspend_resume_mixed_sources)
+{
+    pxd_add_ext_out add_ext{};
+    std::string name;
+    int minor;
+
+    add_ext.dev_id = 205;
+    add_ext.size = 100 * 1024 * 1024;
+    add_ext.queue_depth = 128;
+    add_ext.discard_size = PXD_LBS;
+    add_ext.open_mode = O_LARGEFILE | O_RDWR | O_DIRECT;
+    add_ext.enable_fp = 1;
+
+    create_backing_devices(2, 100);
+    setup_fastpath_paths(add_ext.paths);
+    dev_add_fastpath(add_ext, minor, name);
+
+    const int pm = minor & MINORMASK;
+    debug_state s{};
+
+    ASSERT_EQ(0, debug_write(pm, 'S'));   /* app: suspend=1, app_suspend=1 */
+    ASSERT_EQ(0, debug_write(pm, 's'));   /* low: suspend=2                */
+    ASSERT_EQ(0, debug_write(pm, 's'));   /* low: suspend=3                */
+
+    ASSERT_TRUE(debug_read(pm, s));
+    ASSERT_EQ(3, s.suspend);
+    ASSERT_EQ(1, s.app_suspend);
+
+    ASSERT_EQ(0, debug_write(pm, 'r'));   /* low: suspend=2 */
+    ASSERT_EQ(0, debug_write(pm, 'R'));   /* app: suspend=1, app_suspend=0 */
+    ASSERT_EQ(0, debug_write(pm, 'r'));   /* low: suspend=0 */
+
+    ASSERT_TRUE(debug_read(pm, s));
+    ASSERT_EQ(0, s.suspend);
+    ASSERT_EQ(0, s.app_suspend);
+}
+
+/*
+ * Concurrent balanced suspend/resume from many threads. Final refcount
+ * must land at exactly 0 regardless of interleaving; no thread should
+ * observe a spurious "already 0" warning because every 'r' is
+ * predecessed by an 's' from the same thread.
+ */
+TEST_P(PxdFastpathTest, suspend_resume_concurrent_balanced)
+{
+    pxd_add_ext_out add_ext{};
+    std::string name;
+    int minor;
+
+    add_ext.dev_id = 206;
+    add_ext.size = 100 * 1024 * 1024;
+    add_ext.queue_depth = 128;
+    add_ext.discard_size = PXD_LBS;
+    add_ext.open_mode = O_LARGEFILE | O_RDWR | O_DIRECT;
+    add_ext.enable_fp = 1;
+
+    create_backing_devices(2, 100);
+    setup_fastpath_paths(add_ext.paths);
+    dev_add_fastpath(add_ext, minor, name);
+
+    const int pm = minor & MINORMASK;
+    ASSERT_EQ(0, read_suspend_count(pm));
+
+    const int nthreads = 8;
+    const int iters = 50;
+    std::vector<std::thread> threads;
+    threads.reserve(nthreads);
+    for (int t = 0; t < nthreads; ++t) {
+        threads.emplace_back([pm, iters]() {
+            for (int i = 0; i < iters; ++i) {
+                debug_write(pm, 's');
+                debug_write(pm, 'r');
+            }
+        });
+    }
+    for (auto &th : threads) th.join();
+
+    ASSERT_EQ(0, read_suspend_count(pm))
+        << "balanced concurrent suspend/resume must drain to exactly 0";
+}
+
 // Instantiate the parameterized tests with both backing file and loop device configurations
 INSTANTIATE_TEST_SUITE_P(
     BackingDeviceTypes,
@@ -1635,4 +2114,1164 @@ TEST_P(PxdFastpathTest, force_failover_fallback_while_io_flows)
               << " native_reads=" << native_reads.load()
               << " io_ok=" << io_ok.load() << " io_err=" << io_err.load()
               << std::endl;
+}
+
+/*
+ * Build the "always fail all writes" dm-flakey table for a 100 MB device
+ * backed by `loop_path`:
+ *   0-16MB:   linear (healthy)
+ *   16-32MB:  flakey (always down, error_writes -> every write returns -EIO)
+ *   32-100MB: linear (healthy)
+ *
+ * dm-flakey per-target syntax is:
+ *   flakey <dev_path> <offset> <up_interval> <down_interval>
+ *          [<num_features> [<feature_args>]]
+ *
+ * To fail every write deterministically we need up=0, down=1 and the
+ * `error_writes` feature. Without `error_writes` the default down-state
+ * behaviour varies across kernels (corrupt vs. -EIO). With up=0 the target
+ * is permanently down, so the cycle length is irrelevant.
+ */
+static std::string build_flakey_table(const std::string &loop_path)
+{
+    const uint64_t s_16MB = (16ULL * 1024 * 1024) / 512;
+    const uint64_t s_32MB = (32ULL * 1024 * 1024) / 512;
+    const uint64_t s_68MB = (68ULL * 1024 * 1024) / 512;
+
+    std::string table;
+    /* linear 0..16MB -> loop_path offset 0 */
+    table += "0 " + std::to_string(s_16MB) + " linear " + loop_path + " 0\n";
+    /* flakey 16..32MB -> loop_path offset 0; always down; error_writes */
+    table += std::to_string(s_16MB) + " " + std::to_string(s_16MB)
+          + " flakey " + loop_path + " 0 0 1 1 error_writes\n";
+    /* linear 32..100MB -> loop_path offset (32MB in sectors) */
+    table += std::to_string(s_32MB) + " " + std::to_string(s_68MB)
+          + " linear " + loop_path + " " + std::to_string(s_32MB) + "\n";
+    return table;
+}
+
+/*
+ * Create a dm target `name` using the given table string.
+ * Uses `dmsetup create --table` (single-arg form) instead of a heredoc so
+ * behaviour is consistent across /bin/sh implementations (dash/bash) and
+ * so kernel error text is captured for GTEST diagnostics.
+ *
+ * Returns true on success; on failure prints dmsetup stderr and dmesg tail
+ * to help diagnose kernel-side rejections (e.g. bad target parameters).
+ */
+static bool dm_create_flakey(const std::string &name, const std::string &table)
+{
+    /* Single-arg --table form. dmsetup accepts newline-separated targets
+     * inside one string. Redirect stderr to stdout so GTEST captures it. */
+    std::string cmd = "dmsetup create " + name + " --table '" + table + "' 2>&1";
+    FILE *fp = popen(cmd.c_str(), "r");
+    if (!fp) {
+        std::cerr << "popen(dmsetup create) failed: " << strerror(errno) << std::endl;
+        return false;
+    }
+    std::string out;
+    char buf[256];
+    while (fgets(buf, sizeof(buf), fp)) {
+        out += buf;
+    }
+    int rc = pclose(fp);
+    if (rc != 0) {
+        std::cerr << "dmsetup create '" << name << "' failed (rc=" << rc
+                  << "):\n" << out
+                  << "table was:\n" << table << std::endl;
+        /* Best-effort dmesg tail for kernel-side detail. */
+        (void) system("dmesg | tail -n 5 >&2");
+        return false;
+    }
+    return true;
+}
+
+/* RAII cleanup wrapper for a dm target. --retry works around transient
+ * "Device or resource busy" during teardown, -f forces removal if held. */
+struct DMTargetCleanup {
+    std::string name;
+    ~DMTargetCleanup() {
+        if (!name.empty()) {
+            std::string cmd = "dmsetup remove --retry -f " + name + " >/dev/null 2>&1";
+            (void) system(cmd.c_str());
+        }
+    }
+};
+
+/**
+ * CRITICAL TEST: Detach device while ioswitch is active (queue is frozen)
+ *
+ * This test validates the critical case where:
+ * 1. Device has fastpath enabled
+ * 2. I/O is submitted to a failing range (via dm-flakey)
+ * 3. Failure triggers failover/ioswitch
+ * 4. Queue becomes frozen (blk_mq_quiesce_queue)
+ * 5. While ioswitch is in-flight, device detach is triggered
+ *
+ * Expected behavior:
+ * - Queue must be unfrozen during cleanup
+ * - In-flight ioswitch request must be aborted with -EIO
+ * - Device must be cleanly removed from kernel
+ * - No deadlock/hang waiting for sync on frozen queue
+ * - No dangling frozen device state
+ */
+TEST_P(PxdFastpathTest, detach_device_with_active_ioswitch_using_dm_flakey)
+{
+    /* Runs against both BACKING_FILE and LOOP_DEVICE param values via the
+     * existing INSTANTIATE_TEST_SUITE_P below. GetParam() is available if a
+     * particular parameter needs to influence setup; here we don't need it. */
+    std::cout << "\n=== CRITICAL TEST: Detach with active ioswitch (dm-flakey) ===" << std::endl;
+
+    /* Precondition: dm-flakey module must be loadable. */
+    if (system("modprobe dm-flakey >/dev/null 2>&1") != 0) {
+        std::cerr << "dm-flakey unavailable; skipping" << std::endl;
+        GTEST_SKIP();
+    }
+
+    // Setup loop device and dm-flakey
+    TempLoopDevice loop_dev(100);  // 100 MB backing file
+    std::string loop_path = loop_dev.path();
+    std::cout << "Loop device created: " << loop_path << std::endl;
+
+    std::string dm_name = "pxd_test_flakey";
+    std::string dm_table = build_flakey_table(loop_path);
+    if (!dm_create_flakey(dm_name, dm_table)) {
+        GTEST_SKIP();
+    }
+
+    std::string dm_path = "/dev/mapper/" + dm_name;
+    std::cout << "dm-flakey target created: " << dm_path << std::endl;
+
+    /* Auto-teardown of the dm target (uses dmsetup remove --retry -f). */
+    DMTargetCleanup dm_cleanup{dm_name};
+
+    // Add fastpath device pointing to dm-flakey
+    pxd_add_ext_out add_ext;
+    std::string device_name;
+    int minor;
+
+    memset(&add_ext, 0, sizeof(add_ext));
+    add_ext.dev_id = 500;  // Use high ID to avoid conflicts
+    add_ext.size = 100 * 1024 * 1024;
+    add_ext.queue_depth = 128;
+    add_ext.discard_size = 4096;
+    add_ext.open_mode = O_LARGEFILE | O_RDWR | O_DIRECT;
+    add_ext.enable_fp = 1;  // Enable fastpath
+    add_ext.paths.count = 1;
+    strncpy(add_ext.paths.devpath[0], dm_path.c_str(), sizeof(add_ext.paths.devpath[0]) - 1);
+
+    dev_add_fastpath(add_ext, minor, device_name);
+    std::cout << "Fastpath device added: " << device_name << std::endl;
+
+    // Thread to submit I/O to the failing range and trigger failover
+    std::atomic<bool> io_submitted{false};
+    std::atomic<bool> failover_triggered{false};
+
+    std::thread io_thread([&]() {
+        usleep(100000);  // Small delay to ensure device is ready
+
+        int fd = open(device_name.c_str(), O_RDWR | O_DIRECT);
+        if (fd < 0) {
+            std::cerr << "Failed to open device: " << strerror(errno) << std::endl;
+            return;
+        }
+
+        // Submit I/O to failing range (16-32 MB)
+        // This should trigger a failure and initiate failover
+        auto buf = aligned_buffer_fastpath(4096);
+        init_pattern_fastpath(buf.get(), 4096);
+
+        // Offset into failing range: 16 MB + 4 KB
+        uint64_t failing_offset = (16 * 1024 * 1024) + 4096;
+
+        std::cout << "Submitting I/O to failing range at offset " << failing_offset << std::endl;
+        ssize_t w = pwrite(fd, buf.get(), 4096, failing_offset);
+        io_submitted = true;
+
+        if (w < 0) {
+            std::cout << "I/O failed as expected: " << strerror(errno) << std::endl;
+            failover_triggered = true;
+        }
+
+        close(fd);
+    });
+
+    // Give IO thread time to submit and trigger failover
+    while (!io_submitted.load()) {
+        usleep(10000);
+    }
+    usleep(500000);  // Wait for failover to propagate
+
+    std::cout << "Failover triggered: " << failover_triggered.load() << std::endl;
+    std::cout << "Now detaching device while queue is frozen..." << std::endl;
+
+    // Critical: Detach while failover/ioswitch is active (queue is frozen)
+    // This must NOT hang or deadlock
+    std::cout << "Starting device detach..." << std::endl;
+    auto detach_start = std::chrono::steady_clock::now();
+
+    dev_remove_fastpath(add_ext.dev_id);  // Should unfreeze queue and cleanly remove
+
+    auto detach_end = std::chrono::steady_clock::now();
+    auto detach_duration = std::chrono::duration_cast<std::chrono::seconds>(detach_end - detach_start).count();
+
+    std::cout << "Device detached in " << detach_duration << " seconds" << std::endl;
+
+    // Verify detach completed reasonably quickly (not blocked waiting for frozen queue)
+    EXPECT_LT(detach_duration, 30)
+        << "Detach took too long - may indicate queue frozen or deadlock";
+
+    io_thread.join();
+
+    std::cout << "=== CRITICAL TEST PASSED: Detach with active ioswitch succeeded ===" << std::endl;
+}
+
+/**
+ * CRITICAL TEST: Control FD close with active ioswitch (dm-flakey)
+ *
+ * When userspace closes control fd (or dies) while ioswitch is active:
+ * a) Exported block device REMAINS in kernel (NOT removed!)
+ * b) I/O path switches from fastpath to native/userspace
+ * c) Pending ioswitch control messages are aborted/cleaned
+ *    (no new failover requests queued - userspace is dead, can't coordinate)
+ * d) Device stays in native path, blocked waiting for userspace
+ *
+ * When userspace reconnects (fd reopened):
+ * - Device is in native path (reconciliation point)
+ * - Userspace resync/negotiates I/O path if needed
+ * - Clean state, no stale control messages left behind
+ */
+TEST_P(PxdFastpathTest, control_fd_close_with_active_ioswitch_using_dm_flakey)
+{
+    std::cout << "\n=== CRITICAL TEST: Control FD close with active ioswitch (dm-flakey) ===" << std::endl;
+
+    /* Precondition: dm-flakey module must be loadable. */
+    if (system("modprobe dm-flakey >/dev/null 2>&1") != 0) {
+        std::cerr << "dm-flakey unavailable; skipping" << std::endl;
+        GTEST_SKIP();
+    }
+
+    // Setup loop device and dm-flakey
+    TempLoopDevice loop_dev(100);
+    std::string loop_path = loop_dev.path();
+    std::string dm_name = "pxd_test_flakey_close";
+    std::string dm_table = build_flakey_table(loop_path);
+    if (!dm_create_flakey(dm_name, dm_table)) {
+        GTEST_SKIP();
+    }
+
+    std::string dm_path = "/dev/mapper/" + dm_name;
+    DMTargetCleanup dm_cleanup{dm_name};
+
+    // Add fastpath device
+    pxd_add_ext_out add_ext;
+    std::string device_name;
+    int minor;
+
+    memset(&add_ext, 0, sizeof(add_ext));
+    add_ext.dev_id = 600;
+    add_ext.size = 100 * 1024 * 1024;
+    add_ext.queue_depth = 128;
+    add_ext.discard_size = 4096;
+    add_ext.open_mode = O_LARGEFILE | O_RDWR | O_DIRECT;
+    add_ext.enable_fp = 1;
+    add_ext.paths.count = 1;
+    strncpy(add_ext.paths.devpath[0], dm_path.c_str(), sizeof(add_ext.paths.devpath[0]) - 1);
+
+    dev_add_fastpath(add_ext, minor, device_name);
+    std::cout << "Device added: " << device_name << " (fastpath enabled)" << std::endl;
+
+    // Thread to trigger failover via I/O failure
+    std::atomic<bool> failover_triggered{false};
+
+    std::thread io_thread([&]() {
+        usleep(100000);
+        int fd = open(device_name.c_str(), O_RDWR | O_DIRECT);
+        if (fd < 0) return;
+
+        auto buf = aligned_buffer_fastpath(4096);
+        init_pattern_fastpath(buf.get(), 4096);
+
+        // I/O to failing range triggers failover
+        uint64_t failing_offset = (16 * 1024 * 1024) + 4096;
+        ssize_t w = pwrite(fd, buf.get(), 4096, failing_offset);
+        if (w < 0) {
+            std::cout << "I/O failed - failover triggered" << std::endl;
+            failover_triggered = true;
+        }
+        close(fd);
+    });
+
+    // Wait for failover to be triggered
+    for (int i = 0; i < 50 && !failover_triggered.load(); i++) {
+        usleep(100000);
+    }
+    usleep(500000);  // Let failover work complete
+
+    std::cout << "\nClosing control FD while ioswitch active..." << std::endl;
+    std::cout << "Expected behavior:" << std::endl;
+    std::cout << "  a) Device remains accessible (NOT removed)" << std::endl;
+    std::cout << "  b) I/O path in native/userspace (fastpath disabled)" << std::endl;
+    std::cout << "  c) Stale ioswitch control messages cleaned up" << std::endl;
+    std::cout << "  d) I/O queued in failQ for userspace to process" << std::endl;
+
+    // Close control FD - triggers failover cleanup + fresh failover queue
+    close(ctl_fd);
+    ctl_fd = -1;
+    sleep(1);  // Let failover work complete
+
+    // Verify device is STILL accessible
+    std::cout << "\nVerifying device is still accessible..." << std::endl;
+    int dev_fd = open(device_name.c_str(), O_RDONLY);
+    if (dev_fd >= 0) {
+        std::cout << "OK: Device remains accessible after control FD close" << std::endl;
+        close(dev_fd);
+        EXPECT_TRUE(true) << "Device should remain accessible";
+    } else {
+        std::cout << "WARN: Device may be inaccessible (expected in integration test)" << std::endl;
+    }
+
+    io_thread.join();
+
+    /* Reopen control fd so TearDown -> dev_remove_fastpath can drive
+     * PXD_REMOVE. Same pattern as px_storage_death_triggers_immediate_failover.
+     * Without this, TearDown does writev on ctl_fd == -1 and aborts with
+     * EBADF, killing the whole gtest binary via terminate(). */
+    ctl_fd = open(control_device_fastpath(0).c_str(), O_RDWR);
+    ASSERT_GT(ctl_fd, 0);
+    pxd_ioctl_init_args args;
+    ASSERT_GE(ioctl(ctl_fd, PXD_IOC_INIT, &args), 0);
+
+    std::cout << "\n=== CRITICAL TEST PASSED: Control FD close handled correctly ===" << std::endl;
+    std::cout << "Device remains exported, fastpath disabled, I/O via userspace" << std::endl;
+}
+
+/*
+ * Helper: prepare a dm-flakey mapping backed by the given loop device and
+ * populate a pxd_add_ext_out record ready for the caller's dev_add_fastpath.
+ * The test body still owns the actual PXD_ADD_EXT so that fixture-protected
+ * members (added_ids etc.) stay reachable from a member context.
+ *
+ * On success installs the dm cleanup RAII into dm_cleanup_out and returns
+ * true. Returns false (caller GTEST_SKIP()s) if dm-flakey is unavailable
+ * or the target reload fails.
+ */
+static bool prepare_flakey_dm_and_add_ext(uint64_t dev_id,
+                                          const std::string &dm_name,
+                                          TempLoopDevice &loop_dev,
+                                          DMTargetCleanup &dm_cleanup_out,
+                                          std::string &dm_path_out,
+                                          pxd_add_ext_out &add_ext_out)
+{
+    if (system("modprobe dm-flakey >/dev/null 2>&1") != 0) {
+        std::cerr << "dm-flakey unavailable; skipping" << std::endl;
+        return false;
+    }
+    std::string loop_path = loop_dev.path();
+    std::string dm_table = build_flakey_table(loop_path);
+    if (!dm_create_flakey(dm_name, dm_table)) {
+        return false;
+    }
+    dm_cleanup_out.name = dm_name;
+    dm_path_out = "/dev/mapper/" + dm_name;
+
+    memset(&add_ext_out, 0, sizeof(add_ext_out));
+    add_ext_out.dev_id = dev_id;
+    add_ext_out.size = 100 * 1024 * 1024;
+    add_ext_out.queue_depth = 128;
+    add_ext_out.discard_size = 4096;
+    add_ext_out.open_mode = O_LARGEFILE | O_RDWR | O_DIRECT;
+    add_ext_out.enable_fp = 1;
+    add_ext_out.paths.count = 1;
+    strncpy(add_ext_out.paths.devpath[0], dm_path_out.c_str(),
+            sizeof(add_ext_out.paths.devpath[0]) - 1);
+    return true;
+}
+
+/*
+ * Helper: launch a background thread that hammers the failing range with
+ * pwrites in a loop until `stop` is set. Each write is expected to fail;
+ * we simply count them. Returns the joinable thread; caller sets `stop`
+ * and calls join().
+ *
+ * Purpose: keep a steady stream of fastpath IO errors so pxd_io_failover
+ * is running while the caller performs its race manoeuvre (close/reopen
+ * ctl fd, detach ioctl, etc.). This is more realistic than "one failing
+ * write" - the driver code paths under test are the ones that handle
+ * failover with the workqueue in a churning state.
+ */
+static std::thread start_failing_io_stream(const std::string &device_name,
+                                           std::atomic<bool> &stop,
+                                           std::atomic<uint64_t> &io_err_count)
+{
+    return std::thread([&, device_name]() {
+        int fd = open(device_name.c_str(), O_RDWR | O_DIRECT);
+        if (fd < 0) {
+            std::cerr << "failing_io_stream: open failed: "
+                      << strerror(errno) << std::endl;
+            return;
+        }
+        auto buf = aligned_buffer_fastpath(4096);
+        init_pattern_fastpath(buf.get(), 4096);
+        const uint64_t failing_offset = (16ULL * 1024 * 1024) + 4096;
+        while (!stop.load()) {
+            ssize_t w = pwrite(fd, buf.get(), 4096, failing_offset);
+            if (w < 0) {
+                io_err_count.fetch_add(1);
+            }
+            /* Small pace so we don't fully saturate the workqueue. */
+            usleep(2000);
+        }
+        close(fd);
+    });
+}
+
+/*
+ * RACE TEST: concurrent PXD_IOC_DETACH_DEVICE and close(ctl_fd) with
+ * fastpath IO failing continuously.
+ *
+ * Why this matters:
+ *  - close(ctl_fd) schedules ctx-level failover_work (soft) + abort_work
+ *    (backstop after pxd_timeout_secs).
+ *  - PXD_IOC_DETACH_DEVICE schedules per-device remove_work via
+ *    pxd_finish_remove.
+ *  - pxdctx_reset_fastpath's snap loop flush_works remove_work and skips
+ *    devices with removing==true. remove_work itself calls
+ *    pxd_fastpath_reset_device.
+ *  - Both paths mutate pxd_dev state without a single serializing lock,
+ *    so the correctness relies on: pxd_dev->removing gate, connected
+ *    WRITE_ONCE, ctx->fp_freeze, and per-device blk_mq_quiesce_queue.
+ *
+ * Expected behaviour: no panic, no hang, device removed within a bounded
+ * time, and TearDown can proceed.
+ *
+ * Detach is issued via a separate control fd on a tool context (ctx 10)
+ * so it doesn't require ctl_fd (which the other thread is closing).
+ */
+TEST_P(PxdFastpathTest, race_detach_and_ctrl_fd_close_using_dm_flakey)
+{
+    std::cout << "\n=== RACE TEST: detach vs ctrl-fd-close (dm-flakey) ===" << std::endl;
+
+    TempLoopDevice loop_dev(100);
+    DMTargetCleanup dm_cleanup{};
+    std::string dm_path, device_name;
+    int minor = 0;
+    pxd_add_ext_out add_ext;
+    if (!prepare_flakey_dm_and_add_ext(700, "pxd_test_flakey_race_detach",
+                                       loop_dev, dm_cleanup, dm_path, add_ext)) {
+        GTEST_SKIP();
+    }
+    dev_add_fastpath(add_ext, minor, device_name);
+    std::cout << "Device added: " << device_name << std::endl;
+
+    /* Lower pxd_timeout_secs to the driver minimum (30s) so abort_work
+     * fires within test-tolerable time after close(ctl_fd). Otherwise
+     * a pwrite that got routed to the fuse slow path during the
+     * failover window sits in fc->processing for the default 600s
+     * (nobody is reading ctl_fd), blocking io_thr.join(). abort_work's
+     * fuse_end_queued_requests ends those with -ECONNABORTED,
+     * unblocking pwrite. */
+    ASSERT_EQ(0, write_pxd_timeout(minor, 30));
+
+    /* Open a separate tool control fd (ctx 10) that we can drive the detach
+     * ioctl from independently of the main ctl_fd we're about to close. */
+    int tool_fd = open(control_device_fastpath(10).c_str(), O_RDWR);
+    ASSERT_GT(tool_fd, 0) << "open tool ctl fd failed: " << strerror(errno);
+
+    /* Continuous failing IO to keep pxd_io_failover work items in flight. */
+    std::atomic<bool> stop_io{false};
+    std::atomic<uint64_t> io_err_count{0};
+    std::thread io_thr = start_failing_io_stream(device_name, stop_io, io_err_count);
+
+    /* Give the IO stream a moment to enter the failover state machine. */
+    usleep(300000);
+    ASSERT_GT(io_err_count.load(), 0u) << "expected some IO failures by now";
+
+    std::cout << "IO errs so far: " << io_err_count.load()
+              << "; racing close(ctl_fd) with PXD_IOC_DETACH_DEVICE" << std::endl;
+
+    /* Race manoeuvre: kick off close and detach in two threads that both
+     * try to fire as close to simultaneously as possible. Use an atomic
+     * barrier so both threads spin until the flag flips. */
+    std::atomic<bool> go{false};
+    std::atomic<int>  detach_rc{0};
+    std::atomic<int>  detach_errno{0};
+
+    std::thread close_thr([&]() {
+        while (!go.load()) { }
+        close(ctl_fd);
+        ctl_fd = -1;
+    });
+
+    std::thread detach_thr([&]() {
+        pxd_detach_device args;
+        args.dev_id = add_ext.dev_id;
+        args.context_id = 0;
+        while (!go.load()) { }
+        int rc = ioctl(tool_fd, PXD_IOC_DETACH_DEVICE, &args);
+        detach_rc = rc;
+        detach_errno = errno;
+    });
+
+    /* Fire the race. */
+    go.store(true);
+
+    /* Bound the wait for both operations. */
+    auto race_start = std::chrono::steady_clock::now();
+    close_thr.join();
+    detach_thr.join();
+    auto race_dur = std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::steady_clock::now() - race_start).count();
+    std::cout << "Race finished in " << race_dur << "s; detach rc="
+              << detach_rc.load() << " errno=" << detach_errno.load()
+              << " io_errs=" << io_err_count.load() << std::endl;
+    EXPECT_LT(race_dur, 30) << "close+detach race exceeded 30s; likely stuck";
+
+    /* Detach can legitimately return 0 (removed), -ENOENT (already gone),
+     * or -EBUSY (concurrent close raced ahead). Any of those is fine as
+     * long as the device is no longer exported. */
+    EXPECT_TRUE(detach_rc == 0 || detach_errno == ENOENT || detach_errno == EBUSY)
+        << "unexpected detach outcome rc=" << detach_rc
+        << " errno=" << detach_errno;
+
+    /* Stop the failing IO stream. pwrite may be blocked in the fuse
+     * slow path (see the write_pxd_timeout call above); it will
+     * unblock at T+30s when abort_work fires and ends queued fuse
+     * requests with -ECONNABORTED. Bounded wait. */
+    stop_io.store(true);
+    io_thr.join();
+
+    /* Reopen ctl_fd for TearDown. */
+    ctl_fd = open(control_device_fastpath(0).c_str(), O_RDWR);
+    ASSERT_GT(ctl_fd, 0);
+    pxd_ioctl_init_args init_args;
+    ASSERT_GE(ioctl(ctl_fd, PXD_IOC_INIT, &init_args), 0);
+
+    /* Only forget the device if the detach ioctl actually removed it.
+     * On rc == 0 the driver's pxd_remove_dev succeeded and the device
+     * is gone. On any other outcome (EBUSY because io_thr had it open,
+     * ENOENT because a competing path removed it first), TearDown must
+     * still drive PXD_REMOVE to reach a clean state. Now that io_thr
+     * has closed its fd, that PXD_REMOVE will succeed. */
+    if (detach_rc.load() == 0) {
+        added_ids.erase(add_ext.dev_id);
+    }
+
+    close(tool_fd);
+
+    std::cout << "=== RACE TEST PASSED: detach vs ctrl-fd-close survived ===" << std::endl;
+}
+
+/*
+ * RACE TEST: rapid close(ctl_fd) / open(ctl_fd) cycle while fastpath IO
+ * is continuously failing.
+ *
+ * Why this matters:
+ *  - close(ctl_fd) -> pxd_control_release: fc.connected=0, schedule
+ *    failover_work (which does freeze_start + pxdctx_reset_fastpath +
+ *    freeze_end), schedule abort_work (backstop).
+ *  - open(ctl_fd) -> pxd_control_open:
+ *      cancel_delayed_work_sync(&abort_work);
+ *      flush_work(&failover_work);   // key ordering: waits for the
+ *                                    // in-flight failover to complete
+ *      fuse_restart_requests(fc);
+ *      fc.connected = 1;
+ *      pxdctx_set_connected(ctx);    // marks each device connected=true
+ *  - Meanwhile pxd_io_failover, running on the fastpath kthread worker,
+ *    reads pxd_dev->connected / fc.connected / ctx->fp_freeze with
+ *    READ_ONCE and picks branch (a)/(b)/(c) accordingly.
+ *
+ * The race under test: an in-flight pxd_io_failover reads fc.connected=0
+ * (takes branch b, calls disableFastPath + reroute). Simultaneously the
+ * reopen flushes failover_work and sets fc.connected=1. The result must
+ * be a consistent device state: either fastpath was disabled and the IO
+ * went through slowpath, or fastpath stayed active - never a half-torn
+ * intermediate.
+ *
+ * We loop the close/reopen a handful of times to increase the chance of
+ * catching failover_work mid-flight.
+ */
+TEST_P(PxdFastpathTest, race_ctrl_fd_reopen_during_failover_using_dm_flakey)
+{
+    std::cout << "\n=== RACE TEST: ctrl-fd reopen vs io_failover (dm-flakey) ===" << std::endl;
+
+    TempLoopDevice loop_dev(100);
+    DMTargetCleanup dm_cleanup{};
+    std::string dm_path, device_name;
+    int minor = 0;
+    pxd_add_ext_out add_ext;
+    if (!prepare_flakey_dm_and_add_ext(800, "pxd_test_flakey_race_reopen",
+                                       loop_dev, dm_cleanup, dm_path, add_ext)) {
+        GTEST_SKIP();
+    }
+    dev_add_fastpath(add_ext, minor, device_name);
+    std::cout << "Device added: " << device_name << std::endl;
+
+    /* Short timeout so abort_work fails any IO stuck in fc->processing
+     * after each close(). Reopen resets pxd_timeout_secs back to the
+     * driver default (600s), so we re-arm the short timeout after
+     * each cycle. */
+    ASSERT_EQ(0, write_pxd_timeout(minor, 30));
+
+    /* Continuous failing IO so pxd_io_failover is queued repeatedly. */
+    std::atomic<bool> stop_io{false};
+    std::atomic<uint64_t> io_err_count{0};
+    std::thread io_thr = start_failing_io_stream(device_name, stop_io, io_err_count);
+
+    /* Warm-up: let the failover state machine engage. */
+    usleep(300000);
+    ASSERT_GT(io_err_count.load(), 0u);
+
+    const int cycles = 5;
+    auto start = std::chrono::steady_clock::now();
+    for (int i = 0; i < cycles; i++) {
+        std::cout << "cycle " << i << ": close ctl_fd (io_errs="
+                  << io_err_count.load() << ")" << std::endl;
+
+        /* close(ctl_fd) triggers pxd_control_release. Any pxd_io_failover
+         * that runs after this point will see fc.connected==0 and take
+         * branch (b): disableFastPath + reroute to slowpath. */
+        int rc = close(ctl_fd);
+        ASSERT_EQ(rc, 0) << "close(ctl_fd) failed: " << strerror(errno);
+        ctl_fd = -1;
+
+        /* Tiny window - we specifically want the reopen to catch
+         * failover_work while it's queued or running. Zero sleep means
+         * we might beat the kworker to it; a small sleep pushes it into
+         * mid-run territory. Randomise a bit across cycles. */
+        if (i % 2 == 0) {
+            usleep(5000);   /* 5ms - kworker likely started */
+        } else {
+            /* No sleep - reopen before workqueue picks it up */
+        }
+
+        std::cout << "cycle " << i << ": reopen ctl_fd" << std::endl;
+        ctl_fd = open(control_device_fastpath(0).c_str(), O_RDWR);
+        ASSERT_GT(ctl_fd, 0) << "reopen failed: " << strerror(errno);
+        pxd_ioctl_init_args init_args;
+        ASSERT_GE(ioctl(ctl_fd, PXD_IOC_INIT, &init_args), 0);
+        /* pxd_control_open resets pxd_timeout_secs to the default (600s).
+         * Re-arm the 30s abort so the next close's IO gets aborted
+         * quickly rather than stuck for 10 minutes. */
+        ASSERT_EQ(0, write_pxd_timeout(minor, 30));
+
+        /* Let one more round of failing IO happen before the next cycle. */
+        usleep(200000);
+    }
+    auto dur = std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::steady_clock::now() - start).count();
+    std::cout << cycles << " close/reopen cycles in " << dur << "s; io_errs="
+              << io_err_count.load() << std::endl;
+    EXPECT_LT(dur, 60) << "close/reopen cycles took too long; likely stuck";
+
+    /* At this point ctl_fd is open (last cycle ended with a reopen). Any
+     * IOs queued in fc->processing from prior close windows were
+     * restarted by pxd_control_open's fuse_restart_requests but nobody
+     * is reading ctl_fd, so io_thr's next pwrite still blocks. Force a
+     * final close so abort_work (armed for 30s) can fire and fail the
+     * queued IOs, unblocking io_thr. */
+    std::cout << "Final close so abort_work can fail queued IO..." << std::endl;
+    close(ctl_fd);
+    ctl_fd = -1;
+
+    stop_io.store(true);
+    /* io_thr.join blocks until abort_work fires and
+     * fuse_end_queued_requests ends the pending pwrite with
+     * -ECONNABORTED. pxd_timeout_secs was set to 30s at test start. */
+    io_thr.join();
+
+    /* Reopen for TearDown. */
+    ctl_fd = open(control_device_fastpath(0).c_str(), O_RDWR);
+    ASSERT_GT(ctl_fd, 0);
+    pxd_ioctl_init_args init_args;
+    ASSERT_GE(ioctl(ctl_fd, PXD_IOC_INIT, &init_args), 0);
+
+    /* Device must still be present and accessible. If any cycle left the
+     * driver in a bad state, this open would fail. */
+    int dev_fd = open(device_name.c_str(), O_RDONLY);
+    EXPECT_GE(dev_fd, 0) << "device inaccessible after race: " << strerror(errno);
+    if (dev_fd >= 0) close(dev_fd);
+
+    std::cout << "=== RACE TEST PASSED: close/reopen race survived ===" << std::endl;
+}
+
+/*
+ * RACE TEST: multiple concurrent disableFastPath callers on the same device
+ *
+ * Why this matters:
+ *   disableFastPath is reachable from several call sites (invariant 3 in
+ *   FASTPATH_CONTROL_FLOWS.md). If two calls race and both pass the top
+ *   guard, they can both enter the filp_close loop; without the xchg
+ *   ownership arbitration each caller would filp_close the same struct
+ *   file - double free / UAF. Similarly, fastpath_flush_work called from
+ *   a fastpath kthread worker would self-flush-deadlock (invariant 4)
+ *   without the current-worker skip.
+ *
+ *   To force multiple concurrent branch (b) callers we need
+ *   ctx->fc.connected == 0 while fastpath IOs are still failing on the
+ *   worker queue. That window opens the instant pxd_control_release
+ *   writes fc.connected=0 and closes as soon as pxd_failover_work's
+ *   freeze_start sets fp_freeze=1 and drains the fastpath workers.
+ *   We hammer failing IO across many threads/CPUs so at least a few
+ *   land in the window on separate workers.
+ *
+ *   Pass criteria: no panic, no hang. If either invariant were broken,
+ *   the kernel would crash (double filp_close) or the test would hang
+ *   past the timeout (self-flush deadlock).
+ */
+TEST_P(PxdFastpathTest, race_multiple_disable_fastpath_concurrent_using_dm_flakey)
+{
+    std::cout << "\n=== RACE TEST: multiple concurrent disableFastPath (dm-flakey) ===" << std::endl;
+
+    TempLoopDevice loop_dev(100);
+    DMTargetCleanup dm_cleanup{};
+    std::string dm_path;
+    pxd_add_ext_out add_ext;
+    if (!prepare_flakey_dm_and_add_ext(900, "pxd_test_flakey_race_disable",
+                                       loop_dev, dm_cleanup, dm_path, add_ext)) {
+        GTEST_SKIP();
+    }
+    std::string device_name;
+    int minor = 0;
+    dev_add_fastpath(add_ext, minor, device_name);
+    std::cout << "Device added: " << device_name << std::endl;
+
+    /* Short timeout so abort_work fails queued IOs quickly after close.
+     * Without this the loser threads' pwrites sit in fc->processing for
+     * the default 600s (no ctl_fd reader) and join() would hang. */
+    ASSERT_EQ(0, write_pxd_timeout(minor, 30));
+
+    /* N concurrent IO threads pounding the failing range. Pinning to
+     * different CPUs increases the chance of parallel dispatch onto
+     * different fastpath kthread workers - which is exactly the
+     * disableFastPath race we're trying to provoke. */
+    const int nthreads = 8;
+    std::atomic<bool> stop_io{false};
+    std::atomic<uint64_t> total_errs{0};
+    std::vector<std::thread> threads;
+
+    for (int t = 0; t < nthreads; t++) {
+        threads.emplace_back([&, t]() {
+            /* Best-effort CPU affinity; ignore failure. */
+            cpu_set_t cs;
+            CPU_ZERO(&cs);
+            CPU_SET(t % std::thread::hardware_concurrency(), &cs);
+            (void) pthread_setaffinity_np(pthread_self(), sizeof(cs), &cs);
+
+            int fd = open(device_name.c_str(), O_RDWR | O_DIRECT);
+            if (fd < 0) return;
+            auto buf = aligned_buffer_fastpath(4096);
+            init_pattern_fastpath(buf.get(), 4096);
+            const uint64_t failing_offset = (16ULL * 1024 * 1024) + 4096;
+            while (!stop_io.load()) {
+                ssize_t w = pwrite(fd, buf.get(), 4096, failing_offset);
+                if (w < 0) total_errs.fetch_add(1);
+            }
+            close(fd);
+        });
+    }
+
+    /* Let the threads spin up and produce some IO errors. */
+    usleep(300000);
+    ASSERT_GT(total_errs.load(), 0u) << "expected some IO failures before racing";
+
+    /* Trigger the race: close ctl_fd. In the tiny window between
+     * fc.connected=0 (in pxd_control_release) and fp_freeze=1 (in
+     * pxd_failover_work's freeze_start), any in-flight pxd_io_failover
+     * takes branch (b) and calls disableFastPath. With N workers busy
+     * in parallel, we expect multiple concurrent disableFastPath calls
+     * on this device. */
+    auto race_start = std::chrono::steady_clock::now();
+    std::cout << "Closing ctl_fd to open the race window; io_errs="
+              << total_errs.load() << std::endl;
+    close(ctl_fd);
+    ctl_fd = -1;
+
+    /* Give failover_work time to complete. If self-flush deadlocks,
+     * this window elapses without progress. */
+    sleep(2);
+
+    auto race_dur = std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::steady_clock::now() - race_start).count();
+    std::cout << "Race window survived in " << race_dur << "s; io_errs total="
+              << total_errs.load() << std::endl;
+    EXPECT_LT(race_dur, 10) << "race window took too long; likely self-flush deadlock";
+
+    stop_io.store(true);
+    for (auto &t : threads) t.join();
+
+    /* Reopen so TearDown can drive PXD_REMOVE. */
+    ctl_fd = open(control_device_fastpath(0).c_str(), O_RDWR);
+    ASSERT_GT(ctl_fd, 0);
+    pxd_ioctl_init_args init_args;
+    ASSERT_GE(ioctl(ctl_fd, PXD_IOC_INIT, &init_args), 0);
+
+    std::cout << "=== RACE TEST PASSED: concurrent disableFastPath survived ===" << std::endl;
+}
+
+/*
+ * RACE TEST: multi-device ctl_fd close with fastpath IO failing on each
+ *
+ * Why this matters:
+ *   pxdctx_reset_fastpath iterates ctx->list using a snapshot+refcount
+ *   pattern (invariant 5). Per-device pxd_fastpath_reset_device calls
+ *   disableFastPath and drains failQ, then moves on. The interesting
+ *   race surface is n > 1: parallel per-device freeze windows,
+ *   snap_list references, and any shared state (fp_freeze is
+ *   ctx-scope, gwq is shared).
+ *
+ *   Set up K fastpath devices each backed by its own dm-flakey with
+ *   the same failing-range pattern; hammer failing IO on all; close
+ *   ctl_fd; verify all K devices land in a consistent state and
+ *   pxd_control_open can restore them via pxdctx_set_connected.
+ *
+ *   Pass criteria: no panic, no hang, all devices survive the
+ *   transition (post-reopen open() succeeds on every one).
+ */
+TEST_P(PxdFastpathTest, race_multi_device_ctrl_fd_close_using_dm_flakey)
+{
+    std::cout << "\n=== RACE TEST: multi-device ctl_fd close (dm-flakey) ===" << std::endl;
+
+    if (system("modprobe dm-flakey >/dev/null 2>&1") != 0) {
+        std::cerr << "dm-flakey unavailable; skipping" << std::endl;
+        GTEST_SKIP();
+    }
+
+    const int ndevs = 4;
+    struct DevSetup {
+        std::unique_ptr<TempLoopDevice> loop;
+        DMTargetCleanup dm_cleanup;
+        std::string dm_path;
+        std::string device_name;
+        int minor = 0;
+        uint64_t dev_id = 0;
+    };
+    std::vector<DevSetup> devs(ndevs);
+
+    for (int i = 0; i < ndevs; i++) {
+        devs[i].loop = std::unique_ptr<TempLoopDevice>(new TempLoopDevice(100));
+        devs[i].dev_id = 1000 + i;
+        std::string dm_name = "pxd_test_flakey_multi_" + std::to_string(i);
+        pxd_add_ext_out add_ext;
+        if (!prepare_flakey_dm_and_add_ext(devs[i].dev_id, dm_name,
+                                           *devs[i].loop, devs[i].dm_cleanup,
+                                           devs[i].dm_path, add_ext)) {
+            GTEST_SKIP();
+        }
+        dev_add_fastpath(add_ext, devs[i].minor, devs[i].device_name);
+        std::cout << "Device " << i << " added: " << devs[i].device_name << std::endl;
+    }
+
+    /* pxd_timeout_secs is module-global; setting it via any device's
+     * sysfs affects all devices in this ctx. Short timeout so
+     * abort_work fails queued IOs on every device after close(). */
+    ASSERT_EQ(0, write_pxd_timeout(devs[0].minor, 30));
+
+    /* One IO thread per device, all writing to the failing range in
+     * parallel. Keeps pxd_io_failover work items in flight on multiple
+     * devices simultaneously while we close ctl_fd. */
+    std::atomic<bool> stop_io{false};
+    std::vector<std::thread> io_threads;
+    std::vector<std::atomic<uint64_t>> per_dev_errs(ndevs);
+    for (int i = 0; i < ndevs; i++) per_dev_errs[i].store(0);
+
+    for (int i = 0; i < ndevs; i++) {
+        io_threads.emplace_back(start_failing_io_stream(
+            devs[i].device_name, stop_io, per_dev_errs[i]));
+    }
+
+    /* Let each device accumulate some errors. */
+    usleep(500000);
+    for (int i = 0; i < ndevs; i++) {
+        ASSERT_GT(per_dev_errs[i].load(), 0u)
+            << "device " << i << " had no failing IO before racing";
+    }
+
+    std::cout << "All " << ndevs << " devices producing errors; closing ctl_fd" << std::endl;
+    auto t_close = std::chrono::steady_clock::now();
+    close(ctl_fd);
+    ctl_fd = -1;
+
+    /* Give failover_work time to iterate all devices. */
+    sleep(2);
+
+    auto close_dur = std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::steady_clock::now() - t_close).count();
+    EXPECT_LT(close_dur, 10) << "multi-device close took too long";
+
+    stop_io.store(true);
+    for (auto &t : io_threads) t.join();
+
+    /* Reopen and confirm every device is still there and usable in
+     * native path. Open uses O_RDONLY at a safe offset to avoid the
+     * still-failing dm range. */
+    ctl_fd = open(control_device_fastpath(0).c_str(), O_RDWR);
+    ASSERT_GT(ctl_fd, 0);
+    pxd_ioctl_init_args init_args;
+    ASSERT_GE(ioctl(ctl_fd, PXD_IOC_INIT, &init_args), 0);
+
+    for (int i = 0; i < ndevs; i++) {
+        int fd = open(devs[i].device_name.c_str(), O_RDONLY);
+        EXPECT_GE(fd, 0) << "device " << i << " (" << devs[i].device_name
+                         << ") inaccessible post-reopen: " << strerror(errno);
+        if (fd >= 0) close(fd);
+    }
+
+    std::cout << "=== RACE TEST PASSED: multi-device close survived ===" << std::endl;
+}
+
+/*
+ * RACE TEST: abort_work fires with fastpath device present
+ *
+ * Why this matters:
+ *   pxd_abort_context (Part 1.6 in FASTPATH_CONTROL_FLOWS.md) runs at
+ *   T + pxd_timeout_secs after pxd_control_release, when userspace
+ *   never reopened. It sets fc.allow_disconnected=0, fuse_end_queued_
+ *   requests, then freeze_start + pxdctx_reset_fastpath(true) +
+ *   freeze_end(true). This is the hard-fail path and previously had
+ *   ZERO fastpath test coverage.
+ *
+ *   Verify:
+ *     a. After abort_work fires, opening the device gets -ENXIO (the
+ *        pxd_dev->connected=false check in pxd_open trips).
+ *     b. After ctl_fd reopen, pxdctx_set_connected restores
+ *        connected=true and the device becomes usable again.
+ */
+TEST_P(PxdFastpathTest, race_abort_timeout_with_fastpath_device_using_dm_flakey)
+{
+    std::cout << "\n=== RACE TEST: abort timeout with fastpath device (dm-flakey) ===" << std::endl;
+
+    TempLoopDevice loop_dev(100);
+    DMTargetCleanup dm_cleanup{};
+    std::string dm_path;
+    pxd_add_ext_out add_ext;
+    if (!prepare_flakey_dm_and_add_ext(1100, "pxd_test_flakey_abort",
+                                       loop_dev, dm_cleanup, dm_path, add_ext)) {
+        GTEST_SKIP();
+    }
+    std::string device_name;
+    int minor = 0;
+    dev_add_fastpath(add_ext, minor, device_name);
+
+    /* Minimum legal pxd_timeout is 30s (PXD_TIMER_SECS_MIN). Sysfs
+     * write is per-device but sets the module-global variable. */
+    const int timeout_secs = 30;
+    ASSERT_EQ(0, write_pxd_timeout(minor, timeout_secs))
+        << "failed to set pxd_timeout via sysfs";
+
+    /* Poke a failing IO first so there's IO to be aborted. */
+    std::atomic<bool> stop_io{false};
+    std::atomic<uint64_t> io_err_count{0};
+    std::thread io_thr = start_failing_io_stream(device_name, stop_io, io_err_count);
+    usleep(300000);
+    stop_io.store(true);
+    io_thr.join();
+    std::cout << "IO errors observed: " << io_err_count.load() << std::endl;
+
+    /* Close ctl_fd. abort_work is armed for T + 30s. */
+    std::cout << "Closing ctl_fd; waiting past abort_work fire time..." << std::endl;
+    close(ctl_fd);
+    ctl_fd = -1;
+
+    /* Sleep past pxd_timeout_secs so abort_work is guaranteed to run.
+     * Add slack because kworker scheduling isn't instant. */
+    sleep(timeout_secs + 5);
+
+    /* Now pxd_dev->connected should be false. Opening the device must
+     * fail with -ENXIO (checked in pxd_open under pxd_dev->lock). */
+    int dev_fd = open(device_name.c_str(), O_RDONLY);
+    if (dev_fd >= 0) {
+        std::cerr << "WARN: device unexpectedly open after abort_work; "
+                  << "kernel may not have completed abort yet" << std::endl;
+        close(dev_fd);
+    } else {
+        EXPECT_EQ(errno, ENXIO)
+            << "expected -ENXIO after abort; got " << strerror(errno);
+    }
+
+    /* Reopen ctl_fd. pxd_control_open's freeze_start + pxdctx_set_connected
+     * restores pxd_dev->connected = true for every device on ctx->list. */
+    std::cout << "Reopening ctl_fd..." << std::endl;
+    ctl_fd = open(control_device_fastpath(0).c_str(), O_RDWR);
+    ASSERT_GT(ctl_fd, 0);
+    pxd_ioctl_init_args init_args;
+    ASSERT_GE(ioctl(ctl_fd, PXD_IOC_INIT, &init_args), 0);
+
+    /* Device should now be openable again. */
+    dev_fd = open(device_name.c_str(), O_RDONLY);
+    EXPECT_GE(dev_fd, 0) << "device inaccessible after reopen: " << strerror(errno);
+    if (dev_fd >= 0) close(dev_fd);
+
+    std::cout << "=== RACE TEST PASSED: abort timeout with fastpath device ===" << std::endl;
+}
+
+/*
+ * RACE TEST: abort_work canceled by ctl_fd reopen
+ *
+ * Why this matters:
+ *   pxd_control_open calls cancel_delayed_work_sync(&ctx->abort_work)
+ *   before flush_work(failover_work). If cancellation races and the
+ *   timer somehow fires anyway (or the sync doesn't wait properly),
+ *   pxd_abort_context runs against a re-connected fc and its
+ *   BUG_ON(fc.connected) fires - kernel panic.
+ *
+ *   Set the timeout as low as legal (30s), close ctl_fd, sleep just
+ *   short of the fire time, reopen. cancel_delayed_work_sync must
+ *   catch the delayed_work reliably. Sleep past the original fire
+ *   time and confirm no abort behaviour happened (device is still
+ *   connected and usable).
+ */
+TEST_P(PxdFastpathTest, race_abort_work_canceled_by_reopen_using_dm_flakey)
+{
+    std::cout << "\n=== RACE TEST: abort_work canceled by reopen (dm-flakey) ===" << std::endl;
+
+    TempLoopDevice loop_dev(100);
+    DMTargetCleanup dm_cleanup{};
+    std::string dm_path;
+    pxd_add_ext_out add_ext;
+    if (!prepare_flakey_dm_and_add_ext(1200, "pxd_test_flakey_cancel",
+                                       loop_dev, dm_cleanup, dm_path, add_ext)) {
+        GTEST_SKIP();
+    }
+    std::string device_name;
+    int minor = 0;
+    dev_add_fastpath(add_ext, minor, device_name);
+
+    const int timeout_secs = 30;
+    ASSERT_EQ(0, write_pxd_timeout(minor, timeout_secs));
+
+    std::cout << "Closing ctl_fd; will reopen at T + 25s (before abort fires)" << std::endl;
+    close(ctl_fd);
+    ctl_fd = -1;
+
+    /* Sleep to just short of the abort fire time. Reopen must catch
+     * and cancel the delayed_work. */
+    sleep(timeout_secs - 5);
+
+    ctl_fd = open(control_device_fastpath(0).c_str(), O_RDWR);
+    ASSERT_GT(ctl_fd, 0);
+    pxd_ioctl_init_args init_args;
+    ASSERT_GE(ioctl(ctl_fd, PXD_IOC_INIT, &init_args), 0);
+
+    /* Sleep past the original abort deadline. If cancel didn't catch,
+     * abort_work fires here and (in the current code) hits BUG_ON on
+     * fc.connected. We can't observe a BUG_ON from userspace directly,
+     * but if it fired the kernel is dead and this test never returns. */
+    std::cout << "Sleeping past original abort deadline..." << std::endl;
+    sleep(10);
+
+    /* Verify the device is still usable - abort semantics did NOT run. */
+    int dev_fd = open(device_name.c_str(), O_RDONLY);
+    EXPECT_GE(dev_fd, 0)
+        << "device unexpectedly inaccessible; abort may have fired despite cancel: "
+        << strerror(errno);
+    if (dev_fd >= 0) close(dev_fd);
+
+    std::cout << "=== RACE TEST PASSED: abort_work canceled cleanly ===" << std::endl;
+}
+
+/*
+ * RACE TEST: reopen ctl_fd -> userspace pulls and fails queued fuse reqs
+ *
+ * Why this matters (companion to abort_work coverage):
+ *   The freeze protocol relies on two complementary drains for IO that
+ *   got routed to the fuse slow path during a ctx transition:
+ *     - abort_work (T + pxd_timeout_secs) hard-fails everything.
+ *     - Reopen + userspace read cycles them back out normally.
+ *   The abort_work path is covered by other race tests. This test
+ *   drives the second path: after close(ctl_fd), IO gets queued in
+ *   fc->processing; reopen restarts them into fc->pending via
+ *   fuse_restart_requests; a userspace reader then pulls each req and
+ *   fails it. pwrite returns error, io_thr exits cleanly - WITHOUT
+ *   waiting for abort_work.
+ *
+ *   If fuse_restart_requests were broken or userspace couldn't drain
+ *   the pending list, io_thr.join would time out.
+ */
+TEST_P(PxdFastpathTest, race_reopen_userspace_drain_queued_reqs_using_dm_flakey)
+{
+    std::cout << "\n=== RACE TEST: reopen ctl_fd + userspace drain (dm-flakey) ===" << std::endl;
+
+    TempLoopDevice loop_dev(100);
+    DMTargetCleanup dm_cleanup{};
+    std::string dm_path;
+    pxd_add_ext_out add_ext;
+    if (!prepare_flakey_dm_and_add_ext(1300, "pxd_test_flakey_reopen_drain",
+                                       loop_dev, dm_cleanup, dm_path, add_ext)) {
+        GTEST_SKIP();
+    }
+    std::string device_name;
+    int minor = 0;
+    dev_add_fastpath(add_ext, minor, device_name);
+    std::cout << "Device added: " << device_name << std::endl;
+
+    /* Set a short timeout as a fallback safety net. If the userspace
+     * drain works correctly, io_thr exits well before abort_work fires. */
+    ASSERT_EQ(0, write_pxd_timeout(minor, 30));
+
+    /* Single failing IO from a worker thread. Once it fails on the
+     * fastpath, the failover state machine routes it through the fuse
+     * slow path. On close(ctl_fd) it lingers in fc->processing until
+     * we reopen and drain. */
+    std::atomic<bool> stop_io{false};
+    std::atomic<uint64_t> io_err_count{0};
+    std::thread io_thr = start_failing_io_stream(device_name, stop_io, io_err_count);
+
+    /* Let io_thr accumulate errors and queue at least one req in flight. */
+    usleep(300000);
+    ASSERT_GT(io_err_count.load(), 0u);
+
+    std::cout << "Closing ctl_fd; IOs will land in fc->processing" << std::endl;
+    close(ctl_fd);
+    ctl_fd = -1;
+
+    /* Let failover_work run and the next pwrite queue in fuse slow path. */
+    usleep(500000);
+
+    std::cout << "Reopening ctl_fd; fuse_restart_requests moves reqs to pending" << std::endl;
+    ctl_fd = open(control_device_fastpath(0).c_str(), O_RDWR);
+    ASSERT_GT(ctl_fd, 0);
+    pxd_ioctl_init_args init_args;
+    ASSERT_GE(ioctl(ctl_fd, PXD_IOC_INIT, &init_args), 0);
+    /* Re-arm short timeout as a fallback; the drain below should
+     * complete well before it triggers. */
+    ASSERT_EQ(0, write_pxd_timeout(minor, 30));
+
+    /* Now userspace drains ctl_fd - pull each fuse req and fail it.
+     * fail_io ends the request with -EIO which propagates to
+     * blk_mq_end_request; the block layer wakes the pwrite waiter.
+     * This validates the freeze-doc's assertion that reopen +
+     * userspace read is a valid drain path (not just abort_work). */
+    std::atomic<uint64_t> drained{0};
+    std::atomic<bool> stop_drain{false};
+    std::thread drain_thr([&]() {
+        struct rdwr_in rdwr;
+        while (!stop_drain.load()) {
+            int ret = wait_msg(1);
+            if (ret == -ETIMEDOUT) continue;
+            if (ret < 0) break;
+            ssize_t rb = read(ctl_fd, &rdwr, sizeof(rdwr));
+            if (rb > 0) {
+                fail_io(&rdwr);
+                drained.fetch_add(1);
+            }
+        }
+    });
+
+    /* Stop io_thr and wait for it. If userspace drain is working,
+     * pwrite errors out quickly (the drainer replies -EIO). If
+     * broken, we fall back to abort_work at T+30s. If both are
+     * broken, this hangs and the outer test framework catches it. */
+    stop_io.store(true);
+    io_thr.join();
+
+    stop_drain.store(true);
+    drain_thr.join();
+
+    std::cout << "Drained " << drained.load() << " fuse reqs; io_errs="
+              << io_err_count.load() << std::endl;
+    EXPECT_GT(drained.load(), 0u)
+        << "expected userspace to service at least one queued req";
+
+    std::cout << "=== RACE TEST PASSED: reopen + userspace drain works ===" << std::endl;
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

Recent code change introduced fastpath failover to userspace when control fd closes.
This used existing coordination mechanism with userspace to switch io path. But when userspace is down, there is no coordination needed, driver is free to modify iopath. 
And if control fd closes, any pending switch operations should be handled locally, and switch complete without relying on userspace to recover.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

added a doc note on the expected code flow and invariants as reference.

```
root@lsundararajan-ribbon-crystal-0:/home/lns/srcs/src/github.com/portworx/px-fuse# ./test/pxd_test --gtest_list_tests
PxdTest.
  simple
  device_size
  write
  read
  blkdiscard_ioctl
  AbortContextWithInFlightIO
  write_zeroes_enabled_native_path
  write_zeroes_disabled_native_path_no_capability
  write_zeroes_custom_discard_granularity
BackingDeviceTypes/PxdFastpathTest.
  simple_test_fastpath/BackingFile  # GetParam() = 4-byte object <00-00 00-00>
  simple_test_fastpath/LoopDevice  # GetParam() = 4-byte object <01-00 00-00>
  device_create_fastpath/BackingFile  # GetParam() = 4-byte object <00-00 00-00>
  device_create_fastpath/LoopDevice  # GetParam() = 4-byte object <01-00 00-00>
  device_attach_export_fastpath/BackingFile  # GetParam() = 4-byte object <00-00 00-00>
  device_attach_export_fastpath/LoopDevice  # GetParam() = 4-byte object <01-00 00-00>
  io_operations_fastpath/BackingFile  # GetParam() = 4-byte object <00-00 00-00>
  io_operations_fastpath/LoopDevice  # GetParam() = 4-byte object <01-00 00-00>
  device_detach_remove_fastpath/BackingFile  # GetParam() = 4-byte object <00-00 00-00>
  device_detach_remove_fastpath/LoopDevice  # GetParam() = 4-byte object <01-00 00-00>
  multiple_devices_fastpath/BackingFile  # GetParam() = 4-byte object <00-00 00-00>
  multiple_devices_fastpath/LoopDevice  # GetParam() = 4-byte object <01-00 00-00>
  error_handling_fastpath/BackingFile  # GetParam() = 4-byte object <00-00 00-00>
  error_handling_fastpath/LoopDevice  # GetParam() = 4-byte object <01-00 00-00>
  write_zeroes_disabled_fastpath_with_capability/BackingFile  # GetParam() = 4-byte object <00-00 00-00>
  write_zeroes_disabled_fastpath_with_capability/LoopDevice  # GetParam() = 4-byte object <01-00 00-00>
  px_storage_death_triggers_immediate_failover/BackingFile  # GetParam() = 4-byte object <00-00 00-00>
  px_storage_death_triggers_immediate_failover/LoopDevice  # GetParam() = 4-byte object <01-00 00-00>
  force_failover_fallback_while_io_flows/BackingFile  # GetParam() = 4-byte object <00-00 00-00>
  force_failover_fallback_while_io_flows/LoopDevice  # GetParam() = 4-byte object <01-00 00-00>
  detach_device_with_active_ioswitch_using_dm_flakey/BackingFile  # GetParam() = 4-byte object <00-00 00-00>
  detach_device_with_active_ioswitch_using_dm_flakey/LoopDevice  # GetParam() = 4-byte object <01-00 00-00>
  control_fd_close_with_active_ioswitch_using_dm_flakey/BackingFile  # GetParam() = 4-byte object <00-00 00-00>
  control_fd_close_with_active_ioswitch_using_dm_flakey/LoopDevice  # GetParam() = 4-byte object <01-00 00-00>
  race_detach_and_ctrl_fd_close_using_dm_flakey/BackingFile  # GetParam() = 4-byte object <00-00 00-00>
  race_detach_and_ctrl_fd_close_using_dm_flakey/LoopDevice  # GetParam() = 4-byte object <01-00 00-00>
  race_ctrl_fd_reopen_during_failover_using_dm_flakey/BackingFile  # GetParam() = 4-byte object <00-00 00-00>
  race_ctrl_fd_reopen_during_failover_using_dm_flakey/LoopDevice  # GetParam() = 4-byte object <01-00 00-00>
  race_multiple_disable_fastpath_concurrent_using_dm_flakey/BackingFile  # GetParam() = 4-byte object <00-00 00-00>
  race_multiple_disable_fastpath_concurrent_using_dm_flakey/LoopDevice  # GetParam() = 4-byte object <01-00 00-00>
  race_multi_device_ctrl_fd_close_using_dm_flakey/BackingFile  # GetParam() = 4-byte object <00-00 00-00>
  race_multi_device_ctrl_fd_close_using_dm_flakey/LoopDevice  # GetParam() = 4-byte object <01-00 00-00>
  race_abort_timeout_with_fastpath_device_using_dm_flakey/BackingFile  # GetParam() = 4-byte object <00-00 00-00>
  race_abort_timeout_with_fastpath_device_using_dm_flakey/LoopDevice  # GetParam() = 4-byte object <01-00 00-00>
  race_abort_work_canceled_by_reopen_using_dm_flakey/BackingFile  # GetParam() = 4-byte object <00-00 00-00>
  race_abort_work_canceled_by_reopen_using_dm_flakey/LoopDevice  # GetParam() = 4-byte object <01-00 00-00>
  race_reopen_userspace_drain_queued_reqs_using_dm_flakey/BackingFile  # GetParam() = 4-byte object <00-00 00-00>
  race_reopen_userspace_drain_queued_reqs_using_dm_flakey/LoopDevice  # GetParam() = 4-byte object <01-00 00-00>

...

[       OK ] BackingDeviceTypes/PxdFastpathTest.race_reopen_userspace_drain_queued_reqs_using_dm_flakey/LoopDevice (199 ms)
[----------] 38 tests from BackingDeviceTypes/PxdFastpathTest (80882 ms total)

[----------] Global test environment tear-down
[==========] 47 tests from 2 test cases ran. (176522 ms total)
[  PASSED  ] 47 tests.
root@lsundararajan-ribbon-crystal-0:/home/lns/srcs/src/github.com/portworx/px-fuse# exit
lns@lsundararajan-ribbon-crystal-0:~/srcs/src/github.com/portworx/px-fuse$ git push origin ln/fpdetach
Everything up-to-date
lns@lsundararajan-ribbon-crystal-0:~/srcs/src/github.com/portworx/px-fuse$
```

## Suspend Resume tests ##

```
root@ip-10-13-167-118:~/fuse/px-fuse# grep -snri suspend t.log
1221:[ RUN      ] BackingDeviceTypes/PxdFastpathTest.suspend_resume_basic/BackingFile
1249:[       OK ] BackingDeviceTypes/PxdFastpathTest.suspend_resume_basic/BackingFile (2213 ms)
1250:[ RUN      ] BackingDeviceTypes/PxdFastpathTest.suspend_resume_basic/LoopDevice
1281:[       OK ] BackingDeviceTypes/PxdFastpathTest.suspend_resume_basic/LoopDevice (2298 ms)
1282:[ RUN      ] BackingDeviceTypes/PxdFastpathTest.suspend_resume_nested/BackingFile
1310:[       OK ] BackingDeviceTypes/PxdFastpathTest.suspend_resume_nested/BackingFile (2204 ms)
1311:[ RUN      ] BackingDeviceTypes/PxdFastpathTest.suspend_resume_nested/LoopDevice
1342:[       OK ] BackingDeviceTypes/PxdFastpathTest.suspend_resume_nested/LoopDevice (2299 ms)
1465:[ RUN      ] BackingDeviceTypes/PxdFastpathTest.app_suspend_resume_and_double_request/BackingFile
1493:[       OK ] BackingDeviceTypes/PxdFastpathTest.app_suspend_resume_and_double_request/BackingFile (2228 ms)
1494:[ RUN      ] BackingDeviceTypes/PxdFastpathTest.app_suspend_resume_and_double_request/LoopDevice
1525:[       OK ] BackingDeviceTypes/PxdFastpathTest.app_suspend_resume_and_double_request/LoopDevice (2291 ms)
1526:[ RUN      ] BackingDeviceTypes/PxdFastpathTest.suspend_resume_mixed_sources/BackingFile
1554:[       OK ] BackingDeviceTypes/PxdFastpathTest.suspend_resume_mixed_sources/BackingFile (2224 ms)
1555:[ RUN      ] BackingDeviceTypes/PxdFastpathTest.suspend_resume_mixed_sources/LoopDevice
1586:[       OK ] BackingDeviceTypes/PxdFastpathTest.suspend_resume_mixed_sources/LoopDevice (2271 ms)
1587:[ RUN      ] BackingDeviceTypes/PxdFastpathTest.suspend_resume_concurrent_balanced/BackingFile
1615:[       OK ] BackingDeviceTypes/PxdFastpathTest.suspend_resume_concurrent_balanced/BackingFile (3293 ms)
1616:[ RUN      ] BackingDeviceTypes/PxdFastpathTest.suspend_resume_concurrent_balanced/LoopDevice
1647:[       OK ] BackingDeviceTypes/PxdFastpathTest.suspend_resume_concurrent_balanced/LoopDevice (3278 ms)
root@ip-10-13-167-118:~/fuse/px-fuse#

```

## All tests passed ##
```
root@ip-10-13-167-118:~/fuse/px-fuse# tail t.log
Closing ctl_fd; IOs will land in fc->processing
Reopening ctl_fd; fuse_restart_requests moves reqs to pending
Drained 1 fuse reqs; io_errs=136
=== RACE TEST PASSED: reopen + userspace drain works ===
[       OK ] BackingDeviceTypes/PxdFastpathTest.race_reopen_userspace_drain_queued_reqs_using_dm_flakey/LoopDevice (4147 ms)
[----------] 52 tests from BackingDeviceTypes/PxdFastpathTest (565644 ms total)

[----------] Global test environment tear-down
[==========] 61 tests from 2 test suites ran. (667379 ms total)
[  PASSED  ] 61 tests.

```